### PR TITLE
Add DBConvert Streams to database tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,6 +558,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Dataflare](https://dataflare.app) - Simple database client supporting Postgres, MySQL, DuckDB, libSQL, Cloudflare D1, and more.
 * [DB Browser for SQLite](http://sqlitebrowser.org/) - Official home of the DB Browser for SQLite. [![Open-Source Software][OSS Icon]](https://github.com/sqlitebrowser/sqlitebrowser) ![Freeware][Freeware Icon]
 * [DBeaver](https://dbeaver.io/) - Universal SQL Client.
+* [DBConvert Streams](https://streams.dbconvert.com) - Database IDE with built-in migration and real-time CDC. Supports MySQL, PostgreSQL, and files (CSV, Parquet, S3).
 * [DB Pro](https://dbpro.app) - Database client for querying and managing SQL databases.
 * [ElectroCRUD](http://garrylachman.github.io/ElectroCRUD/) - Modern MySQL CRUD application. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/garrylachman/ElectroCRUD)
 * [FastoNoSQL](https://fastonosql.com/) - Cross-platform GUI client for various key-value databases. [![OSS][OSS Icon]](https://github.com/fastogt/fastonosql) ![Freeware][Freeware Icon]


### PR DESCRIPTION
NOTE: A similar PR may already be submitted! Please search among the Pull request before creating one.

### Types of Changes

- [x] New addition to list


### Proposed Changes

Adds DBConvert Streams to the database tools section.

DBConvert Streams is a self-hosted database IDE with built-in migration and CDC support for MySQL and PostgreSQL.

It fits the existing category alongside tools like DBeaver, Beekeeper Studio, and DB Pro.

### PR Checklist

- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important
