### PR TITLE
Add Capty to Screencapturing Software section

### DIFF
--- a/README.md
+++ b/README.md
@@ -654,6 +654,7 @@ Any comments, suggestions? [Let us know!](https://github.com/jaywcjlove/awesome-
 
 * [CleanShot X](https://cleanshot.com/) - Discover a superior way to capture your Mac's screen.
 * [CloudApp](https://www.getcloudapp.com/) - Work at the speed of sight. ![Freeware][Freeware Icon]
+* [Capty](https://capty.app/) - Professional screen capture and recording for macOS with built-in video editor, annotation tools, and beautiful wallpaper backgrounds.
 * [Flameshot](https://github.com/flameshot-org/flameshot) - Powerful yet simple to use screenshot software. ![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]
 * [Gifox](https://gifox.app) - Gif Recording and Sharing.
 * [Kap](https://getkap.co/) - Open-source screen-recorder built with web technology. [![Open-Source Software][OSS Icon]](https://github.com/wulkano/kap) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Hi! I'd like to suggest adding [Capty](https://capty.app) to the Screencapturing Software section.

## About Capty

Capty is a professional screen capture and recording app for macOS with:

- **Screenshot capture** — Area, window, and fullscreen modes
- **Screen recording** — With system audio, microphone, and camera overlay
- **Built-in video editor** — Trim, add cursor effects, zoom animations (unique feature most tools lack)
- **Annotation tools** — Arrows, shapes, text, blur, redact
- **Wallpaper studio** — Beautiful backgrounds with gradients, shadows, and frames
- **OCR text capture** — Extract text from any area
- **Multiple export formats** — PNG, JPEG, MP4 (up to 4K/60fps), GIF

It's a native macOS app supporting macOS 15+ on Intel and Apple Silicon.

Thanks for considering!