### PR TITLE
Add talat to Voice-to-Text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1007,6 +1007,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [OpenTypeless](https://github.com/tover0314-w/opentypeless) - Open-source AI voice input that types polished text into any app. [![Open-Source Software][OSS Icon]](https://github.com/tover0314-w/opentypeless) ![Freeware][Freeware Icon]
 * [Ottex](https://ottex.ai) - AI dictation tool that formats text for the app or site you are using.
 * [Spokenly](https://spokenly.app/) - Voice-to-text with 100+ languages, offline mode, and AI-powered formatting.
+* [talat](https://talat.app) - On-device meeting recording and transcription that keeps mic and system audio on your machine.
 * [Tambourine](https://tambourinevoice.com/) - Open-source, customizable AI voice dictation that works in any app. [![Open-Source Software][OSS Icon]](https://github.com/kstonekuan/tambourine-voice/) ![Freeware][Freeware Icon]
 * [TypeWhisper](https://www.typewhisper.com) - Local Whisper-based speech-to-text with a global hotkey. [![Open-Source Software][OSS Icon]](https://github.com/TypeWhisper/typewhisper-mac) ![Freeware][Freeware Icon]
 * [VoiceInk](https://tryvoiceink.com/) - Real-time speech-to-text app. [![Open-Source Software][OSS Icon]](https://github.com/Beingpax/VoiceInk) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adding talat to Voice-to-Text. It's an on-device meeting recorder and transcriber; the closest existing entry is probably buzz, which already lives in this section, so it felt like the right home (the rest of the section skews dictation, but buzz is the precedent for non-dictation transcribers landing here).

Slotted alphabetically between Spokenly and Tambourine. It's a paid, closed-source app, so I've left the icons off to match the convention used elsewhere.

Happy to move it to Audio and Video Tools instead if you'd rather; either fits.

Cheers,
Nick