### PR TITLE
Add Shake It On to Menu Bar Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1187,6 +1187,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Reminders MenuBar](https://github.com/DamascenoRafael/reminders-menubar/) -  Simple macOS menu bar app to view and interact with reminders. [![Open-Source Software][OSS Icon]](https://github.com/DamascenoRafael/reminders-menubar/) ![Freeware][Freeware Icon]
 * [RewriteBar](https://rewritebar.com/) - A macOS menu bar app that helps you write your text with the assistance of AI.
 * [Second Clock](https://sindresorhus.com/second-clock) - Show a second clock for a different time zone in your menu bar. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id6450279539?platform=mac)
+* [Shake It On](https://shakeiton.app?ref=awesome-mac) - Keep your Mac awake with organic mouse movement and smart conditions. Menu bar app with intelligent triggers for CPU, apps, Wi-Fi, display, and more.
 * [Thaw](https://github.com/stonerl/Thaw) - A powerful menu bar management tool for hiding and showing menu bar items. [![Open-Source Software][OSS Icon]](https://github.com/stonerl/Thaw)
 * [SketchyBar](https://github.com/FelixKratz/SketchyBar) - A highly customizable macOS status bar replacement. [![Open-Source Software][OSS Icon]](https://github.com/FelixKratz/SketchyBar) ![Freeware][Freeware Icon]
 * [Spaced](https://sindresorhus.com/spaced) - Organize your menu bar items into groups. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id1666327168?platform=mac)


### PR DESCRIPTION
## What

Adding [Shake It On](https://shakeiton.app) to the Menu Bar Tools section.

## About Shake It On

Shake It On is a macOS menu bar app that keeps your Mac awake by generating organic mouse movement to reset the system idle timer.

**Key features:**
- Smart activation conditions: CPU usage, running apps, Wi-Fi network, external display, audio playing
- Smart pause triggers: battery mode, camera in use, Focus/DND active, screen locked
- Works with corporate MDM-managed Macs and remote desktop sessions
- Keeps Slack/Teams showing active status
- $9.99 one-time purchase, no subscription
- macOS 14 Sonoma or later

**Website:** https://shakeiton.app