### PR TITLE
Add ClearDisk to System Related Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1373,6 +1373,7 @@ Any comments, suggestions? [Let us know!](https://github.com/jaywcjlove/awesome-
 * [Background Music](https://github.com/kyleneideck/BackgroundMusic) - Control app volumes and record system audio. [![Open-Source Software][OSS Icon]](https://github.com/kyleneideck/BackgroundMusic)
 * [Cleaner One](https://apps.apple.com/app/apple-store/id1133028347?pt=444218&ct=GitHub&mt=8&platform=mac) - Disk cleaning and Mac optimization. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/apple-store/id1133028347?pt=444218&ct=GitHub&mt=8&platform=mac)
 * [Cleaner for Xcode](https://github.com/waylybaye/XcodeCleaner-SwiftUI) - Remove unwanted Xcode files. [![Open-Source Software][OSS Icon]](https://github.com/waylybaye/XcodeCleaner-SwiftUI) ![Freeware][Freeware Icon]
+* [ClearDisk](https://github.com/bysiber/cleardisk) - Visualize and clean developer caches (Xcode, node_modules, CocoaPods, SPM) to reclaim disk space on macOS. [![Open-Source Software][OSS Icon]](https://github.com/bysiber/cleardisk) ![Freeware][Freeware Icon]
 * [coconutBattery](https://www.coconut-flavour.com/coconutbattery/) - Mac battery information and statistics.
 * [DaisyDisk](https://daisydiskapp.com/) - Disk usage analyzer and cleaner.
 * [Dayflow](https://github.com/JerryZLiu/Dayflow) - Screen activity timeline with AI support. [![Open-Source Software][OSS Icon]](https://github.com/JerryZLiu/Dayflow) ![Freeware][Freeware Icon]


### PR DESCRIPTION
## What is ClearDisk?

[ClearDisk](https://github.com/bysiber/cleardisk) is a free, open-source macOS utility that helps developers reclaim disk space by scanning and cleaning development-related caches.

### Features
- Scans Xcode DerivedData, node_modules, CocoaPods, and Swift Package Manager caches
- Visual breakdown of disk usage by cache type
- One-click cleanup with size preview
- Built natively with Swift 5.9+ and SwiftUI
- Requires macOS 14 (Sonoma) or later

### Why it belongs in System Related Tools
ClearDisk fits alongside tools like Cleaner for Xcode and DaisyDisk as it helps developers manage and reclaim disk space occupied by development caches. Unlike general-purpose cleaners, it specifically targets developer tool caches that can silently consume tens of gigabytes.

### Checklist
- [x] Open-source (MIT License)
- [x] Free to use
- [x] macOS native application
- [x] Added in alphabetical order
- [x] Follows the existing format with OSS and Freeware icons
