### PR TITLE
Add ClaudeUsageBar — Claude.ai usage limits in macOS menu bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -732,6 +732,7 @@ Any comments, suggestions? [Let us know!](https://github.com/jaywcjlove/awesome-
 * [ChatGPT](https://openai.com/chatgpt/mac/) - A conversational AI system that listens, learns, and challenges
 * [Claude](https://claude.ai/download) - Your AI partner on desktop. Fast, focused, and designed for deep work.
 * [ClaudeUsageBar](https://github.com/yagcioglutoprak/ClaudeUsageBar) - See your Claude.ai session and weekly usage limits live in your macOS menu bar. Zero setup, no Electron. [\![Open-Source Software][OSS Icon] \![Freeware][Freeware Icon]](https://github.com/yagcioglutoprak/ClaudeUsageBar)
+* [ClaudeUsageBar](https://github.com/yagcioglutoprak/ClaudeUsageBar) - See your Claude.ai session and weekly usage limits live in your macOS menu bar. Zero setup, no Electron. [\![Open-Source Software][OSS Icon] \![Freeware][Freeware Icon]](https://github.com/yagcioglutoprak/ClaudeUsageBar)
 * [Cherry Studio](https://www.cherry-ai.com/) - A desktop client that supports multiple large language model (LLM) providers. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/CherryHQ/cherry-studio)
 * [Chatbox](https://chatboxai.app) - User-friendly Desktop Client App for AI Models/LLMs (GPT, Claude, Gemini, Ollama...). [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/chatboxai/chatbox)
 * [Fluent](https://fluentmac.app) - Native AI assistant that brings 450+ models (BYOK) into any macOS app with instant app & browser context, customizable actions, shortcuts, and local models support.


### PR DESCRIPTION
Adds [ClaudeUsageBar](https://github.com/yagcioglutoprak/ClaudeUsageBar) to the AI Client section, right after the Claude desktop app entry.

Free, open-source macOS menu bar app showing Claude.ai session (5-hour) and weekly usage limits — useful for Pro/Team subscribers who hit limits unexpectedly.

- Color-coded indicator: green/yellow/red
- macOS notifications at 80% and 95%
- Zero setup — reads local browser cookies, nothing transmitted
- No Electron, ~900 lines Python
- MIT licensed, one-command install