### PR TITLE
Add swipic

### DIFF
--- a/README.md
+++ b/README.md
@@ -718,6 +718,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Amazing AI](https://sindresorhus.com/amazing-ai) - Generate images from text using Stable Diffusion. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id1660147028?platform=mac)
 * [APNGb](https://github.com/mancunianetz/APNGb) - PNG image assembler/disassembler app. [![Open-Source Software][OSS Icon]](https://github.com/mancunianetz/APNGb) ![Freeware][Freeware Icon]
 * [Aspect](https://aspect.bildhuus.com) - Photo organization app with peer-to-peer sync. ![Freeware][Freeware Icon]
+* [swipic](https://github.com/javipd/swipic) - Tinder-style photo cleaner for macOS Photos.app. Swipe to keep or delete with arrow keys. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/javipd/swipic)
 * [Assetizr](https://assetizr.com) - Resizing images and optimising them for web and mobile applications.  ![Freeware][Freeware Icon]
 * [Couleurs](http://couleursapp.com) - Simple app for grabbing and tweaking the colors you see on your screen. ![Freeware][Freeware Icon]
 * [Diffusion Bee](https://diffusionbee.com/) - The easiest way to generate AI art on your computer with Stable Diffusion. [![Open-Source Software][OSS Icon]](https://github.com/divamgupta/diffusionbee-stable-diffusion-ui/) ![Freeware][Freeware Icon]


### PR DESCRIPTION
[swipic](https://github.com/javipd/swipic) — Tinder-style photo cleaner for macOS Photos.app.

Swipe through your Photos.app library with arrow keys to keep or delete photos. Supports RAW formats, shows edited versions, batch delete with single macOS confirmation.

- Open source (MIT)
- Install: `pipx install swipic`
- PyPI: https://pypi.org/project/swipic/