### PR TITLE
Add Tome to Voice-to-Text

### DIFF
--- a/README.md
+++ b/README.md
@@ -986,6 +986,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Ottex](https://ottex.ai) - Dictate emails, Slack messages, notes and more. Detects your app or website and formats accordingly — gmail.com → email, Obsidian → markdown, etc.
 * [Spokenly](https://spokenly.app/) - Voice-to-text with 100+ languages, offline mode, and AI-powered formatting.
 * [Tambourine](https://tambourinevoice.com/) - Open-source, customizable AI voice dictation that works in any app. [![Open-Source Software][OSS Icon]](https://github.com/kstonekuan/tambourine-voice/) ![Freeware][Freeware Icon]
+* [Tome](https://github.com/Gremble-io/Tome) - Local meeting transcription for macOS that outputs structured markdown to your Obsidian vault. Powered by Parakeet-TDT on Apple Silicon. [![Open-Source Software][OSS Icon]](https://github.com/Gremble-io/Tome) ![Freeware][Freeware Icon]
 * [TypeWhisper](https://www.typewhisper.com) - Local speech-to-text transcription using Whisper AI. System-wide dictation with global hotkey. [![Open-Source Software][OSS Icon]](https://github.com/TypeWhisper/typewhisper-mac) ![Freeware][Freeware Icon]
 * [VoiceInk](https://tryvoiceink.com/) - Real-time speech-to-text app. [![Open-Source Software][OSS Icon]](https://github.com/Beingpax/VoiceInk) ![Freeware][Freeware Icon]
 * [Whispering](https://epicenter.md/whispering/) - Multi-provider speech-to-text with AI transformations and keyboard shortcuts. [![Open-Source Software][OSS Icon]](https://github.com/EpicenterHQ/epicenter/tree/main/apps/whispering) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Tome is a free, open-source macOS app for local meeting transcription. It captures meetings and voice memos, transcribes them on-device using Parakeet-TDT v3, and outputs structured markdown with YAML frontmatter directly to your Obsidian vault.