### PR TITLE
Add RightLayout to Input Methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -965,6 +965,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 
 * [Kawa](https://github.com/utatti/kawa) - Better input source switcher for OS X. [![Open-Source Software][OSS Icon]](https://github.com/utatti/kawa) ![Freeware][Freeware Icon]
 * [LangSwitcher](https://github.com/reg2005/langSwitcher) - Open-source keyboard layout text converter. Select text typed in wrong layout, press ⇧⇧ and it's instantly converted. Supports EN/RU/DE/FR/ES. [![Open-Source Software][OSS Icon]](https://github.com/reg2005/langSwitcher) ![Freeware][Freeware Icon]
+* [RightLayout](https://alexchernysh.com/rightlayout) - AI keyboard layout fixer — auto-corrects wrong layout (EN/RU/HE) as you type. Local CoreML, no cloud. ![Freeware][Freeware Icon]
 * [Rocket](http://matthewpalmer.net/rocket/) - Makes typing emoji faster and easier using Slack-style shortcuts. ![Freeware][Freeware Icon]
 * [Touch Emoji](https://github.com/lessmess-dev/touch-emoji) - Emoji picker for MacBook Pro Touch Bar. [![Open-Source Software][OSS Icon]](https://github.com/lessmess-dev/touch-emoji)
 * [Type2Phone](https://www.houdah.com/type2Phone/) - Use Your Mac as Keyboard for iPhone, iPad & Apple TV.


### PR DESCRIPTION
## What is RightLayout?

[RightLayout](https://alexchernysh.com/rightlayout) is an AI keyboard layout fixer for macOS — it auto-corrects wrong keyboard layout (EN/RU/HE) as you type. It runs locally using CoreML with no cloud dependency.

## Checklist

- [x] App is specific to macOS
- [x] Added in alphabetical order within the Input Methods section
- [x] Follows the existing entry format