### PR TITLE
Adding Notepad++ for macOS to the Text Editors section — the first native port of the Notepad++ code editor to macOS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,8 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [LiteEdit](https://arietan.github.io/lite-edit/) - Fast, native macOS code editor under 1 MB — Swift and AppKit, no Electron. [![Open-Source Software][OSS Icon]](https://github.com/arietan/lite-edit) ![Freeware][Freeware Icon]
 * [MacVim](https://github.com/macvim-dev/macvim) - the text editor Vim - for macOS. [![Open-Source Software][OSS Icon]](https://github.com/macvim-dev/macvim) ![Freeware][Freeware Icon]
 * [micro](https://micro-editor.github.io) - Modern and intuitive terminal-based text editor. [![Open-Source Software][OSS Icon]](https://github.com/ory/editor) ![Freeware][Freeware Icon]
+* [Notepad++ for macOS](https://notepad-plus-plus-mac.org) - Native macOS port of the Notepad++ code editor. No Wine, no emulation; runs on Apple Silicon and Intel Macs. [![Open-Source Software][OSS
+  Icon]](https://github.com/notepad-plus-plus-mac/notepad-plus-plus-macos) ![Freeware][Freeware Icon]
 * [Neovim](https://github.com/neovim/neovim) - Vim-fork focused on extensibility and usability. [![Open-Source Software][OSS Icon]](https://github.com/neovim/neovim) ![Freeware][Freeware Icon]
 * [Nova](https://nova.app/) - The beautiful, fast, flexible, native Mac code editor from Panic.
 * [Plain Text Editor](https://sindresorhus.com/plain-text-editor) - Simple distraction-free notepad. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id1572202501?platform=mac)


### PR DESCRIPTION
- Website: https://notepad-plus-plus-mac.org
  - Source: https://github.com/notepad-plus-plus-mac/notepad-plus-plus-macos
  - License: GPL-3.0
  - Runs natively on Apple Silicon and Intel Macs
  - Apple-notarized

  No Wine or compatibility layers — it's the real Notepad++ codebase ported to Mac.

  Thanks for maintaining this list!