### PR TITLE
Add Skilly to AI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -785,6 +785,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [GroAsk](https://groask.com) - Menu bar launcher that sends selected text to AI assistants and CLI agents.
 * [RecurseChat](https://recurse.chat) - Local-first AI chat app with customizable workflows.
 * [Runtime](https://github.com/runtime-org/runtime) - AI taskmate and take control of the web & your office tools
+* [Skilly](https://tryskilly.app) - Voice-first AI tutor that watches your Mac screen and walks you through any app (Blender, Figma, Xcode, Photoshop) out loud. Native Swift + ScreenCaptureKit + OpenAI Realtime, 20+ languages with auto-detect. Ships with 5 free open-source skill curricula. [![Open-Source Software][OSS Icon]](https://github.com/tryskilly/skilly)
 * [TokenMeter](https://priyans-hu.github.io/tokenmeter/) - Track Claude Code usage, rate limits, costs, and activity heatmaps. [![Open-Source Software][OSS Icon]](https://github.com/Priyans-hu/tokenmeter) ![Freeware][Freeware Icon]
 * [Usage4Claude](https://github.com/f-is-h/Usage4Claude) - Real-time monitoring of Claude usage quotas across time windows and plans. [![Open-Source Software][OSS Icon]](https://github.com/f-is-h/Usage4Claude) ![Freeware][Freeware Icon]
 * [Jan](https://jan.ai/) - An open-source alternative to ChatGPT that runs entirely offline on your computer. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/menloresearch/jan)


### PR DESCRIPTION
Adds [Skilly](https://tryskilly.app) under **AI Tools**.

Skilly is a voice-first AI tutor for Mac that watches your screen and walks you through any app out loud. You press a hotkey, ask a question, and Skilly screenshots the active app, narrates the answer, and points your cursor at the exact UI element you need.

**Stack:** native Swift, ScreenCaptureKit, NSPanel-on-every-space, OpenAI Realtime API. macOS 14.2+. No Electron.

**Open source under Apache-2.0:** [github.com/tryskilly/skilly](https://github.com/tryskilly/skilly). Ships with 5 free standalone skill curricula in markdown (Blender, Figma, After Effects, DaVinci Resolve, Premiere Pro — ~33 hours total).

Inserted alphabetically between Runtime and TokenMeter. Followed the existing entry format with the OSS badge linking to source.

Disclosure: I'm the author. Happy to adjust the description/positioning if anything doesn't fit your editorial style.