### PR TITLE
add chunkwm (tilling wm)

### DIFF
--- a/README.md
+++ b/README.md
@@ -709,6 +709,7 @@ Any comments, suggestions? [Let us know!](https://github.com/jaywcjlove/awesome-
 * [Magnet](http://magnet.crowdcafe.com/) - Window manager that keeps your workspace organized. [![App Store][app-store Icon]](https://itunes.apple.com/us/app/id441258766)
 * [Total Spaces](http://totalspaces.binaryage.com/) - Provides window management much like ubuntu. Creates hotkeys for workspaces which allows you to easily move around.
 * [contexts](https://contexts.co/) - Provides more power than the native Mac Dock. Especially when you have multiple screens, it can help you switch more quickly.
+* [chunkwm](https://github.com/koekeishiya/chunkwm) - Tiling window manager for macOS based on plugin architecture. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://koekeishiya.github.io/chunkwm/)
 
 #### Password Management
 


### PR DESCRIPTION
I've been using chunkwm for a couple of weeks now. It blows out of the window the entirety of the list for window management tbh... by far...

You have different tilling modes, automatic split with configurable support, multi monitor support, opacity support, border highlighting, shadow removal, configurable gap, resize windows with mouse, move windows with mouse (or keybinds with skhd). But most importantly, it is incredibly fast, smooth and elegant for a wm hack on top of macos...