### PR TITLE
Add Drevon - Mac GTM agent desktop app powered by AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -777,6 +777,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Chatbox](https://chatboxai.app) - User-friendly Desktop Client App for AI Models/LLMs (GPT, Claude, Gemini, Ollama...). [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/chatboxai/chatbox)
 * [CodexBar](https://codexbar.app) - Show usage stats for OpenAI Codex and Claude Code, without having to login. [![Open-Source Software][OSS Icon]](https://github.com/steipete/CodexBar) ![Freeware][Freeware Icon]
 * [Desktop Control](https://github.com/yaroshevych/desktopctl) - GPU-accelerated CLI for AI agents to control any macOS app via screen, mouse, and keyboard.
+* [Drevon](https://drevon.dev) - Mac desktop workspace for GTM engineers. Run parallel AI agents powered by Claude Code, Codex, or Copilot to build target lists, score accounts, and pull prospect intel from LinkedIn, CRM, and sales tools.
 * [Fazm](https://fazm.ai) - Open-source voice-controlled AI agent for apps, files, and workflows. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/m13v/fazm)
 * [Flock](https://github.com/Divagation/flock) - Terminal multiplexer for running multiple Claude Code and shell sessions in one workspace. [![Open-Source Software][OSS Icon]](https://github.com/Divagation/flock) ![Freeware][Freeware Icon]
 * [Fluent](https://fluentmac.app) - AI assistant that works across apps with model and context integration.


### PR DESCRIPTION
## About Drevon

[Drevon](https://drevon.dev) is a Mac desktop workspace for GTM engineers. It runs parallel AI agents powered by Claude Code, Codex, or Copilot to:
- Build target lists and score accounts
- Pull prospect intel from LinkedIn, CRM, and sales tools
- Automate GTM workflows with AI agents

**Website:** https://drevon.dev
**Category:** AI Tools

This is a macOS-native app for AI-powered go-to-market engineering.