### PR TITLE
Add Macfax to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1134,6 +1134,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Dropshelf](https://pilotmoon.com/dropshelf/) - A drag and drop helper app for macOS. ![Freeware][Freeware Icon]
 * [Dropover](https://dropoverapp.com/) - Temporary shelf for collecting and moving dragged files, text, and links. [![App Store][app-store Icon]](https://apps.apple.com/us/app/dropover-easier-drag-drop/id1355679052?platform=mac)
 * [cmd+x](https://apps.apple.com/app/cmd-x/id6754665762?platform=mac) - Launch Activity Monitor with Ctrl+Opt+Delete, cut and move files in Finder with Cmd+X.
+* [Macfax](https://macfax.com) - Free Mac diagnostic that issues a signed report verifying Activation Lock, serial, and hardware spec before a private Mac sale. ![Freeware][Freeware Icon]
 
 ### Clipboard Tools
 


### PR DESCRIPTION
Adding Macfax under Utilities. Free Mac diagnostic that produces a signed verification report covering Activation Lock state, Apple Coverage, serial match, and hardware spec. Didn't see a sub-category that fit cleanly.