### PR TITLE
Add LyricGlow

### DIFF
--- a/README.md
+++ b/README.md
@@ -804,6 +804,8 @@ Any comments, suggestions? [Let us know!](https://github.com/jaywcjlove/awesome-
 * [Kodi](https://kodi.tv/) - Award-winning free and open-source (GPL) software media center for playing videos, music, pictures, games, and more. [![Open-Source Software][OSS Icon]](https://github.com/xbmc/xbmc) ![Freeware][Freeware Icon]
 * [LMMS](https://lmms.io) - Formerly "Linux MultiMedia Studio", LMMS is a powerful Digital Audio Workstation designed like FL Studio (formerly Fruity Loops). [![Open-Source Software][OSS Icon]](https://github.com/lmms/lmms) ![Freeware][Freeware Icon]
 * [LosslessCut](https://github.com/mifi/lossless-cut) - Cross platform tool for quick and lossless video and audio trimming using ffmpeg. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/mifi/lossless-cut)
+* [LyricGlow](https://github.com/ateymoori/lyricglow) - Synchronized lyrics player with word-by-word glow effects for Spotify, Apple Music, and YouTube Music. [![Open-Source Software][OSS Icon]](https://github.com/ateymoori/lyricglow) ![Freeware][Freeware Icon]
+
 * [LyricsX](https://github.com/ddddxxx/LyricsX) - Lyrics for iTunes, Spotify and Vox. [![Open-Source Software][OSS Icon]](https://github.com/ddddxxx/LyricsX) ![Freeware][Freeware Icon]
 * [MacMusicPlayer](https://github.com/samzong/macmusicplayer) - A clean, lightweight music player for macOS users. ![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]
 * [MacYTDL](https://github.com/section83/MacYTDL) -  A macOS GUI front-end for the youtube-dl video downloader. [![Open-Source Software][OSS Icon]](https://github.com/section83/MacYTDL) ![Freeware][Freeware Icon]


### PR DESCRIPTION
### Types of Changes

**What types of changes does your PR introduce?** Put an x in all boxes that apply

- [x] New addition to list
- [ ] Fixing bug in existing item in list
- [ ] Removing item from list
- [ ] Changing structure (organization) of list

### Proposed Changes

**Describe each of your changes here to communicate to the maintainers why we should accept this pull request.**

1. Adding **LyricGlow** to the Audio and Video Tools section.

**Why it should be added:**

LyricGlow is a synchronized lyrics player for macOS that displays word-by-word glow effects while you listen to music from Spotify, Apple Music, and YouTube Music. It's a free, open-source (MIT License) application that enhances the music listening experience with:

- 🎵 Real-time synchronized lyrics with word-level highlighting
- ✨ Smooth animated glow effects  
- 🎨 Artist metadata, biography, and album artwork
- 🌐 RTL language support (Persian, Arabic, Hebrew)
- 🪟 Always-on-top floating window
- 🔒 Privacy-first design (no data collection)

**Placement:** Alphabetically positioned before LyricsX in the Audio and Video Tools section.

**Links:**
- Repository: https://github.com/ateymoori/lyricglow
- License: MIT (Open Source)
- Platform: macOS 11.0+

### PR Checklist

Put an x in the boxes once you've completed each step.

- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important
- [x] I have added necessary documentation (if appropriate)
- [x] Entry is in alphabetical order
- [x] Checked for duplicate entries
- [x] Spelling and grammar are correct

### Further Comments

LyricGlow complements existing lyrics tools like LyricsX by offering a unique word-by-word glow effect that creates an immersive visual experience synchronized with the music. It's actively maintained and designed specifically for macOS users who want enhanced lyrics display.

Thank you for maintaining this awesome resource! 🎵