### PR TITLE
Add WobblePic to Other Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -759,6 +759,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [PicGo](https://github.com/Molunerfinn/PicGo) - Support for common cdn image hosting tool.  [![Open-Source Software][OSS Icon]](https://github.com/Molunerfinn/PicGo)
 * [AppIconBuilder](https://apps.apple.com/app/shotbuilder/id1294179975?platform=mac) - Export icons for multi-platform[![App Store][app-store Icon]](https://apps.apple.com/app/shotbuilder/id1294179975?platform=mac)
 * [uPic](https://github.com/gee1k/uPic) - macOS native app, powerful terse image hosting client. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/gee1k/uPic)
+* [WobblePic](https://wobblepic.com) - Image viewer with soft-body physics; drag images and watch them wobble like rubber. Uses SAM2 for AI segmentation. ![Freeware][Freeware Icon]
 * [Zipic](https://zipic.app/) - Batch image compression tool with presets and automation.
 
 ## AI Tools

--- a/README.md
+++ b/README.md
@@ -759,7 +759,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [PicGo](https://github.com/Molunerfinn/PicGo) - Support for common cdn image hosting tool.  [![Open-Source Software][OSS Icon]](https://github.com/Molunerfinn/PicGo)
 * [AppIconBuilder](https://apps.apple.com/app/shotbuilder/id1294179975?platform=mac) - Export icons for multi-platform[![App Store][app-store Icon]](https://apps.apple.com/app/shotbuilder/id1294179975?platform=mac)
 * [uPic](https://github.com/gee1k/uPic) - macOS native app, powerful terse image hosting client. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/gee1k/uPic)
-* [WobblePic](https://wobblepic.com) - Image viewer with soft-body physics; drag images and watch them wobble like rubber. Uses SAM2 for AI segmentation. ![Freeware][Freeware Icon]
+* [WobblePic](https://wobblepic.com) - Image viewer with soft-body physics; drag images and watch them wobble like rubber. ![Freeware][Freeware Icon]
 * [Zipic](https://zipic.app/) - Batch image compression tool with presets and automation.
 
 ## AI Tools


### PR DESCRIPTION
### Types of Changes

- [x] New addition to list
- [ ] Fixing bug in existing item in list
- [ ] Removing item from list
- [ ] Changing structure (organization) of list

### Proposed Changes

Adds WobblePic to the "Other Tools" section under "Design and Product".

WobblePic is a free desktop image viewer for macOS (Apple Silicon + Intel) and Windows that applies real-time soft-body physics to images. Users can drag any part of a photo and watch it wobble back like rubber. It uses Meta's SAM2 model (via CoreML on Apple Silicon) to segment objects so only the clicked object deforms.

- Website: https://wobblepic.com
- GitHub: https://github.com/wobblepic/WobblePicPublic
- Freeware (closed source, free for personal and commercial use)
- Actively maintained (v1.2.1 released recently)

### PR Checklist

- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important
- [x] I have added necessary documentation (if appropriate)
