### PR TITLE
Add Noxen to Security Tools

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1084,6 +1084,7 @@ Awesome Mac
 * [MakLock](https://github.com/dutkiewiczmaciej/MakLock) - Touch ID、Apple Watch、またはパスワードで任意のmacOSアプリをロックし、全モニターにぼかしオーバーレイを表示するツール。 [![Open-Source Software][OSS Icon]](https://github.com/dutkiewiczmaciej/MakLock) ![Freeware][Freeware Icon]
 * [MalwareBytes](https://www.malwarebytes.com/mac-download/) - マルウェアを検出・除去するセキュリティツール。 ![Freeware][Freeware Icon]
 * [Mana Security](https://www.manasecurity.com/) - 個人向けの脆弱性管理アプリ。 [![Open-Source Software][OSS Icon]](https://github.com/manasecurity/mana-security-app)
+* [Noxen](https://noxen.app/) - SSH で管理する Linux サーバー群向けの Mac ネイティブな脆弱性スキャナー。エージェントレス CVE マッチング、公開管理画面の検出、スケジュールスキャンに対応。 ![Freeware][Freeware Icon]
 * [NoxKey](https://github.com/No-Box-Dev/Noxkey) - キーチェーンとTouch IDでAPIキーやトークンを管理するツール。 [![Open-Source Software][OSS Icon]](https://github.com/No-Box-Dev/Noxkey) ![Freeware][Freeware Icon]
 * [Vulert](https://vulert.com) - オープンソース依存関係の脆弱性を監視するサービス。
 * [OverSight](https://objective-see.com/products/oversight.html) - マイクとWebカメラのアクセスを監視するツール。 [![Open-Source Software][OSS Icon]](https://github.com/objective-see/OverSight) ![Freeware][Freeware Icon]

--- a/README-ko.md
+++ b/README-ko.md
@@ -809,6 +809,7 @@ Awesome Mac
 * [LuLu](https://objective-see.com/products/lulu.html) - 무단 네트워크 트래픽을 차단하는 무료 방화벽. [![Open-Source Software][OSS Icon]](https://github.com/objective-see/LuLu) ![Freeware][Freeware Icon]
 * [MakLock](https://github.com/dutkiewiczmaciej/MakLock) - Touch ID, Apple Watch 또는 비밀번호로 원하는 macOS 앱을 잠그고 모든 모니터에 블러 오버레이를 표시하는 도구. [![Open-Source Software][OSS Icon]](https://github.com/dutkiewiczmaciej/MakLock) ![Freeware][Freeware Icon]
 * [MalwareBytes](https://www.malwarebytes.com/mac-download/) - 악성코드를 검사하고 제거하는 보안 도구. ![Freeware][Freeware Icon]
+* [Noxen](https://noxen.app/) - SSH로 관리되는 Linux 서버 플릿을 위한 Mac 네이티브 취약점 스캐너. 에이전트리스 CVE 매칭, 노출된 관리 인터페이스 탐지, 예약 스캔을 지원합니다. ![Freeware][Freeware Icon]
 * [NoxKey](https://github.com/No-Box-Dev/Noxkey) - 키체인과 Touch ID로 API 키와 토큰을 관리하는 도구. [![Open-Source Software][OSS Icon]](https://github.com/No-Box-Dev/Noxkey) ![Freeware][Freeware Icon]
 * [OverSight](https://objective-see.com/products/oversight.html) - 마이크와 웹캠 접근을 감시하는 도구. ![Freeware][Freeware Icon]
 * [Santa](https://northpole.security/) - 바이너리와 파일 접근을 제어하는 권한 부여 시스템. [![Open-Source Software][OSS Icon]](https://github.com/northpolesec/santa) ![Native App][Native Icon]

--- a/README-zh.md
+++ b/README-zh.md
@@ -1027,6 +1027,7 @@ Awesome Mac
 * [Murus](https://www.murusfirewall.com/) - 强大、灵活且易于理解使用的防火墙，官方提供多种不同的APP以提供不同功能的组合。最基础的免费版本`Murus Lite`是纯粹基于传入端口的防火墙，跟基于应用程序的macOS原生防火墙形成有效互补。![Freeware][Freeware Icon]
 * [NoxKey](https://github.com/No-Box-Dev/Noxkey) - 一款通过钥匙串和 Touch ID 管理 API 密钥与令牌的工具。 [![Open-Source Software][OSS Icon]](https://github.com/No-Box-Dev/Noxkey) ![Freeware][Freeware Icon]
 * [MalwareBytes](https://www.malwarebytes.com/mac-download/) - 用于扫描和移除恶意软件的安全工具。 ![Freeware][Freeware Icon]
+* [Noxen](https://noxen.app/) - 面向通过 SSH 管理的 Linux 服务器集群的 Mac 原生漏洞扫描器。无代理 CVE 匹配、暴露管理界面检测、计划扫描。 ![Freeware][Freeware Icon]
 * [OverSight](https://objective-see.com/products/oversight.html) - 用于监控麦克风和摄像头访问的工具。 ![Freeware][Freeware Icon]
 * [RansomWhere?](https://objective-see.com/products/ransomwhere.html) - 通用 Ransomware 检测。
 * [Santa](https://northpole.security/) - 二进制与文件访问授权系统。 [![Open-Source Software][OSS Icon]](https://github.com/northpolesec/santa) ![Native App][Native Icon]

--- a/README.md
+++ b/README.md
@@ -1088,6 +1088,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [LuLu](https://objective-see.com/products/lulu.html) - LuLu is the free macOS firewall that aims to block unauthorized (outgoing) network traffic. [![Open-Source Software][OSS Icon]](https://github.com/objective-see/LuLu) [![Open-Source Software][OSS Icon]](1) ![Freeware][Freeware Icon]
 * [MalwareBytes](https://www.malwarebytes.com/mac-download/) - Malware scanner and removal tool. ![Freeware][Freeware Icon]
 * [Mana Security](https://www.manasecurity.com/) - vulnerability management app for individuals. [![Open-Source Software][OSS Icon]](https://github.com/manasecurity/mana-security-app)
+* [Noxen](https://noxen.app/) - Mac-native vulnerability scanner for SSH-managed Linux fleets. Agentless CVE matching, admin-surface detection, scheduled scans. ![Freeware][Freeware Icon]
 * [Vulert](https://vulert.com) - Dependency vulnerability monitoring service for open-source packages.
 * [NoxKey](https://github.com/No-Box-Dev/Noxkey) - Keychain-based secret manager for API keys and tokens with Touch ID. [![Open-Source Software][OSS Icon]](https://github.com/No-Box-Dev/Noxkey) ![Freeware][Freeware Icon]
 * [OverSight](https://objective-see.com/products/oversight.html) - Tool for monitoring microphone and webcam access. [![Open-Source Software][OSS Icon]](https://github.com/objective-see/OverSight) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds Noxen to the **Security Tools** section.

- **What:** Noxen is a Mac-native vulnerability scanner for SSH-managed Linux fleets. Agentless CVE matching against a signed daily feed, exposed-admin-surface detection (~70 services), TLS auditing, and scheduled background scans.
- **Homepage:** https://noxen.app/
- **Distribution:** Notarised Developer ID direct download (Sparkle auto-update), universal binary (Apple Silicon + Intel), macOS 26+. 14-day full-feature trial; permanent free tier covers 3 hosts.
- **Why this list:** Fits alongside existing entries like Mana Security and Vulert in the same section — Mac-native, security-focused, end-user app.

### Compliance with docs/CONTRIBUTING.md

- [x] Searched for duplicates — no existing Noxen entry. (Note: there is an unrelated `NoxKey` app already listed; different product.)
- [x] Title-cased name format: ``[Noxen](https://noxen.app/)``.
- [x] Added in alphabetical position within Security Tools section (between Mana Security and OverSight in en, ja; near MalwareBytes in zh, ko which are partial translations).
- [x] Single sentence description, ≤ existing-entry length.
- [x] Synced across all four READMEs: README.md, README-zh.md, README-ja.md, README-ko.md, with translated descriptions (best-effort — happy to revise if the maintainer's `\$awesome-mac-maintainer` skill produces preferred phrasing).
- [x] No trailing whitespace; diff is 4 lines (one per README).

### Disclosure

Author submission. AI-assisted contribution (Claude) per the AI-assisted contributions section of CONTRIBUTING.md — followed the repository's category, ordering, wording, and multilingual sync rules manually rather than via the Codex skill.