### PR TITLE
Add AFK to Quality of Life Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1346,6 +1346,7 @@ Any comments, suggestions? [Let us know!](https://github.com/jaywcjlove/awesome-
 ### Quality of Life Improvements
 
 * [Actions](https://github.com/sindresorhus/Actions) - Provides many useful actions for the Shortcuts app. [![Open-Source Software][OSS Icon]](https://github.com/sindresorhus/Actions) ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id1586435171)
+* [AFK](https://afk-app.vercel.app) - Lightweight break reminder following the 20-20-20 rule with fullscreen reminders, statistics, and health exercises. [![Open-Source Software][OSS Icon]](https://github.com/Harry-kp/afk) ![Freeware][Freeware Icon]
 * [AI Actions](https://sindresorhus.com/ai-actions) - AI actions for the Shortcuts app. ![Freeware][Freeware Icon]
 * [DisplayBuddy](https://displaybuddy.app) - Control the brightness, contrast, input source and more of your external display directly from your Mac.
 * [f.lux](https://justgetflux.com/) - Makes the color of your computer's display adapt to the time of day. ![Freeware][Freeware Icon]


### PR DESCRIPTION
## Add AFK

[AFK](https://afk-app.vercel.app) is a lightweight, open-source break reminder for macOS built with Tauri + Rust. It follows the 20-20-20 rule to prevent digital eye strain.

**Features:** Fullscreen break reminders, configurable timing, statistics dashboard, global keyboard shortcuts, health exercises, menu bar timer. Under 5 MB.

- [Website](https://afk-app.vercel.app)
- [GitHub](https://github.com/Harry-kp/afk)
- License: MIT
- Category: Utilities > Quality of Life Improvements