### PR TITLE
Add AIQuotaBar — Claude + ChatGPT usage tracker for macOS menu bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,7 @@ Any comments, suggestions? [Let us know!](https://github.com/jaywcjlove/awesome-
 
 ### Developer Utilities
 
+* [AIQuotaBar](https://github.com/yagcioglutoprak/AIQuotaBar) - See your Claude.ai and ChatGPT usage limits live in your macOS menu bar. [![Open-Source Software][OSS Icon]](https://github.com/yagcioglutoprak/AIQuotaBar) ![Freeware][Freeware Icon]
 * [BetterRename](http://www.publicspace.net/BetterRename/) - The most powerful and complete Mac file renaming application on the market. [![App Store][app-store Icon]](https://apps.apple.com/us/app/better-rename-11/id1501308038)
 * [Beyond Compare](http://www.scootersoftware.com/) - Compare files and folders with powerful commands. ![Freeware][Freeware Icon]
 * [Bidbar](https://www.getbidbar.com) - Manage bash commands from the menu bar and run them with keyboard shortcuts.


### PR DESCRIPTION
AIQuotaBar is a lightweight macOS menu bar app that shows live Claude.ai and ChatGPT usage limits. Zero setup — reads browser cookies automatically from Chrome, Arc, Firefox, Brave. MIT licensed, open source. GitHub: https://github.com/yagcioglutoprak/AIQuotaBar