### PR TITLE
Add clipsync to Clipboard Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1083,6 +1083,7 @@ Any comments, suggestions? [Let us know!](https://github.com/jaywcjlove/awesome-
 * [CleanClip](https://cleanclip.cc) - The cleanest Clipboard Manager on macOS, ever! ![Freeware][Freeware Icon]
 * [Clipboard](https://getclipboard.app/) - Easy-to-use terminal clipboard manager for all platforms. [![Open-Source Software][OSS Icon]](https://github.com/Slackadays/Clipboard) ![Freeware][Freeware Icon]
 * [ClipMenu](http://www.clipmenu.com) - Clipboard manager for Mac OS X. [![Open-Source Software][OSS Icon]](https://github.com/naotaka/ClipMenu) ![Freeware][Freeware Icon]
+* [clipsync](https://github.com/evoleinik/clipsync) - Clipboard sync over TCP — text and images between machines. Built for Tailscale. [![Open-Source Software][OSS Icon]](https://github.com/evoleinik/clipsync) ![Freeware][Freeware Icon]
 * [ClipTools](https://macmost.com/cliptools) - ClipTools is a status menu application that gives you access to a variety of simple clipboard utilities. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/us/app/cliptools/id1619348240?platform=mac)
 * [Clipy](https://clipy-app.com/) - Clipy is a Clipboard extension app for macOS. Based on ClipMenu. [![Open-Source Software][OSS Icon]](https://github.com/Clipy/Clipy) ![Freeware][Freeware Icon]
 * [CopyQ](https://hluk.github.io/CopyQ) - Clipboard Manager with Advanced Features. [![Open-Source Software][OSS Icon]](https://github.com/hluk/CopyQ) ![Freeware][Freeware Icon]


### PR DESCRIPTION
### Types of Changes

- [x] New addition to list

### Proposed Changes

[clipsync](https://github.com/evoleinik/clipsync) is a clipboard sync tool that copies text and images between machines over TCP. It's a single Go binary with zero dependencies, designed to work with Tailscale's stable hostnames for seamless clipboard sharing across devices.

It fits in the Clipboard Tools section because it extends clipboard functionality across machines — complementing the existing clipboard managers that work locally.

### PR Checklist

- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important
- [x] I have added necessary documentation (if appropriate)