### PR TITLE
Add open-source macOS apps by @kochj23

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,7 @@ Any comments, suggestions? [Let us know!](https://github.com/jaywcjlove/awesome-
 * [MacSystemColors](https://github.com/kaunteya/MacSystemColors) - Mac app that shows all system colors in light and dark mode for Cocoa developers. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/kaunteya/MacSystemColors)
 * [Medio](https://github.com/nuance-dev/medio) - A native, lightweight text diff tool with a clean UI and real-time highlighting. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/nuance-dev/medio)
 * [MJML](https://mjmlio.github.io/mjml-app/) - Create responsive emails with a semantic syntax and rich components. [![OSS][OSS Icon]](https://github.com/mjmlio/mjml) ![Freeware][Freeware Icon]
+* [MLXCode](https://github.com/kochj23/MLXCode) - Local LLM-powered coding assistant using Apple MLX framework. No cloud, no telemetry. [![Open-Source Software][OSS Icon]](https://github.com/kochj23/MLXCode) ![Freeware][Freeware Icon]
 * [NameQuick](https://namequick.app) - AI-powered file renaming tool for macO
 * [PaintCode](https://www.paintcodeapp.com/) - Vector drawing app that generates Objective-C or Swift code in real time.
 * [Pasteboard Viewer](https://github.com/sindresorhus/Pasteboard-Viewer) - Inspect the system pasteboards. [![Open-Source Software][OSS Icon]](https://github.com/sindresorhus/Pasteboard-Viewer) ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id1499215709)
@@ -1013,6 +1014,7 @@ Any comments, suggestions? [Let us know!](https://github.com/jaywcjlove/awesome-
 * [LuLu](https://objective-see.com/products/lulu.html) - LuLu is the free macOS firewall that aims to block unauthorized (outgoing) network traffic. [![Open-Source Software][OSS Icon]](https://github.com/objective-see/LuLu) [![Open-Source Software][OSS Icon]](1) ![Freeware][Freeware Icon]
 * [MalwareBytes](https://www.malwarebytes.com/mac-download/) - Malwarebytes crushes the growing threat of Mac malware, so you are protected and your machine keeps running silky smooth. Cybersecurity smart enough for the Mac. ![Freeware][Freeware Icon]
 * [Mana Security](https://www.manasecurity.com/) - vulnerability management app for individuals. [![Open-Source Software][OSS Icon]](https://github.com/manasecurity/mana-security-app)
+* [NMAPScanner](https://github.com/kochj23/NMAPScanner) - Native macOS network security scanner with HomeKit device discovery and vulnerability scanning. [![Open-Source Software][OSS Icon]](https://github.com/kochj23/NMAPScanner) ![Freeware][Freeware Icon]
 * [Vulert](https://vulert.com) - Vulert secures software by detecting vulnerabilities in open-source dependencies—without accessing your code. It supports Js, PHP, Java, Python, and more
 * [OverSight](https://objective-see.com/products/oversight.html) - Monitor mic and webcam, alerting you when the internal mic is activated, or whenever a process accesses the webcam. [![Open-Source Software][OSS Icon]](https://github.com/objective-see/OverSight)
 * [ParetoSecurity](https://paretosecurity.com/) - A MenuBar app to automatically audit your Mac for basic security hygiene. [![Open-Source Software][OSS Icon]](https://github.com/ParetoSecurity/pareto-mac)
@@ -1386,6 +1388,7 @@ Any comments, suggestions? [Let us know!](https://github.com/jaywcjlove/awesome-
 * [OnyX](https://www.titanium-software.fr/en/onyx.html) - Multifunction utility to verify disks and files, run cleaning and system maintenance tasks, configure hidden options and more. ![Freeware][Freeware Icon]
 * [Pearcleaner](https://itsalin.com/appInfo/?id=pearcleaner) - A free, source-available and fair-code licensed mac app cleaner. ![Freeware][Freeware Icon] [![Open-Source Software][OSS Icon]](https://github.com/alienator88/Pearcleaner)
 * [Paragon NTFS](https://www.paragon-software.com/home/ntfs-mac/) - Read/write access to NTFS in macOS Sierra.
+* [RsyncGUI](https://github.com/kochj23/RsyncGUI) - Professional rsync GUI for macOS with real-time progress and profile management. [![Open-Source Software][OSS Icon]](https://github.com/kochj23/RsyncGUI) ![Freeware][Freeware Icon]
 * [stats](https://github.com/exelban/stats) - free Mac system monitor for the menubar. [![Open-Source Software][OSS Icon]](https://github.com/exelban/stats)
 * [Sensei](https://sensei.app/) - Sensei is a multi-tool for Mac performance, with features spanning across both hardware and software.
 * [Sleepr](https://sleepr.app/) - Sleepr brings back sleep timer on macOS. [![App Store][app-store Icon]](https://apps.apple.com/us/app/sleepr-app/id6465683427)
@@ -1395,6 +1398,7 @@ Any comments, suggestions? [Let us know!](https://github.com/jaywcjlove/awesome-
 * [Core Tunnel](https://codinn.com/tunnel/) - Application for managing SSH connections. [![App Store][app-store Icon]](https://apps.apple.com/us/app/core-tunnel/id1354318707)
 * [TG Pro](https://www.tunabellysoftware.com/tgpro/) - Temperature monitoring, fan control & hardware diagnostics to help keep your Mac cool and healthy.
 * [Time Machine Inspector](https://github.com/probablykasper/time-machine-inspector) - Find out what's hogging up your Time Machine backups. [![Open-Source Software][OSS Icon]](https://github.com/probablykasper/time-machine-inspector) ![Freeware][Freeware Icon]
+* [TopGUI](https://github.com/kochj23/TopGUI) - LCARS-inspired system monitor with real-time CPU, memory, disk, and network visualization. [![Open-Source Software][OSS Icon]](https://github.com/kochj23/TopGUI) ![Freeware][Freeware Icon]
 * [Tuxera NTFS](http://www.tuxera.com/products/tuxera-ntfs-for-mac/) - Full read-write compatibility with NTFS-formatted drives on a Mac.
 * [Overkill](https://github.com/KrauseFx/overkill-for-mac) - Stop iTunes from opening when you connect your iPhone.
 


### PR DESCRIPTION
## Summary

Adding 4 open-source macOS applications to the list:

- **MLXCode** (Developer Utilities) - Local LLM-powered coding assistant using Apple MLX framework. No cloud, no telemetry.
- **NMAPScanner** (Security Tools) - Native macOS network security scanner with HomeKit device discovery and vulnerability scanning.
- **RsyncGUI** (System Related Tools) - Professional rsync GUI for macOS with real-time progress and profile management.
- **TopGUI** (System Related Tools) - LCARS-inspired system monitor with real-time CPU, memory, disk, and network visualization.

All projects are:
- Written in Swift
- Open-source under MIT License
- Free to use
- Actively maintained

All projects are personal work by Jordan Koch, not affiliated with any employer.

## Checklist

- [x] Entries follow the existing format with `[![Open-Source Software][OSS Icon]]` and `![Freeware][Freeware Icon]` badges
- [x] Entries are placed in the correct sections
- [x] Entries are alphabetically sorted within their sections
- [x] All links are valid GitHub repository URLs