### PR TITLE
Add Vibe Island to AI Tools

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -802,6 +802,7 @@ Awesome Mac
 * [Runtime](https://github.com/runtime-org/runtime) - AIタスクメイトでWebとオフィスツールをコントロール。
 * [TokenMeter](https://priyans-hu.github.io/tokenmeter/) - Claude Codeの使用量、レート制限、コスト、アクティビティのヒートマップを追跡するツール。 [![Open-Source Software][OSS Icon]](https://github.com/Priyans-hu/tokenmeter) ![Freeware][Freeware Icon]
 * [Usage4Claude](https://github.com/f-is-h/Usage4Claude) - Claudeの各種使用量上限をリアルタイムに監視できるツール。 [![Open-Source Software][OSS Icon]](https://github.com/f-is-h/Usage4Claude) ![Freeware][Freeware Icon]
+* [Vibe Island](https://vibeisland.app) - MacBook のノッチを Claude Code、Codex、Gemini、Cursor など 25 種類の AI コーディング CLI のコントロールパネルに変え、権限承認をノッチ内で処理し、通知から呼び出し元のターミナルへ復帰、プロバイダーごとの利用上限を表示します。 ![Native App][Native Icon]
 * [Jan](https://jan.ai/) - コンピューター上で完全にオフラインで動作するChatGPTのオープンソース代替。 [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/menloresearch/jan)
 * [Maestro](https://runmaestro.ai) - 仕様駆動ワークフローで複数のAIコーディングエージェントを連携させるツール。 [![Open-Source Software][OSS Icon]](https://github.com/pedramamini/Maestro)
 * [MiniClaw](https://github.com/augmentedmike/miniclaw-os) - 記憶機能と自動化機能を備えたローカルファーストの個人向けAIエージェント。 [![Open-Source Software][OSS Icon]](https://github.com/augmentedmike/miniclaw-os) ![Freeware][Freeware Icon]

--- a/README-ko.md
+++ b/README-ko.md
@@ -636,6 +636,7 @@ Awesome Mac
 * [Orchard](https://orchard.5km.tech/) - AI 어시스턴트를 Apple 앱에 연결하는 MCP 서버.
 * [TokenMeter](https://priyans-hu.github.io/tokenmeter/) - Claude Code 사용량, 속도 제한, 비용, 활동 히트맵을 추적하는 도구. [![Open-Source Software][OSS Icon]](https://github.com/Priyans-hu/tokenmeter) ![Freeware][Freeware Icon]
 * [Usage4Claude](https://github.com/f-is-h/Usage4Claude) - Claude의 다양한 사용량 한도를 실시간으로 모니터링하는 도구. [![Open-Source Software][OSS Icon]](https://github.com/f-is-h/Usage4Claude) ![Freeware][Freeware Icon]
+* [Vibe Island](https://vibeisland.app) - 맥북 노치를 Claude Code, Codex, Gemini, Cursor 등 25종 AI 코딩 CLI의 컨트롤 패널로 바꿔, 권한 요청을 노치에서 처리하고, 알림 클릭으로 호출한 터미널로 복귀하며, provider별 사용 한도를 표시합니다. ![Native App][Native Icon]
 * [Witsy](https://github.com/nbonamy/witsy) - 데스크톱 AI 어시스턴트 및 유니버설 MCP 클라이언트. [![Open-Source Software][OSS Icon]](https://github.com/nbonamy/witsy) ![Freeware][Freeware Icon]
 * [remio](https://www.remio.ai/?utm_source=github_list) - 개인 지식 기반으로 답변하는 로컬 우선 AI 채팅 클라이언트. [![Freeware][Freeware Icon]](https://www.remio.ai/?utm_source=github_list)
 * [Warden](https://karatsidhu.gumroad.com/l/warden) - 네이티브 Swift 기반 macOS 앱으로, 사용자 API 키로 여러 LLM 모델을 실행할 수 있습니다. [![Open-Source Software][OSS Icon]](https://github.com/SidhuK/WardenApp) ![Freeware][Freeware Icon]

--- a/README-zh.md
+++ b/README-zh.md
@@ -610,6 +610,7 @@ Awesome Mac
   [![Freeware][Freeware Icon]](https://www.remio.ai/?utm_source=github_list)
 * [TokenMeter](https://priyans-hu.github.io/tokenmeter/) - 跟踪 Claude Code 用量、速率限制、成本与活跃热力图的工具。 [![Open-Source Software][OSS Icon]](https://github.com/Priyans-hu/tokenmeter) ![Freeware][Freeware Icon]
 * [Usage4Claude](https://github.com/f-is-h/Usage4Claude) - 实时监控 Claude 各类用量配额的工具。 [![Open-Source Software][OSS Icon]](https://github.com/f-is-h/Usage4Claude) ![Freeware][Freeware Icon]
+* [Vibe Island](https://vibeisland.app) - 将 MacBook 刘海打造成 Claude Code、Codex、Gemini、Cursor 等 25 个 AI 编码 CLI 的控制面板，权限请求在刘海内处理，点通知跳回触发的终端窗口，每个 provider 的使用额度单独显示。 ![Native App][Native Icon]
 * [Warden](https://karatsidhu.gumroad.com/l/warden) - 原生 Swift 打造的 macOS 应用，可使用你的 API Key 运行多个大语言模型（LLM）。 [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/SidhuK/WardenApp)
 
 ## 通信

--- a/README.md
+++ b/README.md
@@ -804,6 +804,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Runtime](https://github.com/runtime-org/runtime) - AI taskmate and take control of the web & your office tools
 * [TokenMeter](https://priyans-hu.github.io/tokenmeter/) - Track Claude Code usage, rate limits, costs, and activity heatmaps. [![Open-Source Software][OSS Icon]](https://github.com/Priyans-hu/tokenmeter) ![Freeware][Freeware Icon]
 * [Usage4Claude](https://github.com/f-is-h/Usage4Claude) - Real-time monitoring of Claude usage quotas across time windows and plans. [![Open-Source Software][OSS Icon]](https://github.com/f-is-h/Usage4Claude) ![Freeware][Freeware Icon]
+* [Vibe Island](https://vibeisland.app) - Turns the MacBook notch into a control panel for Claude Code, Codex, Gemini, Cursor and 20+ other AI coding CLIs, with permission prompts handled in the notch, jump-back to the terminal pane that asked, and usage limits per provider. ![Native App][Native Icon]
 * [Jan](https://jan.ai/) - An open-source alternative to ChatGPT that runs entirely offline on your computer. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/menloresearch/jan)
 * [Maestro](https://runmaestro.ai) - Multi-agent AI coding tool with spec-driven workflows. [![Open-Source Software][OSS Icon]](https://github.com/pedramamini/Maestro)
 * [MiniClaw](https://miniclaw.bot) - Local-first personal AI agent with memory and automation tools. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/augmentedmike/miniclaw-os)


### PR DESCRIPTION
## Types of Changes

- [x] New addition to list
- [ ] Fixing bug in existing item in list
- [ ] Removing item from list
- [ ] Changing structure (organization) of list

## Proposed Changes

Adds [Vibe Island](https://vibeisland.app) to the **AI Tools** section.

Vibe Island is a native macOS app that turns the MacBook notch into a control panel for 25 AI coding CLIs (Claude Code, Codex, Gemini CLI, Cursor Agent, Droid, OpenCode, Copilot and others). Permission prompts surface in the notch with inline allow/deny, plan previews render with markdown, clicking a notification jumps back to the exact terminal pane or IDE split that triggered the prompt, and per-provider usage limits are shown alongside session status.

## PR Checklist

- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important
- [x] I have added necessary documentation (if appropriate)
- [x] Placed after Usage4Claude in the AI Tools section in all four locale READMEs
- [x] All four locale READMEs updated with native-language descriptions
