### PR TITLE
Add Bzz to Input Methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -983,6 +983,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 
 ## Input Methods
 
+* [Bzz](https://github.com/zlopixatel/bzz) - Automatic keyboard layout switcher for macOS. Detects mistyped words like `ghbdtn` and replaces with `привет` on the fly. Open-source replacement for the abandoned Punto Switcher. [![Open-Source Software][OSS Icon]](https://github.com/zlopixatel/bzz) ![Freeware][Freeware Icon]
 * [Kawa](https://github.com/utatti/kawa) - Better input source switcher for OS X. [![Open-Source Software][OSS Icon]](https://github.com/utatti/kawa) ![Freeware][Freeware Icon]
 * [LangSwitcher](https://github.com/reg2005/langSwitcher) - Keyboard layout converter for mistyped text. [![Open-Source Software][OSS Icon]](https://github.com/reg2005/langSwitcher) ![Freeware][Freeware Icon]
 * [Rocket](http://matthewpalmer.net/rocket/) - Makes typing emoji faster and easier using Slack-style shortcuts. ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds [Bzz](https://github.com/zlopixatel/bzz) — open-source automatic keyboard layout switcher for macOS, in the **Input Methods** section.

Punto Switcher (canonical RU keyboard switcher) was abandoned for macOS in 2017. Caramba Switcher charges a yearly subscription. Bzz fills the gap — MIT, Go, no telemetry.

- Active CGEventTap intercepts Enter before submit
- Fuzzy matching for typos: `gjljk;bv` → `продолжим`
- Cmd+Z undo with per-app exception learning
- Cmd+Shift+X manual selection conversion
- 4.7 MB binary

Placed in Input Methods section near LangSwitcher (similar functionality).