### PR TITLE
Add AI Dictation to Voice-to-Text

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -990,6 +990,7 @@ Awesome Mac
 
 ## 音声テキスト変換
 
+* [AI Dictation](https://aidictation.com/) - オフライン/オンライン認識を自動切り替えする Mac 用音声入力。AI がフィラー語を削除し、文法を修正し、アプリごとにテキストを整形します。
 * [Aiko](https://sindresorhus.com/aiko) - 高品質なデバイス上の文字起こし。 ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id1666327168?platform=mac)
 * [Azex Speech](https://github.com/azex-ai/speech) - AIや暗号資産の作業で中英混在の音声入力に強いツール。 [![Open-Source Software][OSS Icon]](https://github.com/azex-ai/speech) ![Freeware][Freeware Icon]
 * [buzz](https://github.com/chidiwilliams/buzz) - 個人のコンピューター上でオフラインで音声を文字起こし・翻訳。OpenAIのWhisperを使用。 [![Open-Source Software][OSS Icon]](https://github.com/chidiwilliams/buzz)

--- a/README-ja.md
+++ b/README-ja.md
@@ -1031,7 +1031,7 @@ Awesome Mac
 
 ## 音声テキスト変換
 
-* [AI Dictation](https://aidictation.com/) - オフライン/オンライン認識を自動切り替えする Mac 用音声入力。AI がフィラー語を削除し、文法を修正し、アプリごとにテキストを整形します。
+* [AI Dictation](https://aidictation.com) - 対応デバイスでのオフライン認識、任意のクラウド文章整理、個人用語彙に対応したオープンソースの音声テキスト化アプリ。 [![Open-Source Software][OSS Icon]](https://github.com/writingmate/aidictation)
 * [Aiko](https://sindresorhus.com/aiko) - 高品質なデバイス上の文字起こし。 ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id1666327168?platform=mac)
 * [Azex Speech](https://github.com/azex-ai/speech) - AIや暗号資産の作業で中英混在の音声入力に強いツール。 [![Open-Source Software][OSS Icon]](https://github.com/azex-ai/speech) ![Freeware][Freeware Icon]
 * [buzz](https://github.com/chidiwilliams/buzz) - 個人のコンピューター上でオフラインで音声を文字起こし・翻訳。OpenAIのWhisperを使用。 [![Open-Source Software][OSS Icon]](https://github.com/chidiwilliams/buzz)

--- a/README-ja.md
+++ b/README-ja.md
@@ -1031,6 +1031,7 @@ Awesome Mac
 
 ## 音声テキスト変換
 
+* [AI Dictation](https://aidictation.com/) - オフライン/オンライン認識を自動切り替えする Mac 用音声入力。AI がフィラー語を削除し、文法を修正し、アプリごとにテキストを整形します。
 * [Aiko](https://sindresorhus.com/aiko) - 高品質なデバイス上の文字起こし。 ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id1666327168?platform=mac)
 * [Azex Speech](https://github.com/azex-ai/speech) - AIや暗号資産の作業で中英混在の音声入力に強いツール。 [![Open-Source Software][OSS Icon]](https://github.com/azex-ai/speech) ![Freeware][Freeware Icon]
 * [buzz](https://github.com/chidiwilliams/buzz) - 個人のコンピューター上でオフラインで音声を文字起こし・翻訳。OpenAIのWhisperを使用。 [![Open-Source Software][OSS Icon]](https://github.com/chidiwilliams/buzz)

--- a/README-ko.md
+++ b/README-ko.md
@@ -748,6 +748,7 @@ Awesome Mac
 
 ## 음성 텍스트 변환 (Voice-to-Text)
 
+* [AI Dictation](https://aidictation.com/) - 오프라인/온라인 인식을 자동으로 전환하는 Mac용 음성 인식 도구. AI가 필러 단어를 제거하고, 문법을 수정하며, 앱별로 텍스트를 형식화합니다.
 * [Aiko](https://sindresorhus.com/aiko) - 고품질 온디바이스 전사 도구. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id1666327168?platform=mac)
 * [Azex Speech](https://github.com/azex-ai/speech) - AI와 크립토 작업에서 중영 혼용 받아쓰기에 강한 음성 입력 도구. [![Open-Source Software][OSS Icon]](https://github.com/azex-ai/speech) ![Freeware][Freeware Icon]
 * [EnviousWispr](https://enviouswispr.com/) - 음성을 다듬어진 텍스트로 빠르게 바꿔 바로 붙여넣을 수 있는 온디바이스 AI 받아쓰기 도구. ![Freeware][Freeware Icon]

--- a/README-ko.md
+++ b/README-ko.md
@@ -790,7 +790,7 @@ Awesome Mac
 
 ## 음성 텍스트 변환 (Voice-to-Text)
 
-* [AI Dictation](https://aidictation.com/) - 오프라인/온라인 인식을 자동으로 전환하는 Mac용 음성 인식 도구. AI가 필러 단어를 제거하고, 문법을 수정하며, 앱별로 텍스트를 형식화합니다.
+* [AI Dictation](https://aidictation.com) - 지원 기기의 오프라인 인식, 선택적 클라우드 문장 정리, 개인 어휘를 제공하는 오픈 소스 음성-텍스트 변환 앱입니다. [![Open-Source Software][OSS Icon]](https://github.com/writingmate/aidictation)
 * [Aiko](https://sindresorhus.com/aiko) - 고품질 온디바이스 전사 도구. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id1666327168?platform=mac)
 * [Azex Speech](https://github.com/azex-ai/speech) - AI와 크립토 작업에서 중영 혼용 받아쓰기에 강한 음성 입력 도구. [![Open-Source Software][OSS Icon]](https://github.com/azex-ai/speech) ![Freeware][Freeware Icon]
 * [EnviousWispr](https://enviouswispr.com/) - 음성을 다듬어진 텍스트로 빠르게 바꿔 바로 붙여넣을 수 있는 온디바이스 AI 받아쓰기 도구. ![Freeware][Freeware Icon]

--- a/README-ko.md
+++ b/README-ko.md
@@ -790,6 +790,7 @@ Awesome Mac
 
 ## 음성 텍스트 변환 (Voice-to-Text)
 
+* [AI Dictation](https://aidictation.com/) - 오프라인/온라인 인식을 자동으로 전환하는 Mac용 음성 인식 도구. AI가 필러 단어를 제거하고, 문법을 수정하며, 앱별로 텍스트를 형식화합니다.
 * [Aiko](https://sindresorhus.com/aiko) - 고품질 온디바이스 전사 도구. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id1666327168?platform=mac)
 * [Azex Speech](https://github.com/azex-ai/speech) - AI와 크립토 작업에서 중영 혼용 받아쓰기에 강한 음성 입력 도구. [![Open-Source Software][OSS Icon]](https://github.com/azex-ai/speech) ![Freeware][Freeware Icon]
 * [EnviousWispr](https://enviouswispr.com/) - 음성을 다듬어진 텍스트로 빠르게 바꿔 바로 붙여넣을 수 있는 온디바이스 AI 받아쓰기 도구. ![Freeware][Freeware Icon]

--- a/README-zh.md
+++ b/README-zh.md
@@ -671,6 +671,7 @@ Awesome Mac
 * [Aegisub](https://github.com/Aegisub/Aegisub) - 支持时间轴和样式编辑的开源字幕编辑器。 [![Open-Source Software][OSS Icon]](https://github.com/Aegisub/Aegisub/) ![Freeware][Freeware Icon]
 * [ani](https://github.com/open-ani/ani) 一站式在线弹幕追番平台：全自动 BT + 在线多数据源聚合，离线缓存，Bangumi 收藏同步，弹幕云过滤 [![Open-Source Software][OSS Icon]](https://github.com/open-ani/ani) ![Freeware][Freeware Icon]
 * [AnimacX](https://github.com/AnimacX/AnimacX) - 一款可以追番时拥有在线弹幕的本地视频播放器 [![Open-Source Software][OSS Icon]](https://github.com/AnimacX/AnimacX) ![Freeware][Freeware Icon]
+* [AI Dictation](https://aidictation.com/) - 自动切换离线/在线识别的 Mac 语音输入工具。AI 会去除语气词、修正语法，并按应用场景格式化文本。
 * [Azex Speech](https://github.com/azex-ai/speech) - 一款面向 AI 与加密场景、中英混说更友好的语音输入工具。 [![Open-Source Software][OSS Icon]](https://github.com/azex-ai/speech) ![Freeware][Freeware Icon]
 * [VoiceInk](https://github.com/Beingpax/VoiceInk) - 实时语音转文字工具。 [![Open-Source Software][OSS Icon]](https://github.com/Beingpax/VoiceInk) ![Freeware][Freeware Icon]
 * [FnKey](https://github.com/evoleinik/fnkey) - 按住说话、松开即粘贴转写文本的语音输入工具。 [![Open-Source Software][OSS Icon]](https://github.com/evoleinik/fnkey) ![Freeware][Freeware Icon]

--- a/README-zh.md
+++ b/README-zh.md
@@ -698,9 +698,9 @@ Awesome Mac
 
 * [Adapter](https://macroplant.com/adapter) - 视频，音频和图像转换工具。![Freeware][Freeware Icon]
 * [Aegisub](https://github.com/Aegisub/Aegisub) - 支持时间轴和样式编辑的开源字幕编辑器。 [![Open-Source Software][OSS Icon]](https://github.com/Aegisub/Aegisub/) ![Freeware][Freeware Icon]
+* [AI Dictation](https://aidictation.com) - 开源语音转文字应用，在支持的设备上提供离线识别、可选的云端文本整理和个人词汇表。 [![Open-Source Software][OSS Icon]](https://github.com/writingmate/aidictation)
 * [ani](https://github.com/open-ani/ani) 一站式在线弹幕追番平台：全自动 BT + 在线多数据源聚合，离线缓存，Bangumi 收藏同步，弹幕云过滤 [![Open-Source Software][OSS Icon]](https://github.com/open-ani/ani) ![Freeware][Freeware Icon]
 * [AnimacX](https://github.com/AnimacX/AnimacX) - 一款可以追番时拥有在线弹幕的本地视频播放器 [![Open-Source Software][OSS Icon]](https://github.com/AnimacX/AnimacX) ![Freeware][Freeware Icon]
-* [AI Dictation](https://aidictation.com/) - 自动切换离线/在线识别的 Mac 语音输入工具。AI 会去除语气词、修正语法，并按应用场景格式化文本。
 * [Azex Speech](https://github.com/azex-ai/speech) - 一款面向 AI 与加密场景、中英混说更友好的语音输入工具。 [![Open-Source Software][OSS Icon]](https://github.com/azex-ai/speech) ![Freeware][Freeware Icon]
 * [VoiceInk](https://github.com/Beingpax/VoiceInk) - 实时语音转文字工具。 [![Open-Source Software][OSS Icon]](https://github.com/Beingpax/VoiceInk) ![Freeware][Freeware Icon]
 * [VoxFlow](https://github.com/xingbofeng/VoxFlow) - 开源语音输入工作台，支持本地与云端 ASR、OCR、历史记录和编码助手流程。 [![Open-Source Software][OSS Icon]](https://github.com/xingbofeng/VoxFlow) ![Freeware][Freeware Icon]

--- a/README-zh.md
+++ b/README-zh.md
@@ -700,6 +700,7 @@ Awesome Mac
 * [Aegisub](https://github.com/Aegisub/Aegisub) - 支持时间轴和样式编辑的开源字幕编辑器。 [![Open-Source Software][OSS Icon]](https://github.com/Aegisub/Aegisub/) ![Freeware][Freeware Icon]
 * [ani](https://github.com/open-ani/ani) 一站式在线弹幕追番平台：全自动 BT + 在线多数据源聚合，离线缓存，Bangumi 收藏同步，弹幕云过滤 [![Open-Source Software][OSS Icon]](https://github.com/open-ani/ani) ![Freeware][Freeware Icon]
 * [AnimacX](https://github.com/AnimacX/AnimacX) - 一款可以追番时拥有在线弹幕的本地视频播放器 [![Open-Source Software][OSS Icon]](https://github.com/AnimacX/AnimacX) ![Freeware][Freeware Icon]
+* [AI Dictation](https://aidictation.com/) - 自动切换离线/在线识别的 Mac 语音输入工具。AI 会去除语气词、修正语法，并按应用场景格式化文本。
 * [Azex Speech](https://github.com/azex-ai/speech) - 一款面向 AI 与加密场景、中英混说更友好的语音输入工具。 [![Open-Source Software][OSS Icon]](https://github.com/azex-ai/speech) ![Freeware][Freeware Icon]
 * [VoiceInk](https://github.com/Beingpax/VoiceInk) - 实时语音转文字工具。 [![Open-Source Software][OSS Icon]](https://github.com/Beingpax/VoiceInk) ![Freeware][Freeware Icon]
 * [VoxFlow](https://github.com/xingbofeng/VoxFlow) - 开源语音输入工作台，支持本地与云端 ASR、OCR、历史记录和编码助手流程。 [![Open-Source Software][OSS Icon]](https://github.com/xingbofeng/VoxFlow) ![Freeware][Freeware Icon]

--- a/README.md
+++ b/README.md
@@ -993,6 +993,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 
 ## Voice-to-Text
 
+* [AI Dictation](https://aidictation.com/) - Speech-to-text for Mac with auto-switching offline/online recognition; AI removes filler words, fixes grammar, and formats per app. ![Freeware][Freeware Icon]
 * [Aiko](https://sindresorhus.com/aiko) - High-quality on-device transcription. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id1666327168?platform=mac)
 * [Azex Speech](https://github.com/azex-ai/speech) - Voice input tuned for mixed Chinese-English dictation in AI and crypto work. [![Open-Source Software][OSS Icon]](https://github.com/azex-ai/speech) ![Freeware][Freeware Icon]
 * [buzz](https://github.com/chidiwilliams/buzz) - Transcribes and translates audio offline on your personal computer. Powered by OpenAI's Whisper. [![Open-Source Software][OSS Icon]](https://github.com/chidiwilliams/buzz)

--- a/README.md
+++ b/README.md
@@ -993,7 +993,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 
 ## Voice-to-Text
 
-* [AI Dictation](https://aidictation.com/) - Speech-to-text for Mac with auto-switching offline/online recognition; AI removes filler words, fixes grammar, and formats per app. ![Freeware][Freeware Icon]
+* [AI Dictation](https://aidictation.com/) - Speech-to-text for Mac with auto-switching offline/online recognition; AI removes filler words, fixes grammar, and formats per app.
 * [Aiko](https://sindresorhus.com/aiko) - High-quality on-device transcription. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id1666327168?platform=mac)
 * [Azex Speech](https://github.com/azex-ai/speech) - Voice input tuned for mixed Chinese-English dictation in AI and crypto work. [![Open-Source Software][OSS Icon]](https://github.com/azex-ai/speech) ![Freeware][Freeware Icon]
 * [buzz](https://github.com/chidiwilliams/buzz) - Transcribes and translates audio offline on your personal computer. Powered by OpenAI's Whisper. [![Open-Source Software][OSS Icon]](https://github.com/chidiwilliams/buzz)

--- a/README.md
+++ b/README.md
@@ -1034,6 +1034,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 
 ## Voice-to-Text
 
+* [AI Dictation](https://aidictation.com/) - Speech-to-text for Mac with auto-switching offline/online recognition; AI removes filler words, fixes grammar, and formats per app. ![Freeware][Freeware Icon]
 * [Aiko](https://sindresorhus.com/aiko) - High-quality on-device transcription. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id1666327168?platform=mac)
 * [Azex Speech](https://github.com/azex-ai/speech) - Voice input tuned for mixed Chinese-English dictation in AI and crypto work. [![Open-Source Software][OSS Icon]](https://github.com/azex-ai/speech) ![Freeware][Freeware Icon]
 * [buzz](https://github.com/chidiwilliams/buzz) - Transcribes and translates audio offline on your personal computer. Powered by OpenAI's Whisper. [![Open-Source Software][OSS Icon]](https://github.com/chidiwilliams/buzz)

--- a/README.md
+++ b/README.md
@@ -1034,7 +1034,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 
 ## Voice-to-Text
 
-* [AI Dictation](https://aidictation.com/) - Speech-to-text for Mac with auto-switching offline/online recognition; AI removes filler words, fixes grammar, and formats per app.
+* [AI Dictation](https://aidictation.com) - Open-source voice-to-text app with offline recognition on supported devices, optional cloud cleanup, and personal vocabulary. [![Open-Source Software][OSS Icon]](https://github.com/writingmate/aidictation)
 * [Aiko](https://sindresorhus.com/aiko) - High-quality on-device transcription. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id1666327168?platform=mac)
 * [Azex Speech](https://github.com/azex-ai/speech) - Voice input tuned for mixed Chinese-English dictation in AI and crypto work. [![Open-Source Software][OSS Icon]](https://github.com/azex-ai/speech) ![Freeware][Freeware Icon]
 * [buzz](https://github.com/chidiwilliams/buzz) - Transcribes and translates audio offline on your personal computer. Powered by OpenAI's Whisper. [![Open-Source Software][OSS Icon]](https://github.com/chidiwilliams/buzz)

--- a/README.md
+++ b/README.md
@@ -1034,7 +1034,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 
 ## Voice-to-Text
 
-* [AI Dictation](https://aidictation.com/) - Speech-to-text for Mac with auto-switching offline/online recognition; AI removes filler words, fixes grammar, and formats per app. ![Freeware][Freeware Icon]
+* [AI Dictation](https://aidictation.com/) - Speech-to-text for Mac with auto-switching offline/online recognition; AI removes filler words, fixes grammar, and formats per app.
 * [Aiko](https://sindresorhus.com/aiko) - High-quality on-device transcription. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id1666327168?platform=mac)
 * [Azex Speech](https://github.com/azex-ai/speech) - Voice input tuned for mixed Chinese-English dictation in AI and crypto work. [![Open-Source Software][OSS Icon]](https://github.com/azex-ai/speech) ![Freeware][Freeware Icon]
 * [buzz](https://github.com/chidiwilliams/buzz) - Transcribes and translates audio offline on your personal computer. Powered by OpenAI's Whisper. [![Open-Source Software][OSS Icon]](https://github.com/chidiwilliams/buzz)


### PR DESCRIPTION
## What changed

Adds [AI Dictation](https://aidictation.com) to the Voice-to-Text listings in `README.md`, `README-zh.md`, `README-ja.md`, and `README-ko.md`.

AI Dictation is an open-source voice-to-text app with offline recognition on supported devices, optional cloud cleanup, and personal vocabulary. Its native client source is available under the MIT License at <https://github.com/writingmate/aidictation>.

## Why it belongs here

- The current macOS app supports shortcut-driven dictation.
- The repository is public, actively maintained, and MIT-licensed.
- The entry uses the project website as the primary link and the repository's open-source badge format.

## Disclosure

I am on the team behind AI Dictation. AI assistance was used to refresh the four translations and validate this update against the repository's `awesome-mac-maintainer` skill; the product claims and links were checked against the current public repository.

## Checks

- [x] Read the current contribution guide.
- [x] Searched the list and pull requests for duplicates.
- [x] Added one concise sentence to each of the four supported README files.
- [x] Preserved each file's local section structure and alphabetical placement.
- [x] Verified the website and source links return HTTP 200.
- [x] Removed stale pricing and automatic-switching claims from the earlier draft.
