### PR TITLE
Add ScreenTranslate to Translation Tools

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -897,6 +897,7 @@ Awesome Mac
 * [MoePeek](https://github.com/cosZone/MoePeek) - 轻量级翻译工具，支持划词翻译、OCR 截图翻译、剪贴板翻译和手动输入翻译。 [![Open-Source Software][OSS Icon]](https://github.com/cosZone/MoePeek)
 * [Nani](https://nani.now) - 快速AI翻译，附带清晰解释。
 * [OpenAI Translator](https://github.com/yetone/openai-translator) - 基于 ChatGPT API 的划词翻译浏览器插件和跨平台桌面端应用。[![Open-Source Software][OSS Icon]](https://github.com/yetone/openai-translator)
+* [ScreenTranslate](https://screentranslate.filient.ai/) - 屏幕任意区域截取或选择文本即时翻译，完全在设备上运行。 [![Open-Source Software][OSS Icon]](https://github.com/hcmhcs/screenTranslate) ![Freeware][Freeware Icon]
 * [Translate Tab](http://translate-tab.com/) - 菜单栏翻译插件，封装了谷歌翻译，支持自动识别语言。
 * [Translatium](https://translatium.app) - 在 100 多种语言之间翻译单词、短语和图像，并提供字典、音译和语音输出支持。 [![Open-Source Software][OSS Icon]](https://github.com/webcatalog/translatium-desktop) [![App Store][app-store Icon]](https://apps.apple.com/us/app/translatium/id1547052291?platform=mac)
 * [辞海词典](http://cidian.dict.cn/mac.html) - 学单词、背单词、辞海词典。![Freeware][Freeware Icon]

--- a/README.md
+++ b/README.md
@@ -997,6 +997,7 @@ Any comments, suggestions? [Let us know!](https://github.com/jaywcjlove/awesome-
 * [MoePeek](https://github.com/cosZone/MoePeek) - Lightweight translation tool with instant selection translation, OCR screenshot translation, clipboard translation, and manual input translation. [![Open-Source Software][OSS Icon]](https://github.com/cosZone/MoePeek)
 * [Nani](https://nani.now) - Fast AI translation with explanations.
 * [OpenAI Translator](https://github.com/yetone/openai-translator) - Browser extension and cross-platform desktop application for translation based on ChatGPT API.[![Open-Source Software][OSS Icon]](https://github.com/yetone/openai-translator)
+* [ScreenTranslate](https://screentranslate.filient.ai/) - Capture any area or select text to translate instantly, fully on-device. [![Open-Source Software][OSS Icon]](https://github.com/hcmhcs/screenTranslate) ![Freeware][Freeware Icon]
 * [Translatium](https://translatium.app) - Translate words, phrases and images between over 100 languages with dictionary, transliteration and voice output support. [![Open-Source Software][OSS Icon]](https://github.com/webcatalog/translatium-desktop) [![App Store][app-store Icon]](https://apps.apple.com/us/app/translatium/id1547052291?platform=mac)
 
 ## Education


### PR DESCRIPTION
## What is ScreenTranslate?

[ScreenTranslate](https://screentranslate.filient.ai/) is a free, open-source macOS menu bar app that translates any text on your screen instantly.

### Features
- Two translation modes: screen capture (OCR + translate) and text selection (no OCR needed)
- Fully on-device via Apple Vision + Apple Translation — no servers, no tracking
- 20 languages with auto-detect
- Works offline after downloading language packs
- Optional cloud engines (DeepL, Google Cloud, Azure) with your own API key
- Built natively with Swift 6 and SwiftUI
- Requires macOS 15 (Sequoia) or later

### Why it belongs in Translation Tools
ScreenTranslate fits alongside tools like Easydict and MoePeek as a native macOS translation utility. It uniquely offers both screen capture OCR translation and direct text selection translation, all processed entirely on-device.

GitHub: https://github.com/hcmhcs/screenTranslate

### Checklist
- [x] I have read the [CONTRIBUTING guide](https://github.com/jaywcjlove/awesome-mac/blob/master/CONTRIBUTING.md)
- [x] I have searched for duplicates
- [x] Open-source (GPL-3.0 License)
- [x] Free to use
- [x] Native macOS application
- [x] Added in alphabetical order in the Translation Tools section
- [x] Follows the existing format with OSS and Freeware icons
- [x] Updated both README.md and README-zh.md