### PR TITLE
Add renamed.to CLI to Command Line Apps > Other

### DIFF
--- a/command-line-apps.md
+++ b/command-line-apps.md
@@ -147,6 +147,7 @@ A curated list of useful command line apps
 * [OpenRecall](https://github.com/openrecall/openrecall) - Access your digital history, enhance memory and productivity, while maintaining privacy. [![OSS][OSS Icon]](https://github.com/openrecall/openrecall) ![Freeware][Freeware Icon]
 highlighting. [![Open-Source Software][OSS Icon]](https://github.com/dbcli/pgcli) ![Freeware][Freeware Icon]
 * [Rebound](https://github.com/shobrook/rebound/) - Instantly browse Stack Overflow results in your terminal when you get a compiler error. ![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]
+* [renamed.to](https://github.com/upspawn/cli.renamed.to) - AI-powered CLI for bulk file renaming using document content and OCR. Installable via Homebrew (`brew tap renamed-to/cli`). [![Open-Source Software][OSS Icon]](https://github.com/upspawn/cli.renamed.to) ![Freeware][Freeware Icon]
 * [ripgrep (rg)](https://github.com/BurntSushi/ripgrep) - Very fast text searching tool similar to (but faster than) ack, ag or grep ![Freeware][Freeware Icon]
 * [Serial](https://www.decisivetactics.com/products/serial/) - Full-featured serial terminal for the Mac.
 * [shallow-backup](https://github.com/alichtman/shallow-backup) - Easily create text documentation of installed applications, dotfiles, and more. ![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]


### PR DESCRIPTION
NOTE: A similar PR may already be submitted! Please search among the Pull request before creating one.

### Types of Changes

**What types of changes does your PR introduce?** Put an x in all boxes that apply

- [X] New addition to list
- [ ] Fixing bug in existing item in list
- [ ] Removing item from list
- [ ] Changing structure (organization) of list

### Proposed Changes

**Describe each of your changes here to communicate to the maintainers why we should accept this pull request.**

Adding [renamed.to CLI](https://github.com/upspawn/cli.renamed.to) — an open-source command-line tool for AI-powered bulk file renaming on macOS. It reads document content (PDFs, images, contracts, invoices) via OCR and generates descriptive filenames automatically.

Install via Homebrew:

```
brew tap renamed-to/cli && brew install renamed-to
```

- Open source on GitHub (MIT-compatible)
- Installable via Homebrew — native macOS CLI workflow
- Free tier available
- Placed alphabetically in Other section (between Rebound and ripgrep)

**Disclosure:** I am the developer of this tool.

### PR Checklist

Put an x in the boxes once you've completed each step. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- [X] I have read the CONTRIBUTING guide
- [X] I have explained why this PR is important
- [X] I have added necessary documentation (if appropriate)

### Further Comments

Previously submitted as PR #1790 targeting README.md's file tools section, but closed it since the CLI is a better fit for the command-line-apps list. Happy to adjust anything.