### PR TITLE
Add usage to AI Tools

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -789,6 +789,7 @@ Awesome Mac
 * [RecurseChat](https://recurse.chat) - カスタマイズ可能なローカルファーストのAIチャットアプリ。
 * [Runtime](https://github.com/runtime-org/runtime) - AIタスクメイトでWebとオフィスツールをコントロール。
 * [TokenMeter](https://priyans-hu.github.io/tokenmeter/) - Claude Codeの使用量、レート制限、コスト、アクティビティのヒートマップを追跡するツール。 [![Open-Source Software][OSS Icon]](https://github.com/Priyans-hu/tokenmeter) ![Freeware][Freeware Icon]
+* [usage](https://github.com/aqua5230/usage) - Claude Code と Codex のクォータ、トークン使用量、コストをメニューバーに表示。ローカルファイルのみを読み取り、Anthropic や OpenAI の API には一切アクセスしない。 [![Open-Source Software][OSS Icon]](https://github.com/aqua5230/usage) ![Freeware][Freeware Icon]
 * [Usage4Claude](https://github.com/f-is-h/Usage4Claude) - Claudeの各種使用量上限をリアルタイムに監視できるツール。 [![Open-Source Software][OSS Icon]](https://github.com/f-is-h/Usage4Claude) ![Freeware][Freeware Icon]
 * [Jan](https://jan.ai/) - コンピューター上で完全にオフラインで動作するChatGPTのオープンソース代替。 [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/menloresearch/jan)
 * [Maestro](https://runmaestro.ai) - 仕様駆動ワークフローで複数のAIコーディングエージェントを連携させるツール。 [![Open-Source Software][OSS Icon]](https://github.com/pedramamini/Maestro)

--- a/README-ja.md
+++ b/README-ja.md
@@ -789,7 +789,7 @@ Awesome Mac
 * [RecurseChat](https://recurse.chat) - カスタマイズ可能なローカルファーストのAIチャットアプリ。
 * [Runtime](https://github.com/runtime-org/runtime) - AIタスクメイトでWebとオフィスツールをコントロール。
 * [TokenMeter](https://priyans-hu.github.io/tokenmeter/) - Claude Codeの使用量、レート制限、コスト、アクティビティのヒートマップを追跡するツール。 [![Open-Source Software][OSS Icon]](https://github.com/Priyans-hu/tokenmeter) ![Freeware][Freeware Icon]
-* [usage](https://github.com/aqua5230/usage) - Claude Code と Codex のクォータ、トークン使用量、コストをメニューバーに表示。ローカルファイルのみを読み取り、Anthropic や OpenAI の API には一切アクセスしない。 [![Open-Source Software][OSS Icon]](https://github.com/aqua5230/usage) ![Freeware][Freeware Icon]
+* [usage](https://github.com/aqua5230/usage) - Claude Code、Codex、Antigravity のクォータ、トークン使用量、コストをメニューバーに表示。LLM API の呼び出しは一切行わない。 [![Open-Source Software][OSS Icon]](https://github.com/aqua5230/usage) ![Freeware][Freeware Icon]
 * [Usage4Claude](https://github.com/f-is-h/Usage4Claude) - Claudeの各種使用量上限をリアルタイムに監視できるツール。 [![Open-Source Software][OSS Icon]](https://github.com/f-is-h/Usage4Claude) ![Freeware][Freeware Icon]
 * [Jan](https://jan.ai/) - コンピューター上で完全にオフラインで動作するChatGPTのオープンソース代替。 [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/menloresearch/jan)
 * [Maestro](https://runmaestro.ai) - 仕様駆動ワークフローで複数のAIコーディングエージェントを連携させるツール。 [![Open-Source Software][OSS Icon]](https://github.com/pedramamini/Maestro)

--- a/README-ko.md
+++ b/README-ko.md
@@ -622,6 +622,7 @@ Awesome Mac
 * [MiniClaw](https://github.com/augmentedmike/miniclaw-os) - 메모리와 자동화 기능을 갖춘 로컬 우선 개인 AI 에이전트. [![Open-Source Software][OSS Icon]](https://github.com/augmentedmike/miniclaw-os) ![Freeware][Freeware Icon]
 * [Orchard](https://orchard.5km.tech/) - AI 어시스턴트를 Apple 앱에 연결하는 MCP 서버.
 * [TokenMeter](https://priyans-hu.github.io/tokenmeter/) - Claude Code 사용량, 속도 제한, 비용, 활동 히트맵을 추적하는 도구. [![Open-Source Software][OSS Icon]](https://github.com/Priyans-hu/tokenmeter) ![Freeware][Freeware Icon]
+* [usage](https://github.com/aqua5230/usage) - 메뉴 바에서 Claude Code와 Codex의 한도, 토큰 사용량, 비용을 보여주는 도구. 로컬 파일만 읽으며 Anthropic이나 OpenAI API는 전혀 호출하지 않습니다. [![Open-Source Software][OSS Icon]](https://github.com/aqua5230/usage) ![Freeware][Freeware Icon]
 * [Usage4Claude](https://github.com/f-is-h/Usage4Claude) - Claude의 다양한 사용량 한도를 실시간으로 모니터링하는 도구. [![Open-Source Software][OSS Icon]](https://github.com/f-is-h/Usage4Claude) ![Freeware][Freeware Icon]
 * [Witsy](https://github.com/nbonamy/witsy) - 데스크톱 AI 어시스턴트 및 유니버설 MCP 클라이언트. [![Open-Source Software][OSS Icon]](https://github.com/nbonamy/witsy) ![Freeware][Freeware Icon]
 * [remio](https://www.remio.ai/?utm_source=github_list) - 개인 지식 기반으로 답변하는 로컬 우선 AI 채팅 클라이언트. [![Freeware][Freeware Icon]](https://www.remio.ai/?utm_source=github_list)

--- a/README-ko.md
+++ b/README-ko.md
@@ -622,7 +622,7 @@ Awesome Mac
 * [MiniClaw](https://github.com/augmentedmike/miniclaw-os) - 메모리와 자동화 기능을 갖춘 로컬 우선 개인 AI 에이전트. [![Open-Source Software][OSS Icon]](https://github.com/augmentedmike/miniclaw-os) ![Freeware][Freeware Icon]
 * [Orchard](https://orchard.5km.tech/) - AI 어시스턴트를 Apple 앱에 연결하는 MCP 서버.
 * [TokenMeter](https://priyans-hu.github.io/tokenmeter/) - Claude Code 사용량, 속도 제한, 비용, 활동 히트맵을 추적하는 도구. [![Open-Source Software][OSS Icon]](https://github.com/Priyans-hu/tokenmeter) ![Freeware][Freeware Icon]
-* [usage](https://github.com/aqua5230/usage) - 메뉴 바에서 Claude Code와 Codex의 한도, 토큰 사용량, 비용을 보여주는 도구. 로컬 파일만 읽으며 Anthropic이나 OpenAI API는 전혀 호출하지 않습니다. [![Open-Source Software][OSS Icon]](https://github.com/aqua5230/usage) ![Freeware][Freeware Icon]
+* [usage](https://github.com/aqua5230/usage) - 메뉴 바에서 Claude Code, Codex, Antigravity의 한도, 토큰 사용량, 비용을 보여주는 도구. LLM API를 전혀 호출하지 않습니다. [![Open-Source Software][OSS Icon]](https://github.com/aqua5230/usage) ![Freeware][Freeware Icon]
 * [Usage4Claude](https://github.com/f-is-h/Usage4Claude) - Claude의 다양한 사용량 한도를 실시간으로 모니터링하는 도구. [![Open-Source Software][OSS Icon]](https://github.com/f-is-h/Usage4Claude) ![Freeware][Freeware Icon]
 * [Witsy](https://github.com/nbonamy/witsy) - 데스크톱 AI 어시스턴트 및 유니버설 MCP 클라이언트. [![Open-Source Software][OSS Icon]](https://github.com/nbonamy/witsy) ![Freeware][Freeware Icon]
 * [remio](https://www.remio.ai/?utm_source=github_list) - 개인 지식 기반으로 답변하는 로컬 우선 AI 채팅 클라이언트. [![Freeware][Freeware Icon]](https://www.remio.ai/?utm_source=github_list)

--- a/README-zh.md
+++ b/README-zh.md
@@ -598,6 +598,7 @@ Awesome Mac
 * [remio](https://www.remio.ai/?utm_source=github_list) - 基于个人知识库回答问题的本地优先 AI 聊天客户端。
   [![Freeware][Freeware Icon]](https://www.remio.ai/?utm_source=github_list)
 * [TokenMeter](https://priyans-hu.github.io/tokenmeter/) - 跟踪 Claude Code 用量、速率限制、成本与活跃热力图的工具。 [![Open-Source Software][OSS Icon]](https://github.com/Priyans-hu/tokenmeter) ![Freeware][Freeware Icon]
+* [usage](https://github.com/aqua5230/usage) - 菜单栏工具，实时显示 Claude Code 与 Codex 的额度、token 用量与花费。仅读取本地文件，不调用任何 Anthropic 或 OpenAI 接口。 [![Open-Source Software][OSS Icon]](https://github.com/aqua5230/usage) ![Freeware][Freeware Icon]
 * [Usage4Claude](https://github.com/f-is-h/Usage4Claude) - 实时监控 Claude 各类用量配额的工具。 [![Open-Source Software][OSS Icon]](https://github.com/f-is-h/Usage4Claude) ![Freeware][Freeware Icon]
 * [Warden](https://karatsidhu.gumroad.com/l/warden) - 原生 Swift 打造的 macOS 应用，可使用你的 API Key 运行多个大语言模型（LLM）。 [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/SidhuK/WardenApp)
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -598,7 +598,7 @@ Awesome Mac
 * [remio](https://www.remio.ai/?utm_source=github_list) - 基于个人知识库回答问题的本地优先 AI 聊天客户端。
   [![Freeware][Freeware Icon]](https://www.remio.ai/?utm_source=github_list)
 * [TokenMeter](https://priyans-hu.github.io/tokenmeter/) - 跟踪 Claude Code 用量、速率限制、成本与活跃热力图的工具。 [![Open-Source Software][OSS Icon]](https://github.com/Priyans-hu/tokenmeter) ![Freeware][Freeware Icon]
-* [usage](https://github.com/aqua5230/usage) - 菜单栏工具，实时显示 Claude Code 与 Codex 的额度、token 用量与花费。仅读取本地文件，不调用任何 Anthropic 或 OpenAI 接口。 [![Open-Source Software][OSS Icon]](https://github.com/aqua5230/usage) ![Freeware][Freeware Icon]
+* [usage](https://github.com/aqua5230/usage) - 菜单栏工具，实时显示 Claude Code、Codex 与 Antigravity 的额度、token 用量与花费。不调用任何 LLM API。 [![Open-Source Software][OSS Icon]](https://github.com/aqua5230/usage) ![Freeware][Freeware Icon]
 * [Usage4Claude](https://github.com/f-is-h/Usage4Claude) - 实时监控 Claude 各类用量配额的工具。 [![Open-Source Software][OSS Icon]](https://github.com/f-is-h/Usage4Claude) ![Freeware][Freeware Icon]
 * [Warden](https://karatsidhu.gumroad.com/l/warden) - 原生 Swift 打造的 macOS 应用，可使用你的 API Key 运行多个大语言模型（LLM）。 [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/SidhuK/WardenApp)
 

--- a/README.md
+++ b/README.md
@@ -791,6 +791,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [RecurseChat](https://recurse.chat) - Local-first AI chat app with customizable workflows.
 * [Runtime](https://github.com/runtime-org/runtime) - AI taskmate and take control of the web & your office tools
 * [TokenMeter](https://priyans-hu.github.io/tokenmeter/) - Track Claude Code usage, rate limits, costs, and activity heatmaps. [![Open-Source Software][OSS Icon]](https://github.com/Priyans-hu/tokenmeter) ![Freeware][Freeware Icon]
+* [usage](https://github.com/aqua5230/usage) - Menu bar tracker for Claude Code and Codex quota, tokens, and cost. Reads local files only, with zero Anthropic or OpenAI API calls. [![Open-Source Software][OSS Icon]](https://github.com/aqua5230/usage) ![Freeware][Freeware Icon]
 * [Usage4Claude](https://github.com/f-is-h/Usage4Claude) - Real-time monitoring of Claude usage quotas across time windows and plans. [![Open-Source Software][OSS Icon]](https://github.com/f-is-h/Usage4Claude) ![Freeware][Freeware Icon]
 * [Jan](https://jan.ai/) - An open-source alternative to ChatGPT that runs entirely offline on your computer. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/menloresearch/jan)
 * [Maestro](https://runmaestro.ai) - Multi-agent AI coding tool with spec-driven workflows. [![Open-Source Software][OSS Icon]](https://github.com/pedramamini/Maestro)

--- a/README.md
+++ b/README.md
@@ -791,7 +791,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [RecurseChat](https://recurse.chat) - Local-first AI chat app with customizable workflows.
 * [Runtime](https://github.com/runtime-org/runtime) - AI taskmate and take control of the web & your office tools
 * [TokenMeter](https://priyans-hu.github.io/tokenmeter/) - Track Claude Code usage, rate limits, costs, and activity heatmaps. [![Open-Source Software][OSS Icon]](https://github.com/Priyans-hu/tokenmeter) ![Freeware][Freeware Icon]
-* [usage](https://github.com/aqua5230/usage) - Menu bar tracker for Claude Code and Codex quota, tokens, and cost. Reads local files only, with zero Anthropic or OpenAI API calls. [![Open-Source Software][OSS Icon]](https://github.com/aqua5230/usage) ![Freeware][Freeware Icon]
+* [usage](https://github.com/aqua5230/usage) - Menu bar tracker for Claude Code, Codex, and Antigravity quota, tokens, and cost. No LLM API calls. [![Open-Source Software][OSS Icon]](https://github.com/aqua5230/usage) ![Freeware][Freeware Icon]
 * [Usage4Claude](https://github.com/f-is-h/Usage4Claude) - Real-time monitoring of Claude usage quotas across time windows and plans. [![Open-Source Software][OSS Icon]](https://github.com/f-is-h/Usage4Claude) ![Freeware][Freeware Icon]
 * [Jan](https://jan.ai/) - An open-source alternative to ChatGPT that runs entirely offline on your computer. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/menloresearch/jan)
 * [Maestro](https://runmaestro.ai) - Multi-agent AI coding tool with spec-driven workflows. [![Open-Source Software][OSS Icon]](https://github.com/pedramamini/Maestro)


### PR DESCRIPTION
Adding [usage](https://github.com/aqua5230/usage) — a macOS menu bar tracker for Claude Code and Codex quota / tokens / cost.

- **Category**: AI Tools (placed alphabetically after TokenMeter, before Usage4Claude, alongside similar tools like Claude Usage Monitor and CodexBar)
- **License**: AGPL-3.0
- **Open source / Freeware**: both icons applied

Entry added to all four language READMEs (en / zh / ja / ko) using parallel translations, following the conventions of neighboring entries.

Resource summary:
- Pins Claude Code (5-hour / 7-day) and Codex quota percentages to the macOS menu bar
- Expandable popover with per-project usage breakdown, daily token counts, and cost estimates
- Reads only local files (`~/.claude/usage-status.json` written by an installed statusLine hook + `~/.codex/sessions/*.jsonl`)
- Zero calls to Anthropic or OpenAI APIs
- AGPL-3.0