### PR TITLE
Add Brewfile to Package Managers section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1555,6 +1555,7 @@ If you come across websites offering pirated software or cracks, please post [HE
 *Here are some of the major software download sites, there are a number of OSX Mac software sites*
 
 * [Applite](https://aerolite.dev/applite) - User-friendly GUI app for Homebrew Casks. Install, update, and uninstall apps with a single click. ![Freeware][Freeware Icon] [![Open-Source Software][OSS Icon]](https://github.com/milanvarady/Applite)
+* [Brewfile](https://github.com/marchenkovit/Brewfile) - Idempotent one-command MacBook setup script — Homebrew packages, Oh My Zsh, AWS/git/VS Code configs, macOS defaults, and EKS kubectl. Skips apps already installed manually. ![Freeware][Freeware Icon] [![Open-Source Software][OSS Icon]](https://github.com/marchenkovit/Brewfile)
 * [Cork](https://corkmac.app) - An intuitive and complete Homebrew GUI written in SwiftUI that supports all Homebrew features. [![Open-Source Software][OSS Icon]](https://github.com/buresdv/cork)
 * [Homebrew](https://brew.sh/) - The missing package manager for macOS. ![Freeware][Freeware Icon] [![Open-Source Software][OSS Icon]](https://github.com/Homebrew/brew/)
 * [MacPorts](https://www.macports.org/) - Package manager for installing and maintaining open-source software. ![Freeware][Freeware Icon] [![Open-Source Software][OSS Icon]](https://github.com/macports/)


### PR DESCRIPTION
## What

Adds [marchenkovit/Brewfile](https://github.com/marchenkovit/Brewfile) to the **Package Managers** section, next to Applite / Cork / Homebrew.

## Why this fits Package Managers

It's a Homebrew-centric setup tool: bundles `Brewfile` (brew bundle format) with an idempotent `install.sh` orchestrator. Sits in the same niche as Applite (Homebrew GUI) and Cork (Homebrew GUI) — but command-line and aimed at reproducible setups.

## What it does

- Installs all packages from `Brewfile` (brews, casks, VS Code extensions)
- Configures Oh My Zsh, AWS CLI, git, VS Code, Claude Code
- Applies macOS defaults (`defaults write ...`)
- Configures kubectl contexts for EKS
- **Idempotent**: detects already-installed apps via `/Applications/<app>.app` and `pkgutil --pkgs` (with wildcard support for `.pkg` casks like `org.virtualbox.pkg.*`), so it's safe to re-run

## Checklist

- [x] Alphabetical order in section (Applite → **Brewfile** → Cork)
- [x] Format matches existing entries (icons, description style)
- [x] Open-source with MIT LICENSE
- [x] Active development, has releases, CI, docs site (https://marchenkovit.github.io/Brewfile/)