### PR TITLE
Add ModelStatus to AI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -795,6 +795,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Jan](https://jan.ai/) - An open-source alternative to ChatGPT that runs entirely offline on your computer. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/menloresearch/jan)
 * [Maestro](https://runmaestro.ai) - Multi-agent AI coding tool with spec-driven workflows. [![Open-Source Software][OSS Icon]](https://github.com/pedramamini/Maestro)
 * [MiniClaw](https://miniclaw.bot) - Local-first personal AI agent with memory and automation tools. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/augmentedmike/miniclaw-os)
+* [ModelStatus](https://github.com/lucasmullikin/ModelStatus) - macOS menu bar app for monitoring multiple local LLM servers (Ollama, LM Studio, vLLM, MLX, llama.cpp). Multi-instance, auto-provider-detect, LAN + Tailscale discovery, no telemetry. [![Open-Source Software][OSS Icon]](https://github.com/lucasmullikin/ModelStatus) ![Freeware][Freeware Icon]
 * [Orchard](https://orchard.5km.tech/) - MCP server that connects AI assistants to Apple apps.
 * [Witsy](https://github.com/nbonamy/witsy) - desktop AI assistant / universal MCP client. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/nbonamy/witsy)
 * [remio](https://www.remio.ai/?utm_source=github_list) - Local-first AI chat client that answers from your knowledge base.  [![Freeware][Freeware Icon]](https://www.remio.ai/?utm_source=github_list)


### PR DESCRIPTION
Adds ModelStatus to the AI Tools section.

ModelStatus is a free, open-source (MIT) macOS menu bar app for monitoring multiple local LLM servers — Ollama, LM Studio, vLLM, MLX, llama.cpp, and any OpenAI-compatible API. Multi-instance, auto-provider-detects each backend, LAN + Tailscale peer discovery. Pure Swift/AppKit, no dependencies, no telemetry, no account.

- Source: https://github.com/lucasmullikin/ModelStatus
- Install: `brew tap lucasmullikin/tap && brew install --cask modelstatus`
- License: MIT
- macOS 13+

No code change beyond the one-line addition.