### PR TITLE
Add Text-to-Speech section with Murmur

### DIFF
--- a/README.md
+++ b/README.md
@@ -1008,6 +1008,10 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Whispering](https://epicenter.md/whispering/) - Multi-provider speech-to-text with AI transformations and keyboard shortcuts. [![Open-Source Software][OSS Icon]](https://github.com/EpicenterHQ/epicenter/tree/main/apps/whispering) ![Freeware][Freeware Icon]
 * [Willow Voice](https://willowvoice.com/) - AI dictation with automatic editing, style-matching, and noise optimization.
 
+## Text-to-Speech
+
+* [Murmur](https://murmurtts.com/) - On-device text-to-speech studio with 860+ voices across 25+ languages, voice cloning, and four AI models (Kokoro, Qwen3-TTS, Fish S2 Pro, Chatterbox) running entirely on Apple Silicon via MLX.
+
 ## Browsers
 
 * [Arc](https://arc.net/) - Browser with a distinctive workspace-style interface. ![Freeware][Freeware Icon]


### PR DESCRIPTION
## What this PR does

Adds a new **Text-to-Speech** section to the list, seeded with [Murmur](https://murmurtts.com/).

## Why a new section

The list already has a thriving **Voice-to-Text** section (14 entries) but no symmetrical Text-to-Speech category. As on-device TTS apps become viable on Apple Silicon, this category will grow. Seeding it now keeps the structure clean.

If you'd prefer to fold Murmur into the existing **Audio Record and Process** section instead, I'm happy to amend the PR.

## About Murmur

Murmur is a native macOS text-to-speech studio that runs entirely on the user's Mac using Apple's MLX framework. Highlights:

- 860+ voices across 25+ languages
- Voice cloning from a 10-second sample
- Four bundled AI models: Kokoro, Qwen3-TTS, Fish S2 Pro, Chatterbox
- Batch processing for long-form work like audiobooks
- $49 one-time, no subscription, no per-character fees
- macOS 14+, Apple Silicon required

## Translations

Only `README.md` is updated. Happy to mirror the entry into `README-zh.md`, `README-ja.md`, and `README-ko.md` if you prefer translations be handled in the same PR (the translated READMEs currently lag behind English by a few entries, so I left them alone to avoid introducing inconsistency).

Thanks for maintaining this list!