### PR TITLE
Fix command line tools anchor

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Any comments, suggestions? [Let us know!](https://github.com/jaywcjlove/awesome-
     - [Regular Expression Editors](#regular-expression-editors)
     - [API Development and Analysis](#api-development-and-analysis)
     - [Network Analysis](#network-analysis)
-    - [Command Line Tools](#command-line-tools)
+    - [Command Line Tools](#command-line-tools-)
     - [Frameworks for Hybrid Applications](#frameworks-for-hybrid-applications)
     - [Version Control](#version-control)
     - [Virtualization](#virtualization)


### PR DESCRIPTION
### Types of Changes

- [ ] New addition to list
- [x] Fixing bug in existing item in list
- [ ] Removing item from list
- [ ] Changing structure (organization) of list

### Proposed Changes

1. The anchor to the command line tool sections is broken. It needs a `-` at the end due to the image at the end of the heading.

### PR Checklist

- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important
- [ ] I have added necessary documentation (if appropriate)

### Further Comments
