### PR TITLE
Add AI Memory Reader to Markdown Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 
 ### Markdown Tools [![Awesome List][awesome-list Icon]](https://github.com/BubuAnabelas/awesome-markdown#tools)
 
+* [AI Memory Reader](https://github.com/nvwalj/ai-memory-reader) - Native macOS & iOS app for browsing AI agent memory files, auto-detects Claude Code, OpenClaw, Codex, Cursor, Gemini directories. [![Open-Source Software][OSS Icon]](https://github.com/nvwalj/ai-memory-reader) ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [Archimedes](https://furnacecreek.org/archimedes/) - Native macOS Markdown editor geared toward mathematical writing with inline LaTeX support.
 * [EME](https://github.com/egoist/eme) - Open-source Markdown editor with an interface like Chrome. ![Open-Source Software][OSS Icon]
 * [iA Writer](https://ia.net/writer/) - Writing app with an emphasis on simplicity and design.


### PR DESCRIPTION
Adding [AI Memory Reader](https://github.com/nvwalj/ai-memory-reader) to the **Markdown Tools** section.

**What it is:** Native macOS & iOS app for browsing and editing AI agent memory files (CLAUDE.md, AGENTS.md, GEMINI.md, etc.). Auto-detects directories for Claude Code, OpenClaw, Codex, Cursor, Gemini, Continue, Aider, and GitHub Copilot.

**Why it fits Markdown Tools:** It's a markdown viewer/editor purpose-built for AI agent memory files — similar in spirit to Pixley Reader (which is already in this section) but with broader auto-discovery of AI tool memory directories. Built with SwiftUI + MarkdownUI for GitHub-style rendering.

**Compliance with contribution guidelines:**
- ✅ Checked for duplicates (not present in list)
- ✅ Useful and unique (no other entry covers AI agent memory specifically)
- ✅ Format follows existing convention (`* [Name](url) - one-sentence description.`)
- ✅ Alphabetical order (placed before "Archimedes")
- ✅ Open source (GPL-3.0), free, native macOS app

Repo: https://github.com/nvwalj/ai-memory-reader (v0.4.0 with downloadable universal binary on Releases)