### PR TITLE
修正了 veertu 简介的翻译错误

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -327,7 +327,7 @@
 * [Parallels Desktop](http://www.parallels.com/) - 虽然好用但是收费机制，更新花钱、花钱、花钱。![hot][hot Icon]
 * [Virtual Box](http://www.virtualbox.org) - 免费、免费、免费，带NTFS读写，不用买ParagonNTFS，省100块。![Freeware][Freeware Icon] ![tuijian][tuijian Icon] ![star 4][star4 Icon]
 * [VMWare Fusion](http://www.vmware.com/) - 强大的虚拟机，商业软件。
-* [Veertu](https://veertu.com) - 图片管理，用于图片研究。![Freeware][Freeware Icon] ![tuijian][tuijian Icon]
+* [Veertu](https://veertu.com) - Mac上轻量级的虚拟机。通过一种高响应，沙箱且本地化的方式在你在 Mac 上运行虚拟机。![Freeware][Freeware Icon] ![tuijian][tuijian Icon]
 
 
 ## 通信


### PR DESCRIPTION
In README-zh.md:

> Veertu - 图片管理，用于图片研究。

In README.md:

> Veertu - The lightest VM on Mac. A responsive, sandboxed & native way to run VM on your Mac.

事实上英文中对 veertu 的介绍就不准确，veertu 其实是集成了 **[xhyve](https://github.com/mist64/xhyve) 虚拟机**的一套开发者工具。而这句介绍放在 xhyve 上就很合适。

所以我打算开个issue，请求添加 xhyve。