### PR TITLE
Add HeyRobyn - Native Mac unified inbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -799,6 +799,7 @@ Any comments, suggestions? [Let us know!](https://github.com/jaywcjlove/awesome-
 * [CanaryMail](https://canarymail.io/) - Secure email app for Mac and iPhone with built-in PGP Support and AI assistance. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/us/app/canary-mail-email-meet-ai/id1236045954?platform=mac)
 * [ElectronMail](https://github.com/vladimiry/ElectronMail) - An Electron-based unofficial desktop client for ProtonMail. [![Open-Source Software][OSS Icon]](https://github.com/vladimiry/ElectronMail) ![Freeware][Freeware Icon]
 * [Foxmail](http://www.foxmail.com/mac/en) - Fast email client. ![Freeware][Freeware Icon]
+* [HeyRobyn](https://heyrobyn.ai) - Native Mac unified inbox for email, Slack, and GitHub. Built with SwiftUI, all data stays on-device. ![Freeware][Freeware Icon]
 * [MailTags](https://smallcubed.com/) - Use tags to organize email and schedule.
 * [Mailspring](https://getmailspring.com/) - A beautiful, fast, and fully open source mail client. [![Open-Source Software][OSS Icon]](https://github.com/Foundry376/Mailspring) ![Freeware][Freeware Icon]
 * [N1](https://www.nylas.com/) - Extensible, open-source mail app, free for developers and $7/month for Pro. ![Open-Source Software][OSS Icon]


### PR DESCRIPTION
## Added Application

**Name:** HeyRobyn  
**Website:** https://heyrobyn.ai  
**Category:** Email Clients (Communication section)

## Description

HeyRobyn is a native macOS application built with SwiftUI that provides a unified inbox for email, Slack, and GitHub notifications. All data processing happens on-device for privacy.

## Why it belongs in awesome-mac

- **Native Mac app**: Built specifically for macOS using SwiftUI (not Electron)
- **Productivity-focused**: Combines email, Slack, and GitHub in one unified interface
- **Privacy-first**: All data stays on-device with on-device processing
- **Free to use**: Freemium model

## Checklist

- [x] Application is available for macOS
- [x] Added to appropriate category (Email Clients)
- [x] Follows existing formatting
- [x] Alphabetically ordered within section
- [x] Includes correct icon tags (Freeware)

Looking forward to your feedback! 🙏

🤖 Generated with [Claude Code](https://claude.com/claude-code)