### PR TITLE
Add BookShelves to Ebooks section

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ Any comments, suggestions? [Let us know!](https://github.com/jaywcjlove/awesome-
 ### Ebooks
 
 * [Calibre](http://calibre-ebook.com/) - Free, open-source e-book manager and reader. [![OSS][OSS Icon]](https://github.com/kovidgoyal/calibre) ![Freeware][Freeware Icon]
+* [BookShelves](https://getbookshelves.app/) - Ebook reader and library manager with 100,000+ free public domain books and iCloud sync across Mac, iPhone, and iPad. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/bookshelves-ebook-reader/id6756848973)
 * [Clearview](http://www.clearview-reader.com/clearview/) - Tabbed style e-book reader for PDF, EPUB (DRM free), CHM, and MOBI. [![App Store][app-store Icon]](https://apps.apple.com/us/app/clearview/id557090104?mt=12)
 * [iChm](https://github.com/NSGod/ichm) - Ebook reader for CHM (Microsoft Compiled HTML help) files. [![Open-Source Software][OSS Icon]](https://github.com/NSGod/ichm) ![Freeware][Freeware Icon]
 * [Kindle App](https://www.amazon.com/l/16571048011) - Amazon official reading app of kindle.


### PR DESCRIPTION
Added [BookShelves](https://getbookshelves.app/) to the Ebooks section.

BookShelves is a native macOS/iOS ebook reader and library manager with:
- 100,000+ free public domain books (Standard Ebooks, Internet Archive)
- iCloud sync across Mac, iPhone, and iPad
- EPUB, PDF, MOBI, AZW3 support
- Free on the Mac App Store

[Mac App Store link](https://apps.apple.com/app/bookshelves-ebook-reader/id6756848973)

Entry added in alphabetical order.