### PR TITLE
Add markdown-quicklook to QuickLook Plugins

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -1275,6 +1275,7 @@ Awesome Mac
 
 * [QuicklookStephen](https://github.com/whomwah/qlstephen) - 可以让您查看没有文件扩展名的纯文本文件，如 README、INSTALL、Capfile、CHANGELOG...`brew install --cask install qlstephen`
 * [FluxMarkdown](https://github.com/xykong/flux-markdown) - 在 Finder 中即时预览 Markdown，支持 Mermaid、KaTeX、GFM、目录和图表。 [![Open-Source Software][OSS Icon]](https://github.com/xykong/flux-markdown) ![Freeware][Freeware Icon]
+* [markdown-quicklook](https://github.com/ruspg/markdown-quicklook) - 渲染 Markdown 预览，支持语法高亮、YAML front matter、可配置字体/颜色，以及菜单栏切换开关。一键安装。 [![Open-Source Software][OSS Icon]](https://github.com/ruspg/markdown-quicklook) ![Freeware][Freeware Icon]
 * [Torrent Preview](https://github.com/sveinbjornpalsson/torrentpreview/) - 在 Finder 中快速预览 `.torrent` 内容，直接查看文件列表、Tracker 和元数据。 [![Open-Source Software][OSS Icon]](https://github.com/sveinbjornpalsson/torrentpreview/)
 
 ## 第三方应用市场APP

--- a/README.md
+++ b/README.md
@@ -1496,6 +1496,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 
 * [QLMarkdown](https://github.com/sbarex/QLMarkdown) - Quick Look extension for Markdown files. - ![Freeware][Freeware Icon] ![Open-Source Software][OSS Icon]
 * [FluxMarkdown](https://github.com/xykong/flux-markdown) - Quick Look extension for instant Markdown previews in Finder with Mermaid, KaTeX, GFM, TOC, and charts. [![Open-Source Software][OSS Icon]](https://github.com/xykong/flux-markdown) ![Freeware][Freeware Icon]
+* [markdown-quicklook](https://github.com/ruspg/markdown-quicklook) - Rendered Markdown preview with syntax highlighting, YAML front matter, configurable fonts/colors, and a menu bar toggle to switch between rendered and plain text modes. Build-from-source, one-command install. [![Open-Source Software][OSS Icon]](https://github.com/ruspg/markdown-quicklook) ![Freeware][Freeware Icon]
 * [Torrent Preview](https://github.com/sveinbjornpalsson/torrentpreview/) - Quick Look extension for previewing `.torrent` contents in Finder, including files, trackers, and metadata. [![Open-Source Software][OSS Icon]](https://github.com/sveinbjornpalsson/torrentpreview/)
 * [quick-look-plugins](https://github.com/sindresorhus/quick-look-plugins) - List of useful [Quick Look](https://en.wikipedia.org/wiki/Quick_Look) plugins for developers
 * [Syntax Highlight](https://github.com/sbarex/SourceCodeSyntaxHighlight) - Quick Look extension for highlight source code files. - ![Freeware][Freeware Icon] ![Open-Source Software][OSS Icon]


### PR DESCRIPTION
Adds [markdown-quicklook](https://github.com/ruspg/markdown-quicklook) to the QuickLook Plugins section.

A build-from-source Quick Look extension for Markdown files with:
- Rendered preview with syntax highlighting
- YAML front matter support
- Configurable fonts and colors
- Menu bar toggle to switch between rendered/plain text modes
- One-command install (`./build.sh`)
- macOS 13+ App Extension (not legacy `.qlgenerator`)

Based on [smittytone/PreviewMarkdown](https://github.com/smittytone/PreviewMarkdown).

Updated both README.md and README-zh.md.