### PR TITLE
Add Azex Speech to Voice-to-Text section

### DIFF
--- a/README.md
+++ b/README.md
@@ -969,6 +969,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 ## Voice-to-Text
 
 * [Aiko](https://sindresorhus.com/aiko) - High-quality on-device transcription. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id1666327168?platform=mac)
+* [Azex Speech](https://github.com/azex-ai/speech) - Mac native voice input for Crypto & AI professionals. Local ASR (FireRedASR), 1800+ domain terms, pronunciation training. [![Open-Source Software][OSS Icon]](https://github.com/azex-ai/speech) ![Freeware][Freeware Icon]
 * [buzz](https://github.com/chidiwilliams/buzz) - Transcribes and translates audio offline on your personal computer. Powered by OpenAI's Whisper. [![Open-Source Software][OSS Icon]](https://github.com/chidiwilliams/buzz)
 * [FnKey](https://github.com/evoleinik/fnkey) - Hold Fn, speak, release — text is pasted instantly. Streams audio to Deepgram Nova-3 in real time, no batch delay. [![Open-Source Software][OSS Icon]](https://github.com/evoleinik/fnkey) ![Freeware][Freeware Icon]
 * [OpenTypeless](https://github.com/tover0314-w/opentypeless) - Open-source AI voice input for desktop. Press a hotkey, speak, and get AI-polished text typed into any app. Supports 6+ STT providers (Whisper, Groq, Deepgram) and multiple LLMs (GPT, Claude, Gemini, Ollama). [![Open-Source Software][OSS Icon]](https://github.com/tover0314-w/opentypeless) ![Freeware][Freeware Icon]


### PR DESCRIPTION
## Summary

- Adds [Azex Speech](https://github.com/azex-ai/speech) to the **Voice-to-Text** section, in alphabetical order (between Aiko and buzz)

## About the App

- **Mac native** menu bar app (Swift/SwiftUI, macOS 14+)
- **Local ASR** via sherpa-onnx FireRedASR — no cloud dependency for core transcription
- **1800+ domain vocabulary** covering Crypto and AI terminology (e.g. DeFi, zkSNARK, LLM, RAG)
- **Pronunciation training** — flashcard-based calibration flow for domain terms
- Global hotkey, editable floating panel, implicit learning from user corrections
- Open source (MIT) and free

## Checklist

- [x] Entry is in alphabetical order within the section
- [x] Follows existing format (OSS Icon + Freeware Icon badges)
- [x] Link goes to the GitHub repository
- [x] Description is concise and accurate