### PR TITLE
Add TickerBar to Finance Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -997,6 +997,7 @@ Any comments, suggestions? [Let us know!](https://github.com/jaywcjlove/awesome-
 ## Finance
 
 * [SubManager](https://submanager.app) - Track your subscriptions in one place and get notified when a subscription is due for renewal. Available for macOS, iOS and visionOS and syncs across all your devices. [![App Store][app-store Icon]](https://apps.apple.com/app/submanager-subscription-list/id1632853914)
+* [TickerBar](https://github.com/TerrifiedBug/TickerBar) - A lightweight macOS menu bar app for tracking stock prices in real-time with sparklines, price alerts, and multi-exchange support. [![Open-Source Software][OSS Icon]](https://github.com/TerrifiedBug/TickerBar) ![Freeware][Freeware Icon]
 
 ## Encryption
 


### PR DESCRIPTION
Added [TickerBar](https://github.com/TerrifiedBug/TickerBar) to the Finance section.

TickerBar is a free, open-source macOS menu bar app for tracking stock prices in real-time. Features include sparkline charts, price alerts with macOS notifications, multi-exchange support, and Homebrew installation.

- Entry placed in alphabetical order within the Finance section
- Includes Open-Source Software and Freeware badges
- App is MIT licensed and actively maintained