### PR TITLE
Add LangSwitcher — keyboard layout text converter

### DIFF
--- a/README-ko.md
+++ b/README-ko.md
@@ -628,6 +628,7 @@ Awesome Mac
 ## 입력기
 
 * [Kawa](https://github.com/utatti/kawa) - OS X용 단축키 기반 입력 소스 전환기. [![Open-Source Software][OSS Icon]](https://github.com/utatti/kawa) ![Freeware][Freeware Icon]
+* [LangSwitcher](https://github.com/reg2005/langSwitcher) - 오픈 소스 키보드 레이아웃 텍스트 변환기. 잘못된 레이아웃으로 입력한 텍스트를 선택하고 ⇧⇧를 누르면 즉시 변환됩니다. EN/RU/DE/FR/ES 지원. [![Open-Source Software][OSS Icon]](https://github.com/reg2005/langSwitcher) ![Freeware][Freeware Icon]
 * [Rocket](https://matthewpalmer.net/rocket/) - Slack 스타일의 단축키를 사용하여 이모지를 더 빠르게 입력. ![Freeware][Freeware Icon]
 
 ## 음성 텍스트 변환 (Voice-to-Text)

--- a/README-zh.md
+++ b/README-zh.md
@@ -837,6 +837,7 @@ Awesome Mac
 
 * [imewlconverter](https://github.com/studyzy/imewlconverter) 深蓝词库转换,一款开源免费的输入法词库转换程序 [![Open-Source Software][OSS Icon]](https://github.com/studyzy/imewlconverter) ![Freeware][Freeware Icon]
 * [fcitx5-macos](https://github.com/fcitx-contrib/fcitx5-macos) - 小企鹅输入法 macOS版本 [![Open-Source Software][OSS Icon]](https://github.com/fcitx-contrib/fcitx5-macos) ![Freeware][Freeware Icon]
+* [LangSwitcher](https://github.com/reg2005/langSwitcher) - 开源键盘布局文字转换工具。选中错误布局输入的文字，按 ⇧⇧ 即刻转换。支持 EN/RU/DE/FR/ES。 [![Open-Source Software][OSS Icon]](https://github.com/reg2005/langSwitcher) ![Freeware][Freeware Icon]
 * [RIME](http://rime.im/) - 中州韻輸入法引擎。[![Open-Source Software][OSS Icon]](https://github.com/rime) ![Freeware][Freeware Icon]
 * [Rocket](http://matthewpalmer.net/rocket/) - 使用冒号快捷键可以更快捷地输入表情符号。![Freeware][Freeware Icon]
 * [Type2Phone](https://www.houdah.com/support/) - 把 Macbook 键盘变为 iPhone 的蓝牙键盘。 [![App Store][app-store Icon]](https://apps.apple.com/cn/app/type2phone-bluetooth-keyboard/id472717129?platform=mac)

--- a/README.md
+++ b/README.md
@@ -932,6 +932,7 @@ Any comments, suggestions? [Let us know!](https://github.com/jaywcjlove/awesome-
 ## Input Methods
 
 * [Kawa](https://github.com/utatti/kawa) - Better input source switcher for OS X. [![Open-Source Software][OSS Icon]](https://github.com/utatti/kawa) ![Freeware][Freeware Icon]
+* [LangSwitcher](https://github.com/reg2005/langSwitcher) - Open-source keyboard layout text converter. Select text typed in wrong layout, press ⇧⇧ and it's instantly converted. Supports EN/RU/DE/FR/ES. [![Open-Source Software][OSS Icon]](https://github.com/reg2005/langSwitcher) ![Freeware][Freeware Icon]
 * [Rocket](http://matthewpalmer.net/rocket/) - Makes typing emoji faster and easier using Slack-style shortcuts. ![Freeware][Freeware Icon]
 * [Touch Emoji](https://github.com/lessmess-dev/touch-emoji) - Emoji picker for MacBook Pro Touch Bar. [![Open-Source Software][OSS Icon]](https://github.com/lessmess-dev/touch-emoji)
 * [Type2Phone](https://www.houdah.com/type2Phone/) - Use Your Mac as Keyboard for iPhone, iPad & Apple TV.


### PR DESCRIPTION
Adding [LangSwitcher](https://github.com/reg2005/langSwitcher) — a free, open-source keyboard layout text converter for macOS.

- Converts text typed in the wrong keyboard layout via hotkey (⇧⇧)
- Smart auto-detection of where wrong layout begins (greedy line detection)
- Pure Swift, zero dependencies, privacy-first (no network, no telemetry)
- MIT licensed
- Supports English, Russian, German, French, Spanish layouts
- Available via Homebrew: `brew tap reg2005/langswitcher && brew install --cask langswitcher`

GitHub: https://github.com/reg2005/langSwitcher

Added to Input Methods section in EN, ZH, and KO READMEs.