### PR TITLE
docs: add ClashX Guide to Chinese README

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -938,6 +938,7 @@ Awesome Mac
 * [Algo](https://github.com/trailofbits/algo) - 在云中设置个人 IPSEC VPN。[![Open-Source Software][OSS Icon]](https://github.com/trailofbits/algo)
 * [Clash Nyanpasu](https://github.com/LibNyanpasu/clash-nyanpasu) - 基于 Tauri 的 Clash GUI 自由软件。[![Open-Source Software][OSS Icon]](https://github.com/LibNyanpasu/clash-nyanpasu)![Freeware][Freeware Icon]
 * [Clash-verge-rev](https://github.com/clash-verge-rev/clash-verge-rev) - Clash Verge 的延续，基于 Tauri 的 Clash Meta GUI。[![Open-Source Software][OSS Icon]](https://github.com/clash-verge-rev/clash-verge-rev)![Freeware][Freeware Icon]
+* [ClashX 使用指南](https://clashx.tech) - ClashX 完整中文教程，包含配置指南、故障排除和性能优化。![Freeware][Freeware Icon]
 * [FlClash](https://github.com/chen08209/FlClash) - 拥有 MD3 风格且基于 Clash Meta 的客户端。[![Open-Source Software][OSS Icon]](https://github.com/chen08209/FlClash)![Freeware][Freeware Icon]
 * [Hiddify](https://github.com/hiddify/hiddify-app) - 基于 Sing-box 的多平台代理客户端。[![Open-Source Software][OSS Icon]](https://github.com/hiddify/hiddify-app) ![Freeware][Freeware Icon]
 * [Lantern](https://getlantern.org) - 科学上网。[![Open-Source Software][OSS Icon]](https://github.com/getlantern/lantern)![Freeware][Freeware Icon]


### PR DESCRIPTION
The English README already includes the ClashX Guide entry ([clashx.tech](https://clashx.tech)). This PR adds the corresponding entry to the Chinese README (`README-zh.md`) for consistency.

The entry is placed alphabetically in the proxy tools section, between Clash-verge-rev and FlClash.

**Added line:**
```
* [ClashX 使用指南](https://clashx.tech) - ClashX 完整中文教程，包含配置指南、故障排除和性能优化。![Freeware][Freeware Icon]
```