### PR TITLE
Add Silkwave Voice to Voice-to-Text section

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -992,6 +992,7 @@ Awesome Mac
 * [OpenDictation](https://github.com/kdcokenny/OpenDictation) - ローカルとクラウドの音声テキスト変換に対応したオープンソースのディクテーションツール。 [![Open-Source Software][OSS Icon]](https://github.com/kdcokenny/OpenDictation) ![Freeware][Freeware Icon]
 * [OpenTypeless](https://github.com/tover0314-w/opentypeless) - 整形済みテキストを任意のアプリに入力できるオープンソースのAI音声入力ツール。 [![Open-Source Software][OSS Icon]](https://github.com/tover0314-w/opentypeless) ![Freeware][Freeware Icon]
 * [Ottex](https://ottex.ai) - 使用中のアプリやサイトに合わせて整形するAIディクテーションツール。
+* [Silkwave Voice](https://www.silkwave.ai/silkwave-voice) - macOS 26+向けAIノートテイカー＆文字起こしアプリ。オンデバイスAppleモデルで10以上の言語を録音・文字起こしし、Apple Intelligence経由でChatGPTによる要約を生成。 [![App Store][app-store Icon]](https://apps.apple.com/us/app/silkwave-voice-ai-note-taker/id6758550154)
 * [Spokenly](https://spokenly.app/) - 100以上の言語、オフラインモード、AI搭載のフォーマットを備えた音声テキスト変換。
 * [Tambourine](https://tambourinevoice.com/) - あらゆるアプリで動作するオープンソースのカスタマイズ可能なAI音声ディクテーション。 [![Open-Source Software][OSS Icon]](https://github.com/kstonekuan/tambourine-voice/) ![Freeware][Freeware Icon]
 * [TypeWhisper](https://www.typewhisper.com) - Whisperベースのローカル音声テキスト変換ツール。 [![Open-Source Software][OSS Icon]](https://github.com/TypeWhisper/typewhisper-mac) ![Freeware][Freeware Icon]

--- a/README-ko.md
+++ b/README-ko.md
@@ -747,6 +747,7 @@ Awesome Mac
 * [FnKey](https://github.com/evoleinik/fnkey) - 누르고 말한 뒤 놓으면 전사 텍스트를 바로 붙여넣는 음성 입력 도구. [![Open-Source Software][OSS Icon]](https://github.com/evoleinik/fnkey) ![Freeware][Freeware Icon]
 * [OpenDictation](https://github.com/kdcokenny/OpenDictation) - 로컬 및 클라우드 음성 텍스트 변환을 지원하는 오픈 소스 받아쓰기 도구. [![Open-Source Software][OSS Icon]](https://github.com/kdcokenny/OpenDictation) ![Freeware][Freeware Icon]
 * [OpenTypeless](https://github.com/tover0314-w/opentypeless) - 다듬어진 텍스트를 어떤 앱에든 입력할 수 있는 오픈 소스 AI 음성 입력 도구. [![Open-Source Software][OSS Icon]](https://github.com/tover0314-w/opentypeless) ![Freeware][Freeware Icon]
+* [Silkwave Voice](https://www.silkwave.ai/silkwave-voice) - macOS 26+용 AI 노트 테이커 및 전사 앱. 온디바이스 Apple 모델로 10개 이상 언어를 녹음·전사하고, Apple Intelligence를 통해 ChatGPT 기반 요약을 생성. [![App Store][app-store Icon]](https://apps.apple.com/us/app/silkwave-voice-ai-note-taker/id6758550154)
 * [Whispering](https://epicenter.md/whispering/) - AI 변환 및 키보드 단축키를 지원하는 음성 텍스트 변환 도구. [![Open-Source Software][OSS Icon]](https://github.com/EpicenterHQ/epicenter) ![Freeware][Freeware Icon]
 
 ## 브라우저

--- a/README-zh.md
+++ b/README-zh.md
@@ -671,6 +671,7 @@ Awesome Mac
 * [FnKey](https://github.com/evoleinik/fnkey) - 按住说话、松开即粘贴转写文本的语音输入工具。 [![Open-Source Software][OSS Icon]](https://github.com/evoleinik/fnkey) ![Freeware][Freeware Icon]
 * [OpenDictation](https://github.com/kdcokenny/OpenDictation) - 支持本地与云端语音转文字的开源听写工具。 [![Open-Source Software][OSS Icon]](https://github.com/kdcokenny/OpenDictation) ![Freeware][Freeware Icon]
 * [OpenTypeless](https://github.com/tover0314-w/opentypeless) - 开源 AI 语音输入工具，可将润色后的文本输入到任意应用。 [![Open-Source Software][OSS Icon]](https://github.com/tover0314-w/opentypeless) ![Freeware][Freeware Icon]
+* [Silkwave Voice](https://www.silkwave.ai/silkwave-voice) - macOS 26+ AI 笔记与转录应用。使用设备端 Apple 模型录音并转录 10+ 种语言，通过 Apple Intelligence 生成 ChatGPT 驱动的摘要。 [![App Store][app-store Icon]](https://apps.apple.com/us/app/silkwave-voice-ai-note-taker/id6758550154)
 * [Audio Profile Manager](https://apps.apple.com/us/app/audio-profile-manager/id1484150558?ls=1&platform=mac) - 用于保存输入和输出设备配置的音频管理工具。 [![App Store][app-store Icon]](https://apps.apple.com/us/app/audio-profile-manager/id1484150558?ls=1&platform=mac)
 * [Ardour](http://ardour.org/) - 录制，编辑和混合多轨音频。[![Open-Source Software][OSS Icon]](https://github.com/Ardour/ardour)
 * [Audacity](http://www.audacityteam.org/) - 免费开源的编辑音频的软件。[![Open-Source Software][OSS Icon]](https://github.com/audacity/audacity)

--- a/README.md
+++ b/README.md
@@ -993,6 +993,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [OpenDictation](https://github.com/kdcokenny/OpenDictation) - Open-source dictation utility with local and cloud speech-to-text. [![Open-Source Software][OSS Icon]](https://github.com/kdcokenny/OpenDictation) ![Freeware][Freeware Icon]
 * [OpenTypeless](https://github.com/tover0314-w/opentypeless) - Open-source AI voice input that types polished text into any app. [![Open-Source Software][OSS Icon]](https://github.com/tover0314-w/opentypeless) ![Freeware][Freeware Icon]
 * [Ottex](https://ottex.ai) - AI dictation tool that formats text for the app or site you are using.
+* [Silkwave Voice](https://www.silkwave.ai/silkwave-voice) - AI note taker and transcription app for macOS 26+. Record and transcribe in 10+ languages using on-device Apple models, and get ChatGPT-powered summaries via Apple Intelligence. [![App Store][app-store Icon]](https://apps.apple.com/us/app/silkwave-voice-ai-note-taker/id6758550154)
 * [Spokenly](https://spokenly.app/) - Voice-to-text with 100+ languages, offline mode, and AI-powered formatting.
 * [Tambourine](https://tambourinevoice.com/) - Open-source, customizable AI voice dictation that works in any app. [![Open-Source Software][OSS Icon]](https://github.com/kstonekuan/tambourine-voice/) ![Freeware][Freeware Icon]
 * [TypeWhisper](https://www.typewhisper.com) - Local Whisper-based speech-to-text with a global hotkey. [![Open-Source Software][OSS Icon]](https://github.com/TypeWhisper/typewhisper-mac) ![Freeware][Freeware Icon]


### PR DESCRIPTION
NOTE: A similar PR may already be submitted! Please search among the Pull request before creating one.

### Types of Changes

**What types of changes does your PR introduce?** Put an x in all boxes that apply

- [x] New addition to list
- [ ] Fixing bug in existing item in list
- [ ] Removing item from list
- [ ] Changing structure (organization) of list

### Proposed Changes

**Describe each of your changes here to communicate to the maintainers why we should accept this pull request.**

1. Adding [Silkwave Voice](https://www.silkwave.ai/silkwave-voice) to the **Voice-to-Text** section. Silkwave Voice is an AI note taker and transcription app for macOS 26+. It records meetings, lectures, and podcasts with system audio and mic capture, transcribes in 10+ languages using on-device Apple models, and generates ChatGPT-powered summaries via Apple Intelligence. Available on the [Mac App Store](https://apps.apple.com/us/app/silkwave-voice-ai-note-taker/id6758550154).

### PR Checklist

Put an x in the boxes once you've completed each step. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important
- [x] I have added necessary documentation (if appropriate)

### Further Comments

Entry is alphabetically placed in the Voice-to-Text section (after Ottex, before Spokenly) and includes the App Store badge. All four README versions have been updated (English, Chinese, Japanese, Korean).
