### PR TITLE
Add OpenPaw — CLI personal assistant for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1252,6 +1252,7 @@ Any comments, suggestions? [Let us know!](https://github.com/jaywcjlove/awesome-
 * [nnScreenshots](https://www.nearnorthsoftware.com/software/screenshots.php) - A super easy way to keep a visual record of your productivity to make it easier to fill out timesheets or just to help you review the day. Built in timesheet editor.
 * [OmniPlan](https://www.omnigroup.com/omniplan/) - The best way to visualize, maintain, and simplify your projects. Project Management made easy.
 * [OpenIn](https://loshadki.app/openin4/) - Take control of installed apps on your Mac [![App Store][app-store Icon]](https://apps.apple.com/us/app/openin-4-advanced-link-handler/id1643649331?platform=mac)
+* [OpenPaw](https://github.com/daxaur/openpaw) - CLI tool (`npx pawmode`) that turns Claude Code into a personal assistant with 38 skills including email, calendar, Spotify, smart home, and more. [![Open-Source Software][OSS Icon]](https://github.com/daxaur/openpaw) ![Freeware][Freeware Icon]
 * [PaletteBrain](https://palettebrain.com) - Access the power of ChatGPT across all your Mac applications with the press of a shortcut.
 * [Pie Menu](https://www.pie-menu.com) – Control your tools with a radial menu customized for your active app.
 * [Perplexity](https://apps.apple.com/us/app/perplexity-ask-anything/id6714467650?platform=mac) - Search and discovery with AI.


### PR DESCRIPTION
Adding [OpenPaw](https://github.com/daxaur/openpaw) to the Productivity section.

OpenPaw is a CLI tool (run via `npx pawmode`) that turns Claude Code into a full personal assistant on macOS. It comes with 38 built-in skills covering email, calendar, Spotify, smart home control, Slack, GitHub, and more — all from your terminal.

- **Repo:** https://github.com/daxaur/openpaw
- **npm:** https://www.npmjs.com/package/pawmode
- **License:** MIT
- **Platform:** macOS-focused

It fits naturally in the Productivity section alongside tools like Raycast and Hammerspoon that extend what you can do from your Mac without leaving your workflow.