### PR TITLE
Add Laucnhy app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1129,6 +1129,7 @@ highlighting. [![Open-Source Software][OSS Icon]](https://github.com/dbcli/pgcli
 * [Keyboard Cowboy](https://github.com/zenangst/KeyboardCowboy) - The missing keyboard shortcut utility for macOS. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/zenangst/KeyboardCowboy)
 * [Keyboard Maestro](http://www.keyboardmaestro.com) - Automate routine actions based on triggers from keyboard, menu, location, added devices, and more.
 * [Keytty](http://keytty.com) - App to keep your hands on the keyboard. Move, click, scroll, drag and more with a few strokes.
+* [Launchy](https://apple.co/3PLI2AH) - An app launcher and switcher that utilizes a radial menu.
 * [Lazy](https://www.lazy-app.com/) - Keyboard-driven commands to manage your surroundings directly from your mac.
 * [Linear Mouse](https://linearmouse.app/) - Full control of mouse. Change the speed, scrolling direction, pointer type and much more. [![Open-Source Software][OSS Icon]](https://github.com/linearmouse/linearmouse)
 * [Macaify](https://macaify.com) - Fast use of ChatGPT, lightweight, clean, keyboard-first. ![Freeware][Freeware Icon]


### PR DESCRIPTION
### Types of Changes

- [x] New addition to list
- [ ] Fixing bug in existing item in list
- [ ] Removing item from list
- [ ] Changing structure (organization) of list

### Proposed Changes

Launchy is an app launcher and switcher for macOS. It is designed to enhance productivity through a customizable and visually appealing radial menu interface. Launchy allows users to quickly launch and switch between apps using keyboard shortcuts or mouse gestures, making it perfect for both casual and power users.

I think Launchy deserves to be added because it offers a unique, streamlined alternative to traditional app launching methods like the Dock or Spotlight, with a focus on ease of use, customization, and speed.

AppStore link: [https://apple.co/3PLI2AH](https://apple.co/3PLI2AH)

![image](https://github.com/user-attachments/assets/edc646ec-0db8-44d2-80d0-6f9e43faf769)


### PR Checklist

- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important
- [ ] I have added necessary documentation (if appropriate)

