### PR TITLE
Add TypeWhisper to Voice-to-Text section

### DIFF
--- a/README.md
+++ b/README.md
@@ -945,7 +945,7 @@ Any comments, suggestions? [Let us know!](https://github.com/jaywcjlove/awesome-
 * [Ottex](https://ottex.ai) - Dictate emails, Slack messages, notes and more. Detects your app or website and formats accordingly — gmail.com → email, Obsidian → markdown, etc.
 * [Spokenly](https://spokenly.app/) - Voice-to-text with 100+ languages, offline mode, and AI-powered formatting.
 * [Tambourine](https://tambourinevoice.com/) - Open-source, customizable AI voice dictation that works in any app. [![Open-Source Software][OSS Icon]](https://github.com/kstonekuan/tambourine-voice/) ![Freeware][Freeware Icon]
-* [TypeWhisper](https://typewhisper.app) - Local speech-to-text transcription using Whisper AI. System-wide dictation with global hotkey. [![Open-Source Software][OSS Icon]](https://github.com/TypeWhisper/typewhisper-mac) ![Freeware][Freeware Icon]
+* [TypeWhisper](https://www.typewhisper.com) - Local speech-to-text transcription using Whisper AI. System-wide dictation with global hotkey. [![Open-Source Software][OSS Icon]](https://github.com/TypeWhisper/typewhisper-mac) ![Freeware][Freeware Icon]
 * [VoiceInk](https://tryvoiceink.com/) - Real-time speech-to-text app. [![Open-Source Software][OSS Icon]](https://github.com/Beingpax/VoiceInk) ![Freeware][Freeware Icon]
 * [Whispering](https://epicenter.md/whispering/) - Multi-provider speech-to-text with AI transformations and keyboard shortcuts. [![Open-Source Software][OSS Icon]](https://github.com/EpicenterHQ/epicenter/tree/main/apps/whispering) ![Freeware][Freeware Icon]
 * [Willow Voice](https://willowvoice.com/) - AI dictation with automatic editing, style-matching, and noise optimization.


### PR DESCRIPTION
**TypeWhisper** is a local speech-to-text transcription app for macOS (and Windows) using Whisper AI.

**Key Features:**
- 100% on-device processing - no cloud, fully private
- System-wide dictation via global hotkey (push-to-talk or toggle mode)
- Multiple AI engines: WhisperKit, Parakeet TDT, Apple Speech
- File transcription with subtitle export (SRT, WebVTT)
- Local HTTP API for integrations
- Context-aware profiles for per-app configuration
- Translation support (on-device and cloud)
- Open source (GPLv3)

**Links:**
- Website: https://www.typewhisper.com
- Repository: https://github.com/TypeWhisper/typewhisper-mac

The entry has been added alphabetically to the Voice-to-Text section.