### PR TITLE
Add HeyRobyn - Native Mac unified inbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -798,6 +798,7 @@ Any comments, suggestions? [Let us know!](https://github.com/jaywcjlove/awesome-
 * [CanaryMail](https://canarymail.io/) - Secure email app for Mac and iPhone with built-in PGP Support and AI assistance. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/us/app/canary-mail-email-meet-ai/id1236045954?platform=mac)
 * [ElectronMail](https://github.com/vladimiry/ElectronMail) - An Electron-based unofficial desktop client for ProtonMail. [![Open-Source Software][OSS Icon]](https://github.com/vladimiry/ElectronMail) ![Freeware][Freeware Icon]
 * [Foxmail](http://www.foxmail.com/mac/en) - Fast email client. ![Freeware][Freeware Icon]
+* [HeyRobyn](https://heyrobyn.ai) - Native Mac unified inbox for email, Slack, and GitHub. Privacy-first, all data on-device.
 * [MailTags](https://smallcubed.com/) - Use tags to organize email and schedule.
 * [Mailspring](https://getmailspring.com/) - A beautiful, fast, and fully open source mail client. [![Open-Source Software][OSS Icon]](https://github.com/Foundry376/Mailspring) ![Freeware][Freeware Icon]
 * [N1](https://www.nylas.com/) - Extensible, open-source mail app, free for developers and $7/month for Pro. ![Open-Source Software][OSS Icon]


### PR DESCRIPTION
### New Submission

**App Name:** HeyRobyn
**Category:** Email Clients
**Description:** Native Mac unified inbox for email, Slack, and GitHub. Privacy-first, all data on-device.
**Website:** https://heyrobyn.ai

This app is a native SwiftUI Mac application (not Electron-based) that provides a unified inbox experience for managing email, Slack messages, and GitHub notifications in one place. It follows the contribution guidelines by:

- Being added alphabetically within the Email Clients category
- Using the proper format: [HeyRobyn](https://heyrobyn.ai)
- Providing a concise, descriptive one-line description
- Not being a duplicate (searched previous submissions)

Thank you for maintaining this awesome list!