### PR TITLE
Add Sequel Ace

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,7 @@ Any comments, suggestions? [Let us know!](https://github.com/jaywcjlove/awesome-
 * [RedisClient](https://github.com/UUGU/redis-client-app) - Redis client application on mac, windows and linux. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/UUGU/redis-client-app)
 * [RedisDesktopManager](http://redisdesktop.com) - Cross-platform GUI management tool for Redis. [![Open-Source Software][OSS Icon]](https://github.com/uglide/RedisDesktopManager) ![Freeware][Freeware Icon]
 * [Sequel Pro](http://www.sequelpro.com/) - MySQL database management for Mac OS X. [![Open-Source Software][OSS Icon]](https://github.com/sequelpro/sequelpro) ![Freeware][Freeware Icon]
+*  [Sequel Ace](https://github.com/Sequel-Ace/Sequel-Ace) - The maintained "sequel" to the longtime macOS tool Sequel Pro. [![Open-Source Software][oss icon]](https://github.com/Sequel-Ace/Sequel-Ace)
 * [SQLight](https://aurvan.com/sqlight/) - SQLite database manager tool. ![Freeware][Freeware Icon]
 * [SQLPro Studio](http://www.sqlprostudio.com/) - Simple, powerful database manager for macOS.
 * [Tableau Public](https://public.tableau.com/s/) - Free data-visualization software. ![Freeware][Freeware Icon]


### PR DESCRIPTION
### Types of Changes

**What types of changes does your PR introduce?** Put an x in all boxes that apply

- [X] New addition to list

### Proposed Changes

Adds Sequel Ace which I believe is a better option than Sequel Pro which according to Github was released last time in 2016. Sequel Ace is actively contributed to, seems stable and seems to just about the same as Sequel Pro.

### PR Checklist

- [X] I have read the CONTRIBUTING guide
- [X] I have explained why this PR is important
- [X] I have added necessary documentation (if appropriate)

### Further Comments

Might want to consider removing Sequel Pro. Let me hear your thoughts if so.
