### PR TITLE
Replace Cakebrew with Cork

### DIFF
--- a/README.md
+++ b/README.md
@@ -1250,7 +1250,7 @@ If you come across websites offering pirated software or cracks, please post [HE
 *Here are some of the major software download sites, there are a number of OSX Mac software sites*
 
 * [Applite](https://aerolite.dev/applite) - User-friendly GUI app for Homebrew Casks. Install, update, and uninstall apps with a single click. ![Freeware][Freeware Icon] [![Open-Source Software][OSS Icon]](https://github.com/milanvarady/Applite)
-* [Cakebrew](http://www.cakebrew.com) - GUI client for Homebrew. Install, check or remove apps, no command-line needed. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/brunophilipe/Cakebrew/)
+* [Cork](https://corkmac.app) - An intuitive and complete Homebrew GUI written in SwiftUI that supports all Homebrew features. [![Open-Source Software][OSS Icon]](https://github.com/buresdv/cork)
 * [Homebrew](https://brew.sh/) - The missing package manager for macOS. ![Freeware][Freeware Icon] [![Open-Source Software][OSS Icon]](https://github.com/Homebrew/brew/)
 * [MacPorts](https://www.macports.org/) - Open-source community initiative to design an easy-to-use system for compiling, installing, and upgrading either command-line, X11 or Aqua based open-source software on the Mac OS X operating system. ![Freeware][Freeware Icon] [![Open-Source Software][OSS Icon]](https://github.com/macports/)
 * [MacUpdate Desktop](https://www.macupdate.com/) - Simplifies finding, buying and installing apps for your Mac.


### PR DESCRIPTION
NOTE: A similar PR may already be submitted! Please search among the Pull request before creating one.

### Types of Changes
- [x] New addition to list
- [ ] Fixing bug in existing item in list
- [x] Removing item from list
- [ ] Changing structure (organization) of list

### Proposed Changes

Although perhaps a radical change, I think replacing Cakebrew with Cork is warranted. Cakebrew has been abandoned for three years, so it's no longer getting updates and support, and is likely to break with upcoming Homebrew updates. Cork, on the other hand, is in active development, is the same type of app, and supports the same features Cakebrew does.

As for the app itself, it's a GUI for Homebrew. It supports all Homebrew features, including:
- Formulae and Casks
- Taps
- Installing, updating and pinning packages
- Homebrew services
- Full support for `sudo` operations.

It also supports extra features:
- Automatically respecting the system proxy
- Tagging of packages
- Custom maintenance operations
- Interacting with Homebrew through the Menu Bar

It's written in SwiftUI with a modern macOS design philosophy.

https://corkmac.app

### PR Checklist

Put an x in the boxes once you've completed each step. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important
- [x] I have added necessary documentation (if appropriate)

### Further Comments

At first, I was thinking of only adding Cork, but I think that the abandonement of Cakebrew over three years ago makes it warranted for a replacement instead.
