### PR TITLE
Add Mac Taskbar to menu bar tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1091,6 +1091,7 @@ Any comments, suggestions? [Let us know!](https://github.com/jaywcjlove/awesome-
 
 * [Anvil](https://anvilformac.com/) - Anvil is a beautiful menubar app for managing local websites. Serve up static sites and Rack apps with simple URLs and zero configuration. ![Freeware][Freeware Icon]
 * [Bartender](https://www.macbartender.com) - Organize or hide menu bar icons on your Mac.
+* [Mac Taskbar](https://www.mac-taskbar.com/) - Menu bar utility that provides a taskbar-style overview of open windows and running apps on macOS.
 * [SaneBar](https://sanebar.com) - Privacy-first menu bar manager with Touch ID lock, Always-Hidden Zone, and 7 automation triggers. Open-source alternative to Bartender. [![Open-Source Software][OSS Icon]](https://github.com/sane-apps/SaneBar)
 * [Sharptooth](https://apps.apple.com/app/sharptooth-bluetooth-hotkeys/id6748440814?platform=mac) - Effortlessly manage your Bluetooth devices right from the menu bar with custom hotkeys and smart automation.
 * [BeardedSpice](https://github.com/beardedspice/beardedspice) - Allows you to control web based media players (SoundCloud, YouTube, etc) and some native apps with the media keys on Mac keyboards.  [![Open-Source Software][OSS Icon]](https://github.com/beardedspice/beardedspice) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Added Mac Taskbar to the Menu Bar Tools section.

### Types of Changes
- [x] New addition to list

### Proposed Changes
- Add Mac Taskbar, a macOS menu bar utility that provides a taskbar-style overview of open windows and running apps, to Menu Bar Tools.

### PR Checklist
- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important