### PR TITLE
去除360云盘和快盘

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -468,7 +468,7 @@ It is a free and open source software.[![Open-Source Software][OSS Icon]](https:
 * [Tecent cloud](https://www.weiyun.com/) - Tencent cloud client. (**Require Tencent Account, Missing English UI and Docs**) ![Freeware][Freeware Icon]
 * [Jianguo cloud](https://www.jianguoyun.com/s/downloads) - Jianguo cloud client. (**Not recommended**) ![Freeware][Freeware Icon]
 * [115](http://pc.115.com/) - 115 cloud client. (**Missing English UI and Docs**) ![Freeware][Freeware Icon]
-* [360](http://c49.yunpan.360.cn/) - 360 cloud client. (**Missing English UI and Docs**) ![Freeware][Freeware Icon]
+* <del>[360](http://c49.yunpan.360.cn/) - 360 cloud client. (**Missing English UI and Docs**) ![Freeware][Freeware Icon] </del>
 * [ownCloud](https://owncloud.org) Cloud storage.
 * [Mega](https://mega.nz) - Free cloud service, offers 50GB free storage. ![Freeware][Freeware Icon]
 

--- a/README.md
+++ b/README.md
@@ -452,8 +452,8 @@
 * [腾讯微云](https://www.weiyun.com/) - 腾讯云客户端。![Freeware][Freeware Icon]
 * [坚果云](https://www.jianguoyun.com/s/downloads) - 坚果云客户端。![Freeware][Freeware Icon]
 * [115](http://pc.115.com/) - 115云客户端。![Freeware][Freeware Icon]
-* [360](http://c49.yunpan.360.cn/) - 360云客户端。![Freeware][Freeware Icon]
-* [快盘](http://web.kuaipan.cn/d/mac) - 金山快盘，倒闭了？ ![Freeware][Freeware Icon]
+* <del>[360](http://c49.yunpan.360.cn/) - 360云客户端。![Freeware][Freeware Icon]</del>
+* <del>[快盘](http://web.kuaipan.cn/d/mac) - 金山快盘。 ![Freeware][Freeware Icon]</del>
 * [owncloud](https://owncloud.org) - 私有云网盘。
 * [Mega](https://mega.nz) - 免费的云服务，提供50GB的免费存储空间。![Freeware][Freeware Icon]
 


### PR DESCRIPTION
360云盘服务将于2017年2月1日正式关闭。

快盘个人存储服务已经于2016年8月16日正式关闭。