### PR TITLE
Add PhraseVault to Productivity section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1246,6 +1246,7 @@ Any comments, suggestions? [Let us know!](https://github.com/jaywcjlove/awesome-
 * [OmniPlan](https://www.omnigroup.com/omniplan/) - The best way to visualize, maintain, and simplify your projects. Project Management made easy.
 * [OpenIn](https://loshadki.app/openin4/) - Take control of installed apps on your Mac [![App Store][app-store Icon]](https://apps.apple.com/us/app/openin-4-advanced-link-handler/id1643649331?mt=12)
 * [PaletteBrain](https://palettebrain.com) - Access the power of ChatGPT across all your Mac applications with the press of a shortcut.
+* [PhraseVault](https://phrasevault.app/) - Source-available text expander and snippet manager with fuzzy search, usage-based prioritization, and local-only data storage.
 * [Pie Menu](https://www.pie-menu.com) – Control your tools with a radial menu customized for your active app.
 * [Perplexity](https://apps.apple.com/us/app/perplexity-ask-anything/id6714467650) - Search and discovery with AI.
 * [Pomodoro Cycle](https://github.com/jet8a/pomodoro-cycle-app) - Pomodoro tracker


### PR DESCRIPTION
### Types of Changes

- [x] Adding a new app or link

### Description

Adds [PhraseVault](https://phrasevault.app/) to the Productivity section in alphabetical order (between PaletteBrain and Pie Menu).

PhraseVault is a source-available text expander and snippet manager for macOS with fuzzy search, usage-based prioritization, and local-only data storage.

There is currently no text expander listed in the Productivity section.