### PR TITLE
Add Mundwerk to Voice-to-Text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1001,6 +1001,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [buzz](https://github.com/chidiwilliams/buzz) - Transcribes and translates audio offline on your personal computer. Powered by OpenAI's Whisper. [![Open-Source Software][OSS Icon]](https://github.com/chidiwilliams/buzz)
 * [EnviousWispr](https://enviouswispr.com) - Sub-second dictation running Whisper/Parakeet locally with privacy-first AI text polish. ![Freeware][Freeware Icon]
 * [FnKey](https://github.com/evoleinik/fnkey) - Push-to-talk voice input tool that pastes transcribed text instantly. [![Open-Source Software][OSS Icon]](https://github.com/evoleinik/fnkey) ![Freeware][Freeware Icon]
+* [Mundwerk](https://mundwerkapp.de) - Local dictation with German-English code-switching, push-to-talk, and learnable vocabulary. Whisper.cpp on Apple Silicon, fully offline, one-time purchase.
 * [OpenDictation](https://github.com/kdcokenny/OpenDictation) - Open-source dictation utility with local and cloud speech-to-text. [![Open-Source Software][OSS Icon]](https://github.com/kdcokenny/OpenDictation) ![Freeware][Freeware Icon]
 * [OpenTypeless](https://github.com/tover0314-w/opentypeless) - Open-source AI voice input that types polished text into any app. [![Open-Source Software][OSS Icon]](https://github.com/tover0314-w/opentypeless) ![Freeware][Freeware Icon]
 * [Ottex](https://ottex.ai) - AI dictation tool that formats text for the app or site you are using.


### PR DESCRIPTION
[Mundwerk](https://mundwerkapp.de) is a local dictation macOS app focused on German-English code-switching for bilingual users.

Why it fits Voice-to-Text:
- Push-to-talk (Fn key or custom hotkey), system-wide text injection
- Whisper.cpp + Metal GPU acceleration on Apple Silicon
- Fully offline: no cloud component in the audio pipeline
- Learnable vocabulary: corrections feed back into a personal vocabulary store
- One-time purchase, no subscription

Distinct from other entries:
- Code-switching German↔English mid-sentence (target: bilingual IT professionals in DACH region) — not addressed by other Whisper-based apps in this section
- Reproducible Apple Silicon benchmarks: https://github.com/mundwerk-app/whisper-metal-benchmark
- Apple-notarized, hardened-runtime, code-signed; macOS 14+, Apple Silicon only

Project links:
- App: https://mundwerkapp.de
- Documentation: https://github.com/mundwerk-app/docs

Inserted alphabetically between FnKey and OpenDictation. No Freeware/OSS icons (commercial closed-source).