### PR TITLE
Add ShipClip to Screen Recording section

### DIFF
--- a/README.md
+++ b/README.md
@@ -717,6 +717,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [ScreenSage Pro](https://screensage.pro/) - A screen recording tool for creating polished videos in minutes.
 * [Screenize](https://syi0808.github.io/screenize/) - Open-source screen recorder with auto-zoom, cursor effects, and timeline editing. [![Open-Source Software][OSS Icon]](https://github.com/syi0808/screenize) ![Freeware][Freeware Icon]
 * [Screenpipe](https://github.com/mediar-ai/screenpipe) - Local screen and microphone recorder with AI search. [![Open-Source Software][OSS Icon]](https://github.com/mediar-ai/screenpipe) ![Freeware][Freeware Icon]
+* [ShipClip](https://shipclip.app/) - Native macOS screen recorder with automatic zoom-to-click, multi-track audio, camera PiP with background removal, and shareable links.
 * [Snagit](https://www.techsmith.com/screen-capture.html) - Screen Capture and Recording Software. Simple and Powerful.
 * [Tight Studio](https://tight.studio/) - Screen recorder with smart zoom, captions, and AI voiceovers.
 * [Zappy](https://zapier.com/zappy) - Zappy is a screenshot and screen recording app all in one. Has some simple editing tools built in.


### PR DESCRIPTION
### Types of Changes

- [x] New addition to list
- [ ] Fixing bug in existing item in list
- [ ] Removing item from list
- [ ] Changing structure (organization) of list

### Proposed Changes

1. Adding ShipClip to the Screen Recording section. It is a native macOS screen recorder built with ScreenCaptureKit and a Metal rendering pipeline that offers automatic zoom-to-click effects, multi-track audio editing, camera PiP with real-time background removal, and shareable links with viewer analytics. Under 5 MB, no Electron.

### PR Checklist

- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important
- [x] I have added necessary documentation (if appropriate)