### PR TITLE
Add qnote to Note-taking section

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [SideNotes](https://www.apptorium.com/sidenotes) - Quick notes on the screen side with Markdown support.
 * [Standard Notes](https://standardnotes.com/) - An end-to-end encrypted notes app for digitalists and professionals. [![Open-Source Software][OSS Icon]](https://github.com/standardnotes/app) ![Freeware][Freeware Icon] [![Awesome List][awesome-list Icon]](https://github.com/jonhadfield/awesome-standard-notes#readme)
 * [Stik](https://github.com/0xMassi/stik_app) - Quick-capture markdown notes app with hotkeys and AI semantic search. [![Open-Source Software][OSS Icon]](https://github.com/0xMassi/stik_app) ![Freeware][Freeware Icon]
+* [qnote](https://github.com/Omibranch/qnote) - Minimal frameless notepad with local-only storage, no telemetry. Markdown live preview, real PDF export via Typst, OCR via Tesseract, automatic version history. [![Open-Source Software][OSS Icon]](https://github.com/Omibranch/qnote) ![Freeware][Freeware Icon]
 * [QOwnNotes](http://www.qownnotes.org/) - Open-source notepad with markdown support and todo list manager. [![Open-Source Software][OSS Icon]](https://github.com/pbek/QOwnNotes) ![Freeware][Freeware Icon]
 * [Quick Note](https://quicknoteapp.com) - Colorful sticky notes in the Menu bar. [![App Store][app-store Icon]](https://apps.apple.com/in/app/quick-note-in-the-menu/id1472935217?platform=mac)
 * [Quiver](http://happenapps.com/#quiver) - Mix text, code, Markdown, and LaTeX in one note with live preview.


### PR DESCRIPTION
[qnote](https://github.com/Omibranch/qnote) is a minimal frameless notepad built with Tauri 2 (Rust + React/TypeScript), available for macOS, Linux, and Windows.

**Key features:**
- Local-only storage, no telemetry, no cloud
- Markdown live preview with split editor
- Real PDF export via Typst
- OCR via Tesseract
- Automatic local version history
- Dark/light themes, custom fonts
- Available on AUR (Arch Linux)

MIT license, open source: https://github.com/Omibranch/qnote

Added alphabetically in the Note-taking section (qnote before QOwnNotes).