### PR TITLE
Add OpenBoot - Mac dev environment manager

### DIFF
--- a/command-line-apps.md
+++ b/command-line-apps.md
@@ -137,6 +137,7 @@ A curated list of useful command line apps
 * [ndm](https://720kb.github.io/ndm/) - Manage [npm](http://npmjs.org/) straight from the couch. [![Open-Source Software][OSS Icon]](https://github.com/720kb/ndm) ![Freeware][Freeware Icon]
 * [nushell](https://github.com/nushell/nushell) - nushell is a modern, GitHub-era shell written in Rust. [![Open-Source Software][OSS Icon]](https://sourceforge.net/projects/zsh/) ![Freeware][Freeware Icon]
 * [nvm](https://github.com/nvm-sh/nvm) - POSIX-compliant bash script to manage multiple active node.js versions. [![OSS][OSS Icon]](https://github.com/nvm-sh/nvm) ![Freeware][Freeware Icon]
+* [OpenBoot](https://github.com/openbootdotdev/openboot) - Mac dev environment manager that captures and restores Homebrew packages, casks, dotfiles, shell config, git settings, and macOS preferences. [![Open-Source Software][OSS Icon]](https://github.com/openbootdotdev/openboot) ![Freeware][Freeware Icon]
 * [OpenRecall](https://github.com/openrecall/openrecall) - Access your digital history, enhance memory and productivity, while maintaining privacy. [![OSS][OSS Icon]](https://github.com/openrecall/openrecall) ![Freeware][Freeware Icon]
 highlighting. [![Open-Source Software][OSS Icon]](https://github.com/dbcli/pgcli) ![Freeware][Freeware Icon]
 * [Rebound](https://github.com/shobrook/rebound/) - Instantly browse Stack Overflow results in your terminal when you get a compiler error. ![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]


### PR DESCRIPTION
## OpenBoot

[OpenBoot](https://github.com/openbootdotdev/openboot) is an open-source Mac dev environment manager.

**What it does:**
- Captures your current environment: Homebrew packages/casks/taps, npm globals, shell config, git settings, macOS preferences
- Restores everything with a single command on a new Mac
- Interactive TUI built with Charmbracelet/Bubble Tea
- `.openboot.yml` for per-project dev environment setup
- Web dashboard at openboot.dev for visual config building and team sharing

**Details:**
- MIT licensed, zero telemetry
- Install: `brew install openbootdotdev/tap/openboot`
- GitHub: https://github.com/openbootdotdev/openboot
- 180+ stars