### PR TITLE
Add SnapHotkey to Window Management section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1349,6 +1349,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Selectric](https://selectric.io/) - Private search across email, documents, and chat apps.
 * [SensibleSideButtons](http://sensible-side-buttons.archagon.net) - Make mouse side buttons work for back and forward in more apps. [![Open-Source Software][OSS Icon]](https://github.com/archagon/sensible-side-buttons)
 * [skhd](https://github.com/koekeishiya/skhd) - Simple hotkey daemon for macOS. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/koekeishiya/skhd)
+* [SnapHotkey](https://snaphotkey.com) - Assign a keyboard shortcut directly to each app — press once to switch instantly, no Cmd+Tab cycling. Distinguishes Left vs Right modifier keys for double the shortcut space.
 * [Strategr](https://khrykin.github.io/strategr/) - Time-boxing planner for structuring your day. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/khrykin/StrategrDesktop)
 * [SwiftBiu](https://swiftbiu.com/) - Text productivity tool with a customizable action bar and AI extensions. [![App Store][app-store Icon]](https://apps.apple.com/cn/app/swiftbiu/id6754772331?platform=mac)
 * [Table Habit](https://github.com/FriesI23/mhabit) – Habit tracker with growth charts and offline-first sync. ![Open-Source Software][OSS Icon] [![App Store][app-store Icon]](https://apps.apple.com/us/app/table-habit/id6744886469?platform=mac)


### PR DESCRIPTION
## Summary

- Adds [SnapHotkey](https://snaphotkey.com) to the Window Management section in alphabetical order
- SnapHotkey is a macOS app that lets users assign keyboard shortcuts to specific apps for instant switching, with left/right modifier key distinction and show/hide toggle

## About SnapHotkey

SnapHotkey allows Mac users to configure shortcut-to-app mappings for direct app access without cycling through Cmd+Tab. Key features include left/right modifier key distinction, show/hide toggle, and same-app multi-window cycling.

Website: https://snaphotkey.com