### PR TITLE
Add CATAI to AI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -767,6 +767,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Apple On-Device OpenAI](https://github.com/gety-ai/apple-on-device-openai) - Runs Apple on-device models behind an OpenAI-compatible API. [![Open-Source Software][OSS Icon]](https://github.com/gety-ai/apple-on-device-openai) ![Freeware][Freeware Icon]
 * [Atomic Chat](https://github.com/AtomicBot-ai/Atomic-Chat) - Open-source AI chat client for local and cloud models with MCP support. [![Open-Source Software][OSS Icon]](https://github.com/AtomicBot-ai/Atomic-Chat)
 * [BoltAI](https://boltai.com) - A beautiful & powerful ChatGPT app for Mac. Stay ahead by integrating AI into your workflow today.
+* [CATAI](https://github.com/wil-pe/CATAI) - Pixel art desktop pet cats that walk on your dock and debate ideas together via local Ollama LLMs. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/wil-pe/CATAI) ![Native App][Native Icon]
 * [ChatGPT](https://openai.com/chatgpt/mac/) - A conversational AI system that listens, learns, and challenges
 * [Claude](https://claude.ai/download) - Your AI partner on desktop. Fast, focused, and designed for deep work.
 * [Claude God](https://claudegod.app) - Monitor Claude usage, costs, and session stats. [![Open-Source Software][OSS Icon]](https://github.com/Lcharvol/Claude-God) ![Freeware][Freeware Icon]


### PR DESCRIPTION
## Adds [CATAI](https://github.com/wil-pe/CATAI) to AI Tools

A native macOS Swift app: pixel art cats that live on your dock and debate ideas with you using local Ollama LLMs.

- 🐱 Multi-cat desktop pet (up to 7 cats with distinct personalities)
- 🎤 **Cat Debate mode** — cats brainstorm any topic together using a moderator-synthesis pipeline
- 💬 Streaming chat per cat
- 🪟 Walks on dock and perches on active windows
- ⚙️ Single Swift file, zero dependencies, MIT licensed

### Checklist
- [x] New entry added to **AI Tools** section
- [x] Alphabetical position respected (between BoltAI and ChatGPT)
- [x] Format matches surrounding entries (Open-Source + Freeware + Native App badges)
- [x] Project is open source and actively maintained