### PR TITLE
Add LogGate Pro to Audio and Video Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -897,6 +897,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Kaset](https://github.com/sozercan/kaset) - Native YouTube Music client for macOS. [![Open-Source Software][OSS Icon]](https://github.com/sozercan/kaset) ![Freeware][Freeware Icon]
 * [Kodi](https://kodi.tv/) - Open-source media center for video, music, pictures, and more. [![Open-Source Software][OSS Icon]](https://github.com/xbmc/xbmc) ![Freeware][Freeware Icon]
 * [LMMS](https://lmms.io) - Open-source digital audio workstation for music production. [![Open-Source Software][OSS Icon]](https://github.com/lmms/lmms) ![Freeware][Freeware Icon]
+* [LogGate Pro](https://loggate.tech/) - Apple Log video converter for iPhone 15 Pro and later — converts Log footage to H.264/H.265 with built-in LUT grading. [![App Store][app-store Icon]](https://apps.apple.com/app/id6761159398?platform=mac)
 * [LosslessCut](https://github.com/mifi/lossless-cut) - Cross platform tool for quick and lossless video and audio trimming using ffmpeg. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/mifi/lossless-cut)
 * [LyricGlow](https://github.com/ateymoori/lyricglow) - Synced lyrics player with word-by-word glow effects. [![Open-Source Software][OSS Icon]](https://github.com/ateymoori/lyricglow) ![Freeware][Freeware Icon]
 * [LyricsX](https://github.com/ddddxxx/LyricsX) - Lyrics for iTunes, Spotify and Vox. [![Open-Source Software][OSS Icon]](https://github.com/ddddxxx/LyricsX) ![Freeware][Freeware Icon]


### PR DESCRIPTION
## What is LogGate Pro?

[LogGate Pro](https://loggate.tech/) is a macOS app (universal — Intel + Apple Silicon) that converts Apple Log video footage from iPhone 15 Pro and later models to standard H.264 or H.265, with built-in LUT grading options. It fills a specific gap for iPhone videographers who shoot in Apple Log and need a fast, lightweight conversion workflow without a full-blown NLE.

- **App Store:** https://apps.apple.com/app/id6761159398?platform=mac
- **Website:** https://loggate.tech/

## Placement

Added under **Audio and Video Tools**, alphabetically between LMMS and LosslessCut.

## Checklist

- [x] App is macOS-native (SwiftUI + AVFoundation)
- [x] App Store listing is live
- [x] Entry follows existing format (name, description, App Store badge)
- [x] Alphabetically ordered within section