### PR TITLE
 delete  虾米音乐

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -557,7 +557,6 @@ Awesome Mac
 * [ieaseMusic](https://github.com/trazyn/ieaseMusic) - 基于网易云音乐 [![Open-Source Software][OSS Icon]](https://github.com/Binaryify/NeteaseCloudMusicApi) ![Freeware][Freeware Icon]
 * [QQ音乐](https://y.qq.com/download/index.html) ![Freeware][Freeware Icon]
 * [网易云音乐](http://music.163.com/) ![Freeware][Freeware Icon]
-* [虾米音乐](http://www.xiami.com/apps/mac) ![Freeware][Freeware Icon]
 * [酷我音乐](http://kuwo.cn/down/index) ![Freeware][Freeware Icon]
 * [酷狗音乐](http://download.kugou.com/mac.html) ![Freeware][Freeware Icon]
 


### PR DESCRIPTION
虾米音乐目前已在全球范围内停止了服务,此项可以删除