### PR TITLE
Add mac-ops

### DIFF
--- a/README.md
+++ b/README.md
@@ -1037,6 +1037,7 @@ Any comments, suggestions? [Let us know!](https://github.com/jaywcjlove/awesome-
 * [DNS Easy Switcher](https://github.com/glinford/dns-easy-switcher) - A simple macOS menu bar app that allows you to quickly switch between different DNS providers (or add custom ones). [![Open-Source Software][OSS Icon]](https://github.com/glinford/dns-easy-switcher) ![Freeware][Freeware Icon]
 * [Dropshelf](https://pilotmoon.com/dropshelf/) - A drag and drop helper app for macOS. ![Freeware][Freeware Icon]
 * [Dropover](https://dropoverapp.com/) - A macOS utility that makes Drag and Drop easier. Stash, gather or move draggable content without having to open side-by-side windows. [![App Store][app-store Icon]](https://apps.apple.com/us/app/dropover-easier-drag-drop/id1355679052)
+* [mac-ops](https://github.com/seunggabi/mac-ops) - Safe, zero-dependency macOS system optimizer with 72-hour trash recovery. [![Open-Source Software][OSS Icon]](https://github.com/seunggabi/mac-ops) ![Freeware][Freeware Icon]
 
 ### Clipboard Tools
 


### PR DESCRIPTION
## Submission

**[mac-ops](https://github.com/seunggabi/mac-ops)** – A safe, zero-dependency macOS system optimizer CLI with 72-hour trash recovery.

## Why it fits this list

mac-ops is a practical system maintenance tool for macOS that cleans caches, temp files, logs, and zombie/orphan processes while keeping files recoverable for 72 hours. It uses only macOS built-in tools (pure zsh, zero external dependencies), is thoroughly tested (108+ tests), and runs unattended via launchd. It fits naturally in the Utilities section alongside other macOS system tools.

## Checklist

- [x] No duplicate of existing entries
- [x] Alphabetically ordered within the Utilities section
- [x] Follows the exact format with OSS Icon and Freeware Icon badges
- [x] Concise one-liner description
- [x] MIT Licensed (free and open source)