### PR TITLE
Add prompt-to-asset and unslop to AI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -792,6 +792,8 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Witsy](https://github.com/nbonamy/witsy) - desktop AI assistant / universal MCP client. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/nbonamy/witsy)
 * [remio](https://www.remio.ai/?utm_source=github_list) - Local-first AI chat client that answers from your knowledge base.  [![Freeware][Freeware Icon]](https://www.remio.ai/?utm_source=github_list)
 * [Warden](https://karatsidhu.gumroad.com/l/warden) - A Native Swift macOS app that lets you run multiple LLM models using your own API keys. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/SidhuK/WardenApp)
+* [prompt-to-asset](https://github.com/MohamedAbdallah-14/prompt-to-asset) - MCP server that generates production-ready visual assets (app icons, favicons, OG images, logos) by routing requests across 30+ image generation models. Zero API key required for first run via Pollinations and Stable Horde free tiers. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/MohamedAbdallah-14/prompt-to-asset)
+* [unslop](https://github.com/MohamedAbdallah-14/unslop) - MCP server and CLI that removes named AI writing patterns from text: tricolons, em-dash overuse, hedging stacks, sycophancy openers, and overused vocabulary. Lint-only audit mode and five intensity levels. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/MohamedAbdallah-14/unslop)
 
 
 ## Communication


### PR DESCRIPTION
## Add prompt-to-asset and unslop to AI Tools

Two open-source MCP servers for the AI Tools section.

**prompt-to-asset**

[prompt-to-asset](https://github.com/MohamedAbdallah-14/prompt-to-asset) is an MCP server that generates production-ready visual assets (app icons, favicons, OG images, logos) by routing requests across 30+ image generation models. It requires zero API keys for a first run using Pollinations and Stable Horde free tiers. MIT licensed.

The section already includes Orchard (MCP server that connects AI assistants to Apple apps). Prompt-to-asset is another macOS-compatible MCP server that fits the same category.

**unslop**

[unslop](https://github.com/MohamedAbdallah-14/unslop) is an MCP server and CLI that removes named AI writing patterns from text: tricolons, em-dash overuse, hedging stacks, sycophancy openers, and overused vocabulary. Lint-only audit mode and five intensity levels. MIT licensed.

The section includes other developer CLI tools like Desktop Control ("GPU-accelerated CLI for AI agents") and Claudoscope ("Tool for browsing and analyzing Claude Code sessions"). Unslop is a similar developer-focused AI tool.

Both tools are public repositories, MIT licensed, open-source, and free to use on macOS.
