### PR TITLE
Add md-preview to Markdown Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [LightPaper](https://getlightpaper.com/) - Simple, beautiful, yet powerful text editor for your Mac.
 * [Marked 2](http://marked2app.com/) - This is the Markdown preview with an elegant and powerful set of tools for all writers.
 * [MarkText](https://github.com/marktext/marktext) - Next generation markdown editor, running on platforms of MacOS Windows and Linux. [![Open-Source Software][OSS Icon]](https://github.com/marktext/marktext) ![Freeware][Freeware Icon]
+* [md-preview](https://github.com/vorojar/md-preview) - Ultra-lightweight Markdown preview app (~1MB binary) built with Rust, with offline syntax highlighting, dark mode, and cross-platform support. [![Open-Source Software][OSS Icon]](https://github.com/vorojar/md-preview) ![Freeware][Freeware Icon]
 * [Marp](https://marp.app) - Markdown presentation writer with cross-platform support. [![Open-Source Software][OSS Icon]](https://github.com/marp-team/marp) ![Freeware][Freeware Icon]
 * [Marxico](https://marxi.co/) - Delicate Markdown editor for Evernote. Reliable storage and sync.
 * [MWeb](http://www.mweb.im/) - Pro Markdown writing, and static blog generator App.


### PR DESCRIPTION
## Summary

- Add [MD Preview](https://github.com/vorojar/md-preview) to the **Markdown Tools** section.
- MD Preview is a small native Markdown preview app built with Rust + system WebView, with live reload, offline syntax highlighting, KaTeX, Mermaid, dark mode, and cross-platform releases.

Current release assets are about 4.5 MB for macOS DMG, 1.8 MB for Windows ZIP, and 2.4 MB for Linux tar.gz. The project avoids Electron/Chromium bundling and uses the system WebView instead.

Project site: https://vorojar.github.io/md-preview/