### PR TITLE
Add RightLayout to Input Methods section

### DIFF
--- a/README.md
+++ b/README.md
@@ -965,6 +965,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 
 * [Kawa](https://github.com/utatti/kawa) - Better input source switcher for OS X. [![Open-Source Software][OSS Icon]](https://github.com/utatti/kawa) ![Freeware][Freeware Icon]
 * [LangSwitcher](https://github.com/reg2005/langSwitcher) - Open-source keyboard layout text converter. Select text typed in wrong layout, press ⇧⇧ and it's instantly converted. Supports EN/RU/DE/FR/ES. [![Open-Source Software][OSS Icon]](https://github.com/reg2005/langSwitcher) ![Freeware][Freeware Icon]
+* [RightLayout](https://alexchernysh.com/rightlayout) - AI keyboard layout fixer — auto-corrects wrong layout (EN/RU/HE) as you type. Local CoreML, no cloud. ![Freeware][Freeware Icon]
 * [Rocket](http://matthewpalmer.net/rocket/) - Makes typing emoji faster and easier using Slack-style shortcuts. ![Freeware][Freeware Icon]
 * [Touch Emoji](https://github.com/lessmess-dev/touch-emoji) - Emoji picker for MacBook Pro Touch Bar. [![Open-Source Software][OSS Icon]](https://github.com/lessmess-dev/touch-emoji)
 * [Type2Phone](https://www.houdah.com/type2Phone/) - Use Your Mac as Keyboard for iPhone, iPad & Apple TV.


### PR DESCRIPTION
### Types of Changes

**What types of changes does your PR introduce?** Put an x in all boxes that apply

- [x] New addition to list
- [ ] Fixing bug in existing item in list
- [ ] Removing item from list
- [ ] Changing structure (organization) of list

### Proposed Changes

**Describe each of your changes here to communicate to the maintainers why we should accept this pull request.**

1. Adding [RightLayout](https://alexchernysh.com/rightlayout) to the **Input Methods** section.
2. RightLayout is a macOS utility that automatically detects and corrects wrong keyboard layout as you type. It supports English, Russian, and Hebrew, runs entirely on-device using CoreML (no cloud/API calls), and is free.

### PR Checklist

Put an x in the boxes once you've completed each step.

- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important
- [x] I have added necessary documentation (if appropriate)

### Further Comments

RightLayout fits naturally in the Input Methods section alongside similar tools like LangSwitcher and InputSourcePro. It differentiates itself by fixing layout in real time as you type (rather than after selection), using on-device AI inference with no internet dependency.