### PR TITLE
Add HeyRobyn - native macOS unified inbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -797,6 +797,7 @@ Any comments, suggestions? [Let us know!](https://github.com/jaywcjlove/awesome-
 * [CanaryMail](https://canarymail.io/) - Secure email app for Mac and iPhone with built-in PGP Support and AI assistance. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/us/app/canary-mail-email-meet-ai/id1236045954?platform=mac)
 * [ElectronMail](https://github.com/vladimiry/ElectronMail) - An Electron-based unofficial desktop client for ProtonMail. [![Open-Source Software][OSS Icon]](https://github.com/vladimiry/ElectronMail) ![Freeware][Freeware Icon]
 * [Foxmail](http://www.foxmail.com/mac/en) - Fast email client. ![Freeware][Freeware Icon]
+* [HeyRobyn](https://heyrobyn.ai) - Native macOS unified inbox for email, Slack, and GitHub notifications. ![Freeware][Freeware Icon]
 * [MailTags](https://smallcubed.com/) - Use tags to organize email and schedule.
 * [Mailspring](https://getmailspring.com/) - A beautiful, fast, and fully open source mail client. [![Open-Source Software][OSS Icon]](https://github.com/Foundry376/Mailspring) ![Freeware][Freeware Icon]
 * [N1](https://www.nylas.com/) - Extensible, open-source mail app, free for developers and $7/month for Pro. ![Open-Source Software][OSS Icon]


### PR DESCRIPTION
## What is HeyRobyn?

HeyRobyn is a native macOS application that unifies email, Slack messages, and GitHub notifications in one clean inbox.

## Key Features
- **Native macOS app** built with SwiftUI (not Electron)
- **Unified inbox** for email, Slack, and GitHub
- **Privacy-first** - all data stays on-device
- **Free** during beta

## Why add to awesome-mac?
HeyRobyn fits perfectly in the Email Clients section as it provides a unified communication hub for macOS users who want to manage multiple channels without tab-switching.

Website: https://heyrobyn.ai

Thank you for considering this addition!