### PR TITLE
Add TokenMeter to Menu Bar Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1152,6 +1152,7 @@ Any comments, suggestions? [Let us know!](https://github.com/jaywcjlove/awesome-
 * [TextSniper](https://textsniper.app/) - Simple yet powerful OCR app in your Menu Bar. Instantly copy and paste text from anywhere. [![App Store][app-store Icon]](https://apps.apple.com/app/id1528890965?platform=mac)
 * [Today](https://sindresorhus.com/today) - View today’s schedule right from the menu bar. The perfect companion to the built-in Calendar app. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id6443714928?platform=mac)
 * [TomatoBar](https://github.com/ivoronin/TomatoBar) - World's neatest Pomodoro timer for macOS menu bar. [![Open-Source Software][OSS Icon]](https://github.com/ivoronin/TomatoBar) ![Freeware][Freeware Icon]
+* [TokenMeter](https://priyans-hu.github.io/tokenmeter/) - Native SwiftUI menu bar app to track Claude Code usage, rate limits, costs, and activity heatmaps. [![Open-Source Software][OSS Icon]](https://github.com/Priyans-hu/tokenmeter) ![Freeware][Freeware Icon]
 * [UTC Time](https://sindresorhus.com/utc-time) - Show the time in UTC in the menu bar or a widget. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id1538245904?platform=mac)
 * [Vanilla](https://matthewpalmer.net/vanilla/) - Hide menu bar icons on your Mac. ![Freeware][Freeware Icon]
 * [Week Number](https://sindresorhus.com/week-number) - The current week number in your menu bar. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id6502579523?platform=mac)


### PR DESCRIPTION
## Add TokenMeter

[TokenMeter](https://github.com/Priyans-hu/tokenmeter) is a native SwiftUI macOS menu bar app for tracking Claude Code usage, rate limits, costs, and activity heatmaps.

**Why it's awesome:**
- Native SwiftUI — no Electron/Tauri, lightweight and fast
- Real-time rate limit monitoring via Anthropic API
- Usage heatmaps, daily cost charts, and model breakdown donut charts
- Plan auto-detection from macOS Keychain
- Free and open source, installable via Homebrew

**Placement:** Menu Bar Tools, alphabetically between TomatoBar and UTC Time.