### PR TITLE
Add Cocoa-Way - Linux GUI apps on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,6 +502,7 @@ Any comments, suggestions? [Let us know!](https://github.com/jaywcjlove/awesome-
 ### Virtualization
 
 * [Docker](https://www.docker.com/) - Powerful, performs operating-system-level virtualization. [![Open-Source Software][OSS Icon]](https://github.com/docker) ![Freeware][Freeware Icon] [![Awesome List][awesome-list Icon]](https://github.com/veggiemonk/awesome-docker#readme)
+* [Cocoa-Way](https://github.com/J-x-Z/cocoa-way) - Native Wayland compositor for running Linux GUI apps on macOS without VM overhead. Uses waypipe for seamless integration. [![Open-Source Software][OSS Icon]](https://github.com/J-x-Z/cocoa-way) ![Freeware][Freeware Icon]
 * [MacVirtue](https://naden.co) - Run free and unlimited Virtual Machines on your Mac.
 * [Multipass](https://multipass.run/) - Ubuntu VMs on demand for any workstation. [![Open-Source Software][OSS Icon]](https://github.com/canonical/multipass)
 * [OrbStack](https://orbstack.dev/) - Fast, light, and simple way to run Docker containers and Linux machines on macOS. ![Freeware][Freeware Icon]


### PR DESCRIPTION
Add Cocoa-Way to the Virtualization section.

Cocoa-Way is a native macOS Wayland compositor that allows running Linux GUI applications (Firefox, GTK apps, Qt apps) on macOS without the overhead of a full VM display. It works seamlessly with OrbStack, Docker, or remote Linux hosts via SSH.

- **Open-source**: GPL-3.0 license
- **Native**: Built specifically for macOS with Metal/OpenGL rendering
- **Practical**: One-liner install via Homebrew

**Links:**
- Repository: https://github.com/J-x-Z/cocoa-way
- Homebrew: https://github.com/J-x-Z/homebrew-tap
- Demo video: https://youtu.be/VS3vQp5i8YQ