### PR TITLE
Update Whisky entry to point at active community fork

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1508,7 +1508,7 @@ Awesome Mac
 * [RPCS3](https://rpcs3.net) - オープンソースのPlayStation 3エミュレーター。 [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/RPCS3/rpcs3)
 * [Ryubing](https://github.com/Ryubing) - 開発終了したSwitchエミュレーターRyujinxのフォーク。 [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/Ryubing)
 * [Suyu](https://suyu.dev/) - 馴染みのある、オープンソースで強力なNintendo Switchエミュレーター。 [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://git.suyu.dev/suyu/suyu)
-* [Whisky](https://getwhisky.app/) - GPTK（Game Porting Toolkit）をサポートするWineラッパー。 [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/Whisky-App/Whisky)
+* [Whisky](https://github.com/frankea/Whisky) - macOS向けのネイティブSwiftUI Wineラッパー。D3DMetalおよびDXVKバックエンドをサポート。アクティブなコミュニティフォーク。元の[whisky-app/whisky](https://github.com/whisky-app/whisky)は2025年4月にアーカイブされました。 [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/frankea/Whisky)
 
 ## リモートログインソフトウェア
 

--- a/README.md
+++ b/README.md
@@ -1511,7 +1511,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [RPCS3](https://rpcs3.net) - The Open-source PlayStation 3 Emulator [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/RPCS3/rpcs3)
 * [Ryubing](https://github.com/Ryubing) - A fork of the discontinued Switch emulator, Ryujinx. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/Ryubing)
 * [Suyu](https://suyu.dev/) - A familiar, open source, and powerful Nintendo Switch emulator. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://git.suyu.dev/suyu/suyu)
-* [Whisky](https://getwhisky.app/) - Wine wrapper that supports GPTK (Game Porting Toolkit) [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/Whisky-App/Whisky)
+* [Whisky](https://github.com/frankea/Whisky) - Native SwiftUI Wine wrapper for macOS with D3DMetal/DXVK backends. Active community fork; the original [whisky-app/whisky](https://github.com/whisky-app/whisky) was archived in April 2025. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/frankea/Whisky)
 * [ConsoleMini](https://github.com/momenbasel/ConsoleMini) - Controller-first big-picture launcher that turns a Mac mini into a PS1-PS4 + retro console (wraps DuckStation, PCSX2, RPCS3, shadPS4, PPSSPP, RetroArch, mGBA, Flycast). [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/momenbasel/ConsoleMini)
 
 ## Remote Login Software


### PR DESCRIPTION
The current Whisky entry links to `getwhisky.app` and `Whisky-App/Whisky`, both of which are stale:

- The website [getwhisky.app](https://getwhisky.app/) reflects the archived 2.3.4 release from April 2025.
- The repo [whisky-app/whisky](https://github.com/whisky-app/whisky) was [archived on 2025-04-09](https://github.com/whisky-app/whisky) with a final maintenance notice.

The community fork at [frankea/Whisky](https://github.com/frankea/Whisky) has continued development through 2026 — Wine 11, expanded launcher compatibility, GameDB browser with 80+ entries, signed/notarized DMGs via Sparkle, and per-issue audit accountability against the archived upstream. Latest release is `app-v3.0.1` (May 2026).

This PR updates both English and Japanese README entries to point at the active fork. The description has been refreshed to reflect what the app actually does today (D3DMetal/DXVK backends; GPTK was renamed to D3DMetal in late 2024).

Diff is minimal — two lines, one in each README.