### PR TITLE
Add swiftGuard (Physical Access Security)

### DIFF
--- a/README.md
+++ b/README.md
@@ -853,6 +853,7 @@ Any comments, suggestions? [Let us know!](https://github.com/jaywcjlove/awesome-
 * [RansomWhere?](https://objective-see.com/products/ransomwhere.html) - Generic Ransomware Detection. [![Open-Source Software][OSS Icon]](https://github.com/objective-see/RansomWhere)
 * [stronghold](https://github.com/alichtman/stronghold) - Easily configure MacOS security settings from the terminal. [![Open-Source Software][OSS Icon]](https://github.com/alichtman/stronghold) ![Freeware][Freeware Icon]
 * [Suspicious Package](https://www.mothersruin.com/software/SuspiciousPackage/) - An application for inspecting macOS installer packages. ![Freeware][Freeware Icon]
+* [swiftGuard](https://github.com/Lennolium/swiftGuard) - Lightweight App that safeguards your System's USB Ports from any Unauthorized Access and performs various Counter-Measures. [![Open-Source Software][OSS Icon]](https://github.com/Lennolium/swiftGuard) ![Freeware][Freeware Icon]
 * [TaskExplorer](https://objective-see.com/products/taskexplorer.html) - Explore all processes running on your Mac with TaskExplorer. [![Open-Source Software][OSS Icon]](https://github.com/objective-see/TaskExplorer)
 * [What's Your Sign?](https://objective-see.com/products/whatsyoursign.html) - Adds menu item to Finder.app to display the cryptographic signing information for any file.[![Open-Source Software][OSS Icon]](https://github.com/objective-see/WhatsYourSign)
 


### PR DESCRIPTION
### Types of Changes

- [x] New addition to list
- [ ] Fixing bug in existing item in list
- [ ] Removing item from list
- [ ] Changing structure (organization) of list

### Proposed Changes

It's an anti-forensic macOS tray application designed to safeguard your system or server by monitoring USB ports. It ensures your device's operational security by automatically initiating either a system shutdown or hibernation if an unauthorized device connects or a connected device is unplugged. It offers the flexibility to whitelist designated devices, to select an action to be executed and to set a countdown timer, allowing to disarm the shutdown process. It's a revival of the well-known [usbkill project](https://github.com/hephaest0s/usbkill) by hephaestos, but with a Graphical User Interface and added functionality.

### PR Checklist

- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important
- [x] I have added necessary documentation (if appropriate)

### Further Comments

For non-technical user, using the original usbkill command line tool (see above) is far too difficult. This is the reason for swiftGuard: It offers a nice, clean and intuitive Interface with some additional features, whitelisting and an active development (unlike usbkill, which seems abandoned).

### Screenshots
![Interface](https://github.com/Lennolium/swiftGuard/raw/main/img/screenshots/screenshots.png)

