### PR TITLE
Removing LastPass from the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1002,7 +1002,6 @@ Any comments, suggestions? [Let us know!](https://github.com/jaywcjlove/awesome-
 * [Enpass](https://www.enpass.io/) - Cross-platform password management tool with cloud integration. [![App Store][app-store Icon]](https://itunes.apple.com/us/app/enpass-password-manager/id455566716)
 * [Keeweb](https://keeweb.info/) - Free, cross-platform password manager compatible with KeePass. [![Open-Source Software][OSS Icon]](https://github.com/keeweb/keeweb) ![Freeware][Freeware Icon]
 * [KeepassXC](https://keepassxc.org/) - Free, open source, cross-platform password manager. [![Open-Source Software][OSS Icon]](https://github.com/keepassxreboot/keepassxc) ![Freeware][Freeware Icon]
-* [LastPass](https://lastpass.com/) - Password management tool for Mac OS and browser.
 * [MacPass](https://macpass.github.io/) - Open-source KeePass Mac OS client. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/mstarke/MacPass)
 * [SafeInCloud](https://safe-in-cloud.com/en/) - Cross Platform password management, low cost app! [![App Store][app-store Icon]](https://itunes.apple.com/app/safeincloud-password-manager/id883070818)
 * [Strongbox](https://strongboxsafe.com/) - Secure Password Management for iOS and MacOS. Open Source. Compatible with KeePass and Password Safe. [![Open-Source Software][OSS Icon]](https://github.com/strongbox-password-safe/Strongbox) [![App Store][app-store Icon]](https://apps.apple.com/us/app/strongbox/id1270075435?mt=12)


### PR DESCRIPTION
### Types of Changes

- [ ] New addition to list
- [ ] Fixing bug in existing item in list
- [X] Removing item from list
- [ ] Changing structure (organization) of list

### Proposed Changes

Removing LastPass software in the password managers category.
The removal is due to maintaining the concept of the repository as "collect awesome macOS software in various categories". 

Due to the latest incidents involving user data, it is preferable not to consider this product, at least for the moment, as one of the "awesome" choices in its category.

More details:
[LastPass blog - Security Incident](https://blog.lastpass.com/2022/12/notice-of-recent-security-incident/)
[Wikipedia - Security incidents list](https://en.wikipedia.org/wiki/LastPass#Security_incidents)
[LasPass blog - Additional details of the attack](https://support.lastpass.com/help/incident-2-additional-details-of-the-attack)

### PR Checklist

- [X] I have read the CONTRIBUTING guide
- [X] I have explained why this PR is important
- [X] I have added necessary documentation (if appropriate)
