### PR TITLE
Add VoxTap to Voice-to-Text

### DIFF
--- a/README.md
+++ b/README.md
@@ -946,6 +946,7 @@ Any comments, suggestions? [Let us know!](https://github.com/jaywcjlove/awesome-
 * [Spokenly](https://spokenly.app/) - Voice-to-text with 100+ languages, offline mode, and AI-powered formatting.
 * [Tambourine](https://tambourinevoice.com/) - Open-source, customizable AI voice dictation that works in any app. [![Open-Source Software][OSS Icon]](https://github.com/kstonekuan/tambourine-voice/) ![Freeware][Freeware Icon]
 * [VoiceInk](https://tryvoiceink.com/) - Real-time speech-to-text app. [![Open-Source Software][OSS Icon]](https://github.com/Beingpax/VoiceInk) ![Freeware][Freeware Icon]
+* [VoxTap](https://voxtap.app) - On-device voice-to-text for macOS. One hotkey to dictate anywhere. No cloud, no subscription.
 * [Whispering](https://epicenter.md/whispering/) - Multi-provider speech-to-text with AI transformations and keyboard shortcuts. [![Open-Source Software][OSS Icon]](https://github.com/EpicenterHQ/epicenter/tree/main/apps/whispering) ![Freeware][Freeware Icon]
 * [Willow Voice](https://willowvoice.com/) - AI dictation with automatic editing, style-matching, and noise optimization.
 


### PR DESCRIPTION
### Types of Changes
- [X] New addition to list

### Proposed Changes
Adding [VoxTap](https://voxtap.app) to the **Voice-to-Text** section (alphabetically between VoiceInk and Whispering).

VoxTap is a macOS menu bar app for voice-to-text using on-device AI. Key differentiators:
- One hotkey to dictate anywhere (code editors, terminals, browsers)
- Fully on-device — no cloud processing, no data leaves your Mac
- $29 lifetime, no subscription
- macOS 14+

### PR Checklist
- [X] I have read the CONTRIBUTING guide
- [X] I have explained why this PR is important
- [X] I have added necessary documentation (if appropriate)