### PR TITLE
Add Promptzy — native macOS AI prompt manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1304,6 +1304,7 @@ Any comments, suggestions? [Let us know!](https://github.com/jaywcjlove/awesome-
 * [Pie Menu](https://www.pie-menu.com) – Control your tools with a radial menu customized for your active app.
 * [Perplexity](https://apps.apple.com/us/app/perplexity-ask-anything/id6714467650?platform=mac) - Search and discovery with AI.
 * [Pomodoro Cycle](https://github.com/jet8a/pomodoro-cycle-app) - Pomodoro tracker
+* [Promptzy](https://promptzy.app) - Native macOS AI prompt manager. Press Cmd+Shift+P to search and paste any saved prompt into ChatGPT, Claude, or any app. Prompts stored as plain Markdown. Supports {{clipboard}} and {{date}} tokens. Free + $5 one-time Pro.
 * [Qbserve](https://qotoqot.com/qbserve/) - Time tracking automation: freelance project tracking, timesheets, invoicing & real-time productivity feedback.
 * [Raycast](https://raycast.com?via=ae02) - Raycast lets you control your tools and apps with shortcuts, download extensions from the store, and use AI models like ChatGPT, DeepSeek, Gemini, Claude, etc. You can also create snippets and use Raycast Notes to maximize your productivity.
 * [Rustcast](https://rustcast.app) - Workflow launcher for modes, quick app access, file search, clipboard history, and more. [![Open-Source Software][OSS Icon]](https://github.com/unsecretised/rustcast) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Promptzy is a native macOS app that gives you a Cmd+Shift+P launcher for your AI prompt library. Prompts are stored as plain Markdown files, it supports dynamic tokens like `{{clipboard}}` and `{{date}}`, and pastes directly into any app in under 2 seconds.

https://promptzy.app

Added alphabetically to the Productivity section between Pomodoro Cycle and Qbserve.