### PR TITLE
Add MiniClaw — self-hosted personal AI OS for Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -747,6 +747,7 @@ Any comments, suggestions? [Let us know!](https://github.com/jaywcjlove/awesome-
 * [Runtime](https://github.com/runtime-org/runtime) - AI taskmate and take control of the web & your office tools
 * [Jan](https://jan.ai/) - An open-source alternative to ChatGPT that runs entirely offline on your computer. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/menloresearch/jan)
 * [Maestro](https://runmaestro.ai) - Run multiple AI coding agents in parallel with a spec-driven workflow. [![Open-Source Software][OSS Icon]](https://github.com/pedramamini/Maestro)
+* [MiniClaw](https://miniclaw.bot) - Self-hosted personal AI agent OS for Mac — persistent personality, memory, plugins, cron automation, email, and a kanban project board. Built on OpenClaw. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/augmentedmike/miniclaw-os)
 * [Witsy](https://github.com/nbonamy/witsy) - desktop AI assistant / universal MCP client. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/nbonamy/witsy)
 * [remio](https://www.remio.ai/?utm_source=github_list) - A personal ChatGPT that ​​responds based on your knowledge​​. Lastest LLMs, Local first, and BYOK supported.  [![Freeware][Freeware Icon]](https://www.remio.ai/?utm_source=github_list)
 * [Warden](https://karatsidhu.gumroad.com/l/warden) - A Native Swift macOS app that lets you run multiple LLM models using your own API keys. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/SidhuK/WardenApp)


### PR DESCRIPTION
## Adding MiniClaw to the AI Client section

[MiniClaw](https://miniclaw.bot) ([GitHub](https://github.com/augmentedmike/miniclaw-os)) is an open-source, self-hosted personal AI agent OS that runs on a Mac mini.

Unlike typical AI chat clients, MiniClaw is a complete personal AI infrastructure:
- Persistent personality and long-term memory (it remembers context between sessions)
- Plugin ecosystem: kanban project board, email client, SEO rank tracker, cron automation, image designer
- Runs as an always-on daemon via launchd on macOS
- Connects to Telegram, Discord, and other messaging channels
- Fully self-hosted — all data stays on your own hardware
- Open source, MIT license, free to use

**Links:**
- Website: https://miniclaw.bot
- GitHub: https://github.com/augmentedmike/miniclaw-os

Placed it in the AI Client section after Maestro.