### PR TITLE
Add Notchie - Voice-synced teleprompter for MacBook notch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1197,6 +1197,7 @@ Any comments, suggestions? [Let us know!](https://github.com/jaywcjlove/awesome-
 * [Mos](https://mos.caldis.me/) - Simple tool can offer the smooth scrolling and reverse the mouse scrolling direction on your Mac. [![Open-Source Software][OSS Icon]](https://github.com/Caldis/Mos) ![Freeware][Freeware Icon]
 * [MacPacker](https://macpacker.app) - Archive manager that supports previewing and extracting archive files [![Open-Source Software][OSS Icon]](https://github.com/sarensw/macpacker) ![Freeware][Freeware Icon]
 * [Magic Switch](https://magic-switch.com/) - Switch your Magic Keyboard, Magic Mouse and Magic Trackpad between multiple Macs with different Apple IDs.
+* [Notchie](http://notchie.app/) - Voice-synced teleprompter hidden in your MacBook notch area. Invisible on calls. Built in minimal notes editor.
 * [nnScreenshots](https://www.nearnorthsoftware.com/software/screenshots.php) - A super easy way to keep a visual record of your productivity to make it easier to fill out timesheets or just to help you review the day. Built in timesheet editor.
 * [OmniPlan](https://www.omnigroup.com/omniplan/) - The best way to visualize, maintain, and simplify your projects. Project Management made easy.
 * [OpenIn](https://loshadki.app/openin4/) - Take control of installed apps on your Mac [![App Store][app-store Icon]](https://apps.apple.com/us/app/openin-4-advanced-link-handler/id1643649331?mt=12)


### PR DESCRIPTION
Added new entry for productivity apps for Notchie. Teleprompter for Mac that sits in the notch area, scrolls as you speak, and hides automatically on video calls.

### Types of Changes

**What types of changes does your PR introduce?** Put an x in all boxes that apply

- [x] New addition to list
- [ ] Fixing bug in existing item in list
- [ ] Removing item from list
- [ ] Changing structure (organization) of list

### Proposed Changes

**Describe each of your changes here to communicate to the maintainers why we should accept this pull request.**

1. Adding Notchie to the productivity apps section. Notchie is a native Mac teleprompter with two unique features not found in other apps on this list:
   - **Notch placement** — positions the script directly below the MacBook camera/notch area, allowing natural eye contact during video calls
   - **Voice-synced scrolling** — the text follows your speaking pace in real-time instead of scrolling at a fixed speed
   
   Additionally, the app is invisible during screen sharing, making it useful for presentations, sales calls, and webinars. One-time purchase, no subscription.

### PR Checklist

Put an x in the boxes once you've completed each step. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important
- [x] I have added necessary documentation (if appropriate)

### Further Comments

Notchie fills a gap in the current list — there's no other teleprompter app listed, and existing solutions (PromptSmart, Teleprompter Pro, etc.) don't offer the combination of notch positioning + voice sync + screen share invisibility. The app is actively maintained and available at [notchie.app](https://notchie.app).