### PR TITLE
Add StackWM to Window Management section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1394,6 +1394,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Dockit](https://dockit-docs.pages.dev) - An application that can dock any window to the edge of the screen. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/XiCheng148/Dockit)
 * [Dissolv](https://www.7sols.com/dissolv/) - Hide and close inactive apps. [![App Store][app-store Icon]](https://apps.apple.com/app/dissolv/id1640893012?platform=mac)
 * [Divvy](http://mizage.com/divvy/) - Window management at its finest with its amazing Divvy Grid system.
+* [StackWM](https://www.stackwm.org) - Window manager with workspace memory. Named zones, per-zone stacks, and one-key scene switching for ultrawide and multi-display users. 7-day free trial.
 * [Hummingbird](https://finestructure.co/hummingbird) - Easily move and resize windows without mouse clicks, from anywhere within a window.  [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/finestructure/Hummingbird)
 * [IntelliDock](https://mightymac.app/intellidock/) - Hides the Dock, Automatically.
 * [JankyBorders](https://github.com/FelixKratz/JankyBorders) - A lightweight window border system for macOS. [![Open-Source Software][OSS Icon]](https://github.com/FelixKratz/JankyBorders) ![Freeware][Freeware Icon]


### PR DESCRIPTION
StackWM is a macOS window manager built on a physical desk metaphor.

- Named zones with persistent window positions
- Per-zone window stacks with hotkey cycling
- Scene-based workspace switching
- Multi-display support
- 7-day free trial, one-time purchase $19-$49

https://www.stackwm.org