### PR TITLE
Add UniClipboard to Clipboard Managers

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1143,6 +1143,7 @@ Awesome Mac
 * [Maccy](https://maccy.app/) - macOS用の軽量クリップボードマネージャー。 [![Open-Source Software][OSS Icon]](https://github.com/p0deje/Maccy) ![Freeware][Freeware Icon]
 * [Mask This](https://apps.apple.com/us/app/mask-this/id6759096128) - クリップボード内の機密情報をマスクするメニューバーツール。 [![Open-Source Software][OSS Icon]](https://github.com/tseylerd/MaskThis) ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/us/app/mask-this/id6759096128)
 * [OneClip](https://github.com/Wcowin/OneClip) - シンプルでプロフェッショナルなmacOSクリップボードマネージャー。 [![Open-Source Software][OSS Icon]](https://github.com/Wcowin/OneClip) ![Freeware][Freeware Icon]
+* [UniClipboard](https://github.com/uniclipboard/uniclipboard) - プライバシー重視で、macOS・Windows・Linux間のクリップボードをエンドツーエンド暗号化で同期するツール。 [![Open-Source Software][OSS Icon]](https://github.com/uniclipboard/uniclipboard) ![Freeware][Freeware Icon]
 * [uPaste](https://okaapps.com/product/1503649026) - クリップボード履歴と定型文を整理して再利用しやすくするマネージャー。 [![App Store][app-store Icon]](https://apps.apple.com/app/id1503649026?pt=119209922&ct=github)
 * [Yippy](https://github.com/mattDavo/Yippy) - ユーザーフレンドリーなUIのクリップボードマネージャー。 [![Open-Source Software][OSS Icon]](https://github.com/mattDavo/Yippy) ![Freeware][Freeware Icon]
 * [ClipFlow](https://github.com/praneeth552/clipflow) - ターミナルスタイルのナビゲーションを備えた無料のクリップボード履歴マネージャー。 [![Open-Source Software][OSS Icon]](https://github.com/praneeth552/clipflow) ![Freeware][Freeware Icon]

--- a/README-ko.md
+++ b/README-ko.md
@@ -838,6 +838,7 @@ Awesome Mac
 * [Mask This](https://apps.apple.com/us/app/mask-this/id6759096128) - 클립보드의 민감한 정보를 마스킹해 주는 메뉴 바 도구. [![Open-Source Software][OSS Icon]](https://github.com/tseylerd/MaskThis) ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/us/app/mask-this/id6759096128)
 * [Paste](https://pasteapp.io/) - 세계 최고의 클립보드 관리자.
 * [SaneClip](https://saneclip.com) - 기록, Touch ID 보호, 민감 정보 감지를 갖춘 클립보드 관리자. [![Open-Source Software][OSS Icon]](https://github.com/sane-apps/SaneClip) ![Freeware][Freeware Icon]
+* [UniClipboard](https://github.com/uniclipboard/uniclipboard) - 개인정보 보호를 중시하며 macOS, Windows, Linux 사이의 클립보드를 종단간 암호화로 동기화하는 도구. [![Open-Source Software][OSS Icon]](https://github.com/uniclipboard/uniclipboard) ![Freeware][Freeware Icon]
 * [uPaste](https://okaapps.com/product/1503649026) - 클립보드 기록과 스니펫을 정리해 재사용하기 쉽게 해주는 관리자. [![App Store][app-store Icon]](https://apps.apple.com/app/id1503649026?pt=119209922&ct=github)
 
 ### 메뉴 바 도구

--- a/README-zh.md
+++ b/README-zh.md
@@ -1172,6 +1172,7 @@ Awesome Mac
 * [PasteBot](https://tapbots.com/pastebot/) - 强大的剪贴板管理器。 [![App Store][app-store Icon]](https://apps.apple.com/cn/app/pastebot/id1179623856?platform=mac)
 * [PopClip](https://www.popclip.app/) - 当您在任何应用中选择文本时，PopClip 会出现，为您提供即时访问有用操作的功能。
 * [SaneClip](https://saneclip.com) - 带历史记录、隐私保护和敏感信息检测的剪贴板管理器。 [![Open-Source Software][OSS Icon]](https://github.com/sane-apps/SaneClip) ![Freeware][Freeware Icon]
+* [UniClipboard](https://github.com/uniclipboard/uniclipboard) - 注重隐私、支持端到端加密的跨 macOS、Windows 和 Linux 剪贴板同步工具。 [![Open-Source Software][OSS Icon]](https://github.com/uniclipboard/uniclipboard) ![Freeware][Freeware Icon]
 * [uPaste](https://okaapps.com/product/1503649026) - 自动整理剪贴板历史和常用片段的管理器。 [![App Store][app-store Icon]](https://apps.apple.com/app/id1503649026?pt=119209922&ct=github)
 * [Yippy](https://github.com/mattDavo/Yippy) - 具有用户友好界面的剪贴板管理器。 [![Open-Source Software][OSS Icon]](https://github.com/mattDavo/Yippy) ![Freeware][Freeware Icon]
 

--- a/README.md
+++ b/README.md
@@ -1146,11 +1146,10 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Flycut](https://github.com/TermiT/Flycut) - Clean and simple clipboard manager for developers. [![Open-Source Software][OSS Icon]](https://github.com/TermiT/Flycut) ![Freeware][Freeware Icon]
 * [Maccy](https://maccy.app/) - Lightweight clipboard manager for macOS. [![Open-Source Software][OSS Icon]](https://github.com/p0deje/Maccy) ![Freeware][Freeware Icon]
 * [OneClip](https://github.com/Wcowin/OneClip) - A simple and professional macOS clipboard manager. [![Open-Source Software][OSS Icon]](https://github.com/Wcowin/OneClip) ![Freeware][Freeware Icon]
+* [UniClipboard](https://github.com/uniclipboard/uniclipboard) - Privacy-first, end-to-end encrypted clipboard sync for macOS, Windows, and Linux. [![Open-Source Software][OSS Icon]](https://github.com/uniclipboard/uniclipboard) ![Freeware][Freeware Icon]
 * [uPaste](https://okaapps.com/product/1503649026) - Clipboard history and snippets manager for organizing reusable copied content. [![App Store][app-store Icon]](https://apps.apple.com/app/id1503649026?pt=119209922&ct=github)
 * [Yippy](https://github.com/mattDavo/Yippy) - Clipboard manager with user-friendly UI. [![Open-Source Software][OSS Icon]](https://github.com/mattDavo/Yippy) ![Freeware][Freeware Icon]
 * [ClipFlow](https://github.com/praneeth552/clipflow) - Free clipboard history manager with terminal-style navigation. [![Open-Source Software][OSS Icon]](https://github.com/praneeth552/clipflow) ![Freeware][Freeware Icon]
-
-- [UniClipboard](https://github.com/uniclipboard/uniclipboard) - Privacy-first, end-to-end encrypted clipboard sync across macOS, Windows, and Linux. (Apache-2.0)
 ### Menu Bar Tools
 
 * [Anvil](https://anvilformac.com/) - Tool for serving local static sites and Rack apps with simple URLs. ![Freeware][Freeware Icon]

--- a/README.md
+++ b/README.md
@@ -1150,6 +1150,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Yippy](https://github.com/mattDavo/Yippy) - Clipboard manager with user-friendly UI. [![Open-Source Software][OSS Icon]](https://github.com/mattDavo/Yippy) ![Freeware][Freeware Icon]
 * [ClipFlow](https://github.com/praneeth552/clipflow) - Free clipboard history manager with terminal-style navigation. [![Open-Source Software][OSS Icon]](https://github.com/praneeth552/clipflow) ![Freeware][Freeware Icon]
 
+- [UniClipboard](https://github.com/uniclipboard/uniclipboard) - Privacy-first, end-to-end encrypted clipboard sync across macOS, Windows, and Linux. (Apache-2.0)
 ### Menu Bar Tools
 
 * [Anvil](https://anvilformac.com/) - Tool for serving local static sites and Rack apps with simple URLs. ![Freeware][Freeware Icon]


### PR DESCRIPTION
Hi, thanks for maintaining this awesome list.
I'd like to add UniClipboard under the Clipboard Managers section.

- Project: https://github.com/uniclipboard/uniclipboard
- Website: https://uniclipboard.app
- License: Apache-2.0
- Description: Privacy-first, end-to-end encrypted clipboard sync across macOS, Windows, and Linux.