### PR TITLE
Add PDF Auditor - PDF forensics and analysis tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ Any comments, suggestions? [Let us know!](https://github.com/jaywcjlove/awesome-
 * [CHM Reader](http://www.hewbo.com/chm-reader.html) - Read Compiled HTML (.chm) documents on your Mac. ![Freeware][Freeware Icon]
 * [Chmox](http://chmox.sourceforge.net/) - Read CHM documents on your Mac. ![Freeware][Freeware Icon]
 * [Highlights](https://highlightsapp.net) - The PDF Reader for Research on Mac, iPad & iPhone. ![Freeware][Freeware Icon]
-* [PDF Auditor](https://pura-vida.in/apps/pdf-auditor/?utm_source=github&utm_medium=awesome-mac) - PDF forensics tool for analyzing metadata, fonts, JavaScript, security risks, and structural integrity. [![App Store][app-store Icon]](https://apps.apple.com/us/app/pdf-auditor-inspect-analyze/id6738956506?mt=12)
+* [PDF Auditor](https://pura-vida.in/apps/pdf-auditor/?utm_source=github&utm_medium=awesome-mac) - PDF forensics tool for analyzing metadata, fonts, JavaScript, security risks, and structural integrity. [![App Store][app-store Icon]](https://apps.apple.com/app/apple-store/id6738956506?pt=127483661&ct=GitHub&mt=8)
 * [PDF Expert](https://pdfexpert.com/) - Read, annotate and edit PDFs, change text and images.
 * [PDF Pals](https://pdfpals.com) - Chat with PDF app for Mac. No file size limits!
 * [PDFgear](https://www.pdfgear.com/) - AI-integrated PDF editor. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/pdfgear-pdf-editor-for-adobe/id1615523079)


### PR DESCRIPTION
## Summary

Adding [PDF Auditor](https://pura-vida.in/apps/pdf-auditor/) to the "Reading and Writing Tools" → "Others" section.

PDF Auditor is a macOS app for deep PDF forensics and analysis, allowing users to inspect:
- Metadata and document properties
- Font analysis and embedding status
- JavaScript and actions detection
- Security permissions and encryption details
- Structural integrity and forensic analysis

Available on the Mac App Store.

## Checklist

- [x] Entry follows the required format
- [x] Entry is in alphabetical order (between PDF Pals and PDFgear)
- [x] Description is concise and technical
- [x] App Store badge included