### PR TITLE
Add Command Reopen to Window Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1356,6 +1356,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Assignee](https://assignee.app) - Simple, instant app switcher. [![App Store][app-store Icon]](https://apps.apple.com/app/apple-store/id1491598904?pt=120234215&ct=awesome-mac&mt=8&platform=mac)
 * [Convoker](https://github.com/varie-ai/convoker) - Type an app name, press Enter, all its windows come to you. [![Open-Source Software][OSS Icon]](https://github.com/varie-ai/convoker) ![Freeware][Freeware Icon]
 * [contexts](https://contexts.co/) - Provides more power than the native Mac Dock. Especially when you have multiple screens, it can help you switch more quickly.
+* [Command Reopen](https://commandreopen.com) - Fix Cmd+Tab for minimized and closed windows on macOS. Auto-restore windows with zero permissions. [![Open-Source Software][OSS Icon]](https://github.com/fchen6611/command-reopen) ![Freeware][Freeware Icon]
 * [DockDoor](https://dockdoor.net) - Free and open source window peeking & alt-tab for macOS. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/ejbills/DockDoor)
 * [Dockit](https://dockit-docs.pages.dev) - An application that can dock any window to the edge of the screen. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/XiCheng148/Dockit)
 * [Dissolv](https://www.7sols.com/dissolv/) - Hide and close inactive apps. [![App Store][app-store Icon]](https://apps.apple.com/app/dissolv/id1640893012?platform=mac)


### PR DESCRIPTION
## Project URL
https://commandreopen.com

## Category
Window Management

## Description
Command Reopen fixes the broken Cmd+Tab workflow on macOS:
- Auto-restore minimized windows on every Cmd+Tab switch
- Zero permissions — no Accessibility, no Screen Recording required  
- Works behind native Cmd+Tab
- Under 2 MB
- Open source

Perfect for power users who want to fix Cmd+Tab behavior without heavy window managers.

## Checklist
- [x] I have read the CONTRIBUTING.md
- [x] Only one project/change is in this PR
- [x] Project has a clear README in English
- [x] Project has recent commits (active development)