### PR TITLE
Add Verby to Voice-to-Text section

### DIFF
--- a/README.md
+++ b/README.md
@@ -997,6 +997,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Spokenly](https://spokenly.app/) - Voice-to-text with 100+ languages, offline mode, and AI-powered formatting.
 * [Tambourine](https://tambourinevoice.com/) - Open-source, customizable AI voice dictation that works in any app. [![Open-Source Software][OSS Icon]](https://github.com/kstonekuan/tambourine-voice/) ![Freeware][Freeware Icon]
 * [TypeWhisper](https://www.typewhisper.com) - Local Whisper-based speech-to-text with a global hotkey. [![Open-Source Software][OSS Icon]](https://github.com/TypeWhisper/typewhisper-mac) ![Freeware][Freeware Icon]
+* [Verby](https://verbyai.com) - AI voice dictation that injects polished emails, prompts, and clean text at your cursor in any app. ![Freeware][Freeware Icon]
 * [VoiceInk](https://tryvoiceink.com/) - Real-time speech-to-text app. [![Open-Source Software][OSS Icon]](https://github.com/Beingpax/VoiceInk) ![Freeware][Freeware Icon]
 * [Whispering](https://epicenter.md/whispering/) - Multi-provider speech-to-text with AI transformations and keyboard shortcuts. [![Open-Source Software][OSS Icon]](https://github.com/EpicenterHQ/epicenter/tree/main/apps/whispering) ![Freeware][Freeware Icon]
 * [Willow Voice](https://willowvoice.com/) - AI dictation with automatic editing, style-matching, and noise optimization.


### PR DESCRIPTION
## What is Verby?

[Verby](https://verbyai.com) is a free AI voice dictation app for macOS and Windows that goes beyond transcription — it converts speech into polished emails, structured AI prompts, and clean text, injected instantly at your cursor in any application.

**Key differentiator:** Instead of producing raw transcripts, Verby uses AI to transform casual speech into formatted, professional output (emails with subject lines, structured ChatGPT prompts, grammar-corrected paragraphs).

- **Platforms:** macOS 13+ (Apple Silicon & Intel), Windows 10/11
- **Pricing:** Free (20 dictations/day), Pro $9/mo
- **Developer:** Syntrix LLC

## Changes

- Added Verby to the Voice-to-Text section in alphabetical order
- Included Freeware badge (free tier available)