### PR TITLE
Add Deepend to Developer Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Cutter](https://cutter.re/) - Powerful multi-platform reverse engineering tool. ![Open-Source Software][OSS Icon]
 * [DevHub](https://wangchujiang.com/DevHub/) - Feature-rich offline app for developers. ![OSS][OSS Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/devhub/id6476452351?platform=mac)
 * [Dash](https://kapeli.com/dash) - Awesome API documentation browser and code snippet manager. ![Freeware][Freeware Icon]
+* [Deepend](https://github.com/deepen-stha/deepend-releases) - Offline app bundling 43 developer utilities for JSON, PDF, text, API, and image work. No accounts, no telemetry. ![Freeware][Freeware Icon]
 * [Deeplink Buddy](https://deeplinkbuddy.com) - Deeplink managers, made by developer for developers.
 * [DiffMerge](http://sourcegear.com/diffmerge/) - Application to visually compare and merge files. ![Freeware][Freeware Icon]
 * [EnvPane](https://github.com/hschmidt/EnvPane) - OS X preference pane for environment variables. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/hschmidt/EnvPane)


### PR DESCRIPTION
Adds [Deepend](https://github.com/deepen-stha/deepend-releases) to the **Developer Utilities** section, alphabetically slotted between **Dash** and **Deeplink Buddy**.

Deepend is a Tauri 2 desktop app (native build for Apple Silicon and Intel) that bundles 43 developer utilities into one window:

- **JSON tools** — formatter, repair, semantic diff, JSONPath query, type generator (TS / Go / Rust), JWT decoder, RFC 6902 patch, JSON ↔ YAML/CSV/XML, redactor, mock generator
- **Text tools** — hash (MD5/SHA family), readability scoring, regex bench, n-gram frequency, 16 case transforms, line ops, encode/decode hub
- **PDF tools** — merge, split, compress, encrypt with permissions, signature overlay, drag-reorder pages, render to image
- **API tools** — HTTP request, cURL converter, code generator (7 languages), 10,000-request load test with p50/p95/p99 latency, Postman v2.1 collection import/export
- **PixelForge** — full Canvas image editor, format converter, EXIF inspector

Free, MIT-licensed, no telemetry. Everything runs in the app's memory — nothing uploaded.

Both `aarch64.dmg` (Apple Silicon) and `x64.dmg` (Intel) are published in the linked release.