### PR TITLE
docs: add macbase to Gaming Software

### DIFF
--- a/README.md
+++ b/README.md
@@ -1403,6 +1403,8 @@ Any comments, suggestions? [Let us know!](https://github.com/jaywcjlove/awesome-
 
 ## Gaming Software
 
+* [macbase](https://github.com/joe-ging/macbase) - A free, native macOS chess analysis platform and database, powered by Stockfish and TWIC. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/joe-ging/macbase)
+
 * [OpenEmu](http://openemu.org/) - A great video game console emulator, supports many different emulators in a single application. (e.g. Sony PSP, GameBoy, NDS and so on) [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/OpenEmu/OpenEmu)
 * [PlayCover](https://github.com/PlayCover/PlayCover) - Run iOS apps and games on Apple Silicon Macs with mouse, keyboard and controller support. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/PlayCover/PlayCover)
 * [Porting Kit](http://portingkit.com/) - Install Windows® Games inside your Mac. ![Freeware][Freeware Icon]


### PR DESCRIPTION
Added macbase to the Gaming Software section. macbase is a free, native macOS chess analysis platform and database that provides a local-first alternative to tools like ChessBase.