### PR TITLE
Refactor getHeadingText to remove title parameter

### DIFF
--- a/build/ast.mjs
+++ b/build/ast.mjs
@@ -3,14 +3,17 @@ import { remark } from 'remark'
 import gfm from 'remark-gfm'
 import FS from 'fs-extra'
 
-const getHeadingText = (arr = [], title = '') => {
+const getHeadingText = (arr = []) => {
+  let title = ''
   arr.forEach(child => {
-    title += child.value
+    if (typeof child.value === 'string') {
+      title += child.value
+    }
     if (child.children && Array.isArray(child.children)) {
-      title += getHeadingText(child.children, title)
+      title += getHeadingText(child.children)
     }
   })
-  return title;
+  return title
 }
 
 const getSoftwareName = (obj, result = { title: '' }) => {


### PR DESCRIPTION
getHeadingText passes the current accumulated title as the recursion's second parameter and then concatenates the returned string back onto title: 

title += child.value
title += getHeadingText(child.children, title)

Because the recursive call receives the already-accumulated title, the recursive result itself includes that prefix, so the outer concatenation duplicates earlier text (e.g. "A" + "AB" -> "AAB").
