### PR TITLE
Add Superscribe to Voice-to-Text section

### DIFF
--- a/README.md
+++ b/README.md
@@ -943,7 +943,7 @@ Any comments, suggestions? [Let us know!](https://github.com/jaywcjlove/awesome-
 * [buzz](https://github.com/chidiwilliams/buzz) - Transcribes and translates audio offline on your personal computer. Powered by OpenAI's Whisper. [![Open-Source Software][OSS Icon]](https://github.com/chidiwilliams/buzz)
 * [Ottex](https://ottex.ai) - Dictate emails, Slack messages, notes and more. Detects your app or website and formats accordingly — gmail.com → email, Obsidian → markdown, etc.
 * [Spokenly](https://spokenly.app/) - Voice-to-text with 100+ languages, offline mode, and AI-powered formatting.
-* [Superscribe](https://superscribe.io/) - Voice-first dictation and time tracking from your macOS menu bar. Speak and words appear as you type.
+* [Superscribe](https://superscribe.io/) - Dictate into any app and track your time automatically, all from the menu bar.
 * [VoiceInk](https://tryvoiceink.com/) - Real-time speech-to-text app. [![Open-Source Software][OSS Icon]](https://github.com/Beingpax/VoiceInk) ![Freeware][Freeware Icon]
 * [Whispering](https://epicenter.md/whispering/) - Multi-provider speech-to-text with AI transformations and keyboard shortcuts. [![Open-Source Software][OSS Icon]](https://github.com/EpicenterHQ/epicenter/tree/main/apps/whispering) ![Freeware][Freeware Icon]
 * [Willow Voice](https://willowvoice.com/) - AI dictation with automatic editing, style-matching, and noise optimization.


### PR DESCRIPTION
Added [Superscribe](https://superscribe.io/) to the Voice-to-Text section in alphabetical order.

Superscribe is a macOS menu bar app for voice-first dictation and time tracking. Speak and words appear as you type.

- Website: https://superscribe.io/
- Platform: macOS (menu bar app)
- Category: Voice-to-Text