### PR TITLE
Add GitSquid to Git clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,6 +514,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Gitfox](https://www.gitfox.app) - Commit faster, improve your code quality with superior diffs - and look good doing it. [![App Store][app-store Icon]](https://apps.apple.com/app/gitfox/id1475511261?platform=mac)
 * [GitHub Desktop](https://desktop.github.com/) - The official GitHub GUI. [![Freeware][Freeware Icon] ![Open-Source Software][OSS Icon]](https://github.com/desktop/desktop)
 * [GitKraken](https://www.gitkraken.com/) - The most popular Git GUI for Windows, Mac and Linux.
+* [GitSquid](https://gitsquid.dev/) - Cross-platform Git GUI with visual commit graph, per-line staging and 10 languages. ![Freeware][Freeware Icon]
 * [GitUp](http://gitup.co/) - A simple & powerful Git client。[![Open-Source Software][OSS Icon]](https://github.com/git-up/GitUp) ![Freeware][Freeware Icon]
 * [GitX-dev](https://rowanj.github.io/gitx/) -  Fork of [Pieter's](https://github.com/pieter/gitx) nice git GUI for OS X. Includes branch/tag sidebar and various fixes. [![Open-Source Software][OSS Icon]](https://github.com/rowanj/gitx) ![Freeware][Freeware Icon]
 * [Hub](https://hub.github.com/) - Command-line wrapper for Git that makes you better at GitHub. [![Open-Source Software][OSS Icon]](https://github.com/github/hub) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds [GitSquid](https://gitsquid.dev/) to the Git clients section.

GitSquid is a cross-platform Git GUI client (macOS, Windows, Linux) built with Tauri + Rust. It offers a visual commit graph, per-line/per-hunk staging, and UI translations in 10 languages. A free tier is available; Pro at €49/year.

Alphabetical placement between GitKraken and GitUp.