### PR TITLE
Add Dimly - Multi-monitor brightness control

### DIFF
--- a/README.md
+++ b/README.md
@@ -1141,6 +1141,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [DayBar](https://wangchujiang.com/daybar/) - An application that can display the local date and reminder events in the menu bar. [![App Store][app-store Icon]](https://apps.apple.com/app/daybar/6739052447?platform=mac)
 * [Droppy](https://iordv.github.io/Droppy/) - Turns your screen's notch (or Dynamic Island) into a multifunctional tool. [![Open-Source Software][OSS Icon]](https://github.com/iordv/Droppy) ![Freeware][Freeware Icon]
 * [Dato](https://sindresorhus.com/dato) - A better menu bar clock with calendar, events, and time zones. [![App Store][app-store Icon]](https://apps.apple.com/us/app/dato/id1470584107?platform=mac)
+* [Dimly](https://github.com/punshnut/macos-dimly) - Control brightness across mixed monitor setups from a single menu bar app. [![Open-Source Software][OSS Icon]](https://github.com/punshnut/macos-dimly) ![Freeware][Freeware Icon]
 * [Dozer](https://github.com/Mortennn/Dozer) - Hide MacOS menubar items. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/Mortennn/Dozer)
 * [DynamicHorizon](https://dynamichorizon.app) - Enhances the notch with seamless media controls, airdrop, notifications, system indicators and lock screen widgets.
 * [Eye Timer](https://adelmaer.com/eyetimer) - Take Breaks to prevent Eye Strain timer for Mac. [![App Store][app-store Icon]](https://apps.apple.com/us/app/eye-timer/id1485856873?platform=mac)


### PR DESCRIPTION
**Why does this belong on the list?**

Dimly solves a common macOS pain point: controlling brightness uniformly across 
mixed monitor setups - for example a MacBook display combined with one or more 
external monitors that don't support native brightness control via macOS.

Most existing solutions are either paid (e.g. MonitorControl Pro) or lack 
support for mixed/multi-display setups. Dimly fills this gap as a polished, 
fully free and open-source menu bar utility.

- Free & open-source  
- Supports mixed monitor setups (built-in + external)
- Menu bar native - no dock icon clutter
- No telemetry, no upsells
- Stable, feature-complete release

Fits well under the **Utilities / Menu Bar** section.

Link: https://github.com/Punshnut/macos-dimly