### PR TITLE
Add Stik - Quick capture note app with on-device AI search

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ Any comments, suggestions? [Let us know!](https://github.com/jaywcjlove/awesome-
 * [Saber](https://saber.adil.hanney.org/) - Cross platform stylus and text notetaking app. Supports image and pdf imports, can sync. [![App Store][app-store Icon]](https://apps.apple.com/us/app/saber/id1671523739)[![Open-Source Software][OSS Icon]](https://github.com/adil192/saber)
 * [SideNotes](https://www.apptorium.com/sidenotes) - Quick notes on the screen side with Markdown support.
 * [Standard Notes](https://standardnotes.com/) - An end-to-end encrypted notes app for digitalists and professionals. [![Open-Source Software][OSS Icon]](https://github.com/standardnotes/app) ![Freeware][Freeware Icon] [![Awesome List][awesome-list Icon]](https://github.com/jonhadfield/awesome-standard-notes#readme)
+* [Stik](https://github.com/0xMassi/stik_app) - Quick-capture note app with global hotkey and on-device AI semantic search. Plain markdown files, 8MB binary. [![Open-Source Software][OSS Icon]](https://github.com/0xMassi/stik_app) ![Freeware][Freeware Icon]
 * [QOwnNotes](http://www.qownnotes.org/) - Open-source notepad with markdown support and todo list manager. [![Open-Source Software][OSS Icon]](https://github.com/pbek/QOwnNotes) ![Freeware][Freeware Icon]
 * [Quick Note](https://quicknoteapp.com) - Colorful sticky notes in the Menu bar. [![App Store][app-store Icon]](https://apps.apple.com/in/app/quick-note-in-the-menu/id1472935217?mt=12)
 * [Quiver](http://happenapps.com/#quiver) - Mix text, code, Markdown, and LaTeX in one note with live preview.


### PR DESCRIPTION
Add [Stik](https://github.com/0xMassi/stik_app) to the **Note-taking** section.

**Stik** is a quick-capture note app for macOS built with Tauri 2.0 (Rust + React + TypeScript).

- Global hotkey to summon a floating capture window — hotkey → type → done
- On-device AI semantic search using Apple's NaturalLanguage framework (no cloud, no API keys)
- All notes stored as plain `.md` files locally
- 8MB binary, ~20MB RAM
- MIT licensed, fully open source
- Available via Homebrew: `brew install --cask stik`

GitHub: https://github.com/0xMassi/stik_app
Website: https://stik.ink

## Checklist

- [x] Searched for duplicates — Stik is not currently listed
- [x] Entry placed alphabetically (after Standard Notes, before QOwnNotes)
- [x] Description is short, simple, and descriptive
- [x] Includes Open-Source Software and Freeware badges
- [x] Category: Note-taking