### PR TITLE
Add OpenTypeless to Voice-to-Text section

### DIFF
--- a/README.md
+++ b/README.md
@@ -946,6 +946,7 @@ Any comments, suggestions? [Let us know!](https://github.com/jaywcjlove/awesome-
 
 * [Aiko](https://sindresorhus.com/aiko) - High-quality on-device transcription. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id1666327168?platform=mac)
 * [buzz](https://github.com/chidiwilliams/buzz) - Transcribes and translates audio offline on your personal computer. Powered by OpenAI's Whisper. [![Open-Source Software][OSS Icon]](https://github.com/chidiwilliams/buzz)
+* [OpenTypeless](https://github.com/tover0314-w/opentypeless) - Open-source AI voice input for desktop. Press a hotkey, speak, and get AI-polished text typed into any app. Supports 6+ STT providers (Whisper, Groq, Deepgram) and multiple LLMs (GPT, Claude, Gemini, Ollama). [![Open-Source Software][OSS Icon]](https://github.com/tover0314-w/opentypeless) ![Freeware][Freeware Icon]
 * [Ottex](https://ottex.ai) - Dictate emails, Slack messages, notes and more. Detects your app or website and formats accordingly — gmail.com → email, Obsidian → markdown, etc.
 * [Spokenly](https://spokenly.app/) - Voice-to-text with 100+ languages, offline mode, and AI-powered formatting.
 * [Tambourine](https://tambourinevoice.com/) - Open-source, customizable AI voice dictation that works in any app. [![Open-Source Software][OSS Icon]](https://github.com/kstonekuan/tambourine-voice/) ![Freeware][Freeware Icon]


### PR DESCRIPTION
- App name: OpenTypeless
- Category: Voice-to-Text
- License: MIT
- Platform: macOS / Windows / Linux
- GitHub: https://github.com/tover0314-w/opentypeless

OpenTypeless is an open-source AI voice input tool. Press a global hotkey, speak naturally, and get AI-polished text typed directly into any focused app — no copy-paste required.

Supports 6+ STT providers (Whisper, Groq, Deepgram, AssemblyAI, GLM-ASR, SiliconFlow) and multiple LLMs (GPT, Claude, Gemini, Ollama). Fully BYOK, local API key storage.