### PR TITLE
Add VPN Bypass to Proxy and VPN Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1051,6 +1051,7 @@ Any comments, suggestions? [Let us know!](https://github.com/jaywcjlove/awesome-
 * [tinc](https://www.tinc-vpn.org) - Secure mesh VPN software. [![Open-Source Software][OSS Icon]](https://www.tinc-vpn.org/git/browse?p=tinc) ![Freeware][Freeware Icon]
 * [Tunnelbear](https://www.tunnelbear.com) - Really simple VPN to browse the web privately & securely. Unblock websites around the world with applications for Mac, PC, iOS, Android & Chrome.
 * [Tunnelblick](https://tunnelblick.net/downloads.html) - Free, open-source graphic user interface for OpenVPN on OS X. ![Freeware][Freeware Icon]
+* [VPN Bypass](https://github.com/GeiserX/VPN-Bypass) - Menu bar app to route specific domains and services around your VPN. [![Open-Source Software][OSS Icon]](https://github.com/GeiserX/VPN-Bypass) ![Freeware][Freeware Icon]
 * [Windscribe](https://windscribe.com) - Gives 10GB free bandwidth monthly on the spot and gives limited server location options (for users on free plan). Connection also takes very less time.
 * [Tailscale](https://tailscale.com/) - Tailscale makes creating software-defined networks easy: securely connecting users, services, and devices.
 


### PR DESCRIPTION
## What is VPN Bypass?

[VPN Bypass](https://github.com/GeiserX/VPN-Bypass) is a free, open-source (GPL-3.0) macOS menu bar app that routes specific domains and services around your VPN, ensuring they use your regular internet connection. It supports GlobalProtect, Cisco AnyConnect, Fortinet, Zscaler, WireGuard, and more.

Installable via Homebrew: `brew install --cask vpn-bypass`

### Checklist

- [x] I have read the [CONTRIBUTING guide](https://github.com/jaywcjlove/awesome-mac/blob/master/CONTRIBUTING.md)
- [x] I have searched for duplicates
- [x] Open-source (GPL-3.0 License)
- [x] Free to use
- [x] Native macOS application (Swift/SwiftUI, macOS 13.0+)
- [x] Entry added in alphabetical order in the Proxy and VPN Tools section
- [x] Follows the existing format with OSS and Freeware icons
- [x] Description ends with a full stop