### PR TITLE
Add Capso - free open-source screenshot & screen recording for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -683,6 +683,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 
 ### Screenshot Tools
 
+* [Capso](https://github.com/lzhgus/Capso) - Free, open-source screenshot and screen recording for macOS. Area/window/fullscreen capture, MP4 & GIF recording, webcam PiP, OCR, annotations, and screenshot beautification. [![Open-Source Software][OSS Icon]](https://github.com/lzhgus/Capso) ![Freeware][Freeware Icon]
 * [CleanShot X](https://cleanshot.com/) - Discover a superior way to capture your Mac's screen.
 * [CloudApp](https://www.getcloudapp.com/) - Work at the speed of sight. ![Freeware][Freeware Icon]
 * [Dropbox](https://www.dropbox.com/) - Dropbox app offers easy screenshot capturing and sharing ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adding Capso to the Screenshot Tools section.

Capso is a free, open-source screenshot and screen recording app for macOS, built in native Swift (no Electron).

Features:
- Area / Window / Fullscreen screenshot capture
- MP4 & GIF screen recording with webcam Picture-in-Picture
- Full annotation editor
- Screenshot beautification (gradient backgrounds, shadows)
- OCR text recognition
- No subscription, no paywall, forever free

GitHub: https://github.com/lzhgus/Capso
License: Business Source License 1.1