### PR TITLE
Add schlonk-pad to Download Management Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -966,6 +966,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Motrix](https://motrix.app/) - Download manager for HTTP, FTP, BitTorrent, magnet links, and more. [![Open-Source Software][OSS Icon]](https://github.com/agalwood/Motrix) ![Freeware][Freeware Icon]
 * [Neat Download Manager](https://www.neatdownloadmanager.com/) - Lightweight download manager with an optimized transfer engine. ![Freeware][Freeware Icon]
 * [qBittorrent](https://www.qbittorrent.org/) - A project aims to provide an open-source software alternative to µTorrent. [![Open-Source Software][OSS Icon]](https://github.com/qbittorrent/qBittorrent) ![Freeware][Freeware Icon]
+* [schlonk-pad](https://github.com/crux/schlonk-pad) - Native macOS GUI for grabbing videos from Bluesky, X, TikTok, LinkedIn, and Facebook posts. Drag the result into any chat app. [![Open-Source Software][OSS Icon]](https://github.com/crux/schlonk-pad) ![Freeware][Freeware Icon]
 * [Shuttle](https://fiplab.com/apps/download-shuttle-for-mac) - Easy Download Manager for any links.
 * [Swads](https://swads.app/) - Synology Download Station Client, modern, native, and intuitively redesign.
 * [Transmission](https://www.transmissionbt.com/) - Fast, easy, free BitTorrent Client. [![Open-Source Software][OSS Icon]](https://github.com/transmission/transmission) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds [schlonk-pad](https://github.com/crux/schlonk-pad), a native macOS GUI for grabbing videos from Bluesky, X, TikTok, LinkedIn, and Facebook posts. Wraps yt-dlp under the hood; the UX is built around drag-out — paste a URL, wait for the download, drag the result into any chat app or file destination.

- GitHub: https://github.com/crux/schlonk-pad
- License: MIT
- macOS 13+, universal binary (Apple Silicon + Intel)
- Distributed via Homebrew Cask and direct DMG