### PR TITLE
Add Clipy (free screen recorder) to Screen Recording

### DIFF
--- a/README.md
+++ b/README.md
@@ -707,6 +707,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [BetterCapture](https://jsattler.github.io/BetterCapture/) - Free and open source screen recorder with professional encoding support. [![Open-Source Software][OSS Icon]](https://github.com/jsattler/BetterCapture) ![Freeware][Freeware Icon]
 * [Capty](https://capty.app/) - Screen capture and recording tool with built-in editing and annotations.
 * [Capso](https://github.com/lzhgus/Capso) - Open-source screenshot and screen recording tool with annotations, OCR, and webcam overlays. [![Open-Source Software][OSS Icon]](https://github.com/lzhgus/Capso) ![Freeware][Freeware Icon]
+* [Clipy](https://clipy.online/) - Free, no-watermark screen recorder for macOS, Chrome, and web. A Loom alternative: record, stop, and get an instant shareable link. Viewers need no account or app. ![Freeware][Freeware Icon]
 * [Gifox](https://gifox.app) - Gif Recording and Sharing.
 * [Kap](https://getkap.co/) - Open-source screen-recorder built with web technology. [![Open-Source Software][OSS Icon]](https://github.com/wulkano/kap) ![Freeware][Freeware Icon]
 * [KeyCastr](https://github.com/keycastr/keycastr) - KeyCastr, an open-source keystroke visualizer. [![Open-Source Software][OSS Icon]](https://github.com/keycastr/keycastr) ![Freeware][Freeware Icon]


### PR DESCRIPTION
### Types of Changes

- [x] New addition to list

### Proposed Changes

1. Add **Clipy** to the **Screen Recording** section. Clipy is a free, no-watermark screen recorder for macOS (native menu-bar app), Chrome, and web — a Loom alternative. Record, stop, and an instant shareable link is copied to the clipboard; viewers need no account, app, or extension. Homepage: https://clipy.online/

Note: This is a different product from the existing `Clipy` (clipy-app.com) clipboard manager listed under Clipboard Tools — this one is a screen recorder at clipy.online, placed alphabetically in the Screen Recording section.