### PR TITLE
Add usage to Menu Bar Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1220,6 +1220,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [TextSniper](https://textsniper.app/) - Simple yet powerful OCR app in your Menu Bar. Instantly copy and paste text from anywhere. [![App Store][app-store Icon]](https://apps.apple.com/app/id1528890965?platform=mac)
 * [Today](https://sindresorhus.com/today) - View today’s schedule and calendar events from the menu bar. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id6443714928?platform=mac)
 * [TomatoBar](https://github.com/ivoronin/TomatoBar) - World's neatest Pomodoro timer for macOS menu bar. [![Open-Source Software][OSS Icon]](https://github.com/ivoronin/TomatoBar) ![Freeware][Freeware Icon]
+* [usage](https://github.com/aqua5230/usage) - Pin Claude Code and Codex quota, tokens, and cost to your menu bar. Local-only, no API calls. [![Open-Source Software][OSS Icon]](https://github.com/aqua5230/usage) ![Freeware][Freeware Icon]
 * [UTC Time](https://sindresorhus.com/utc-time) - Show the time in UTC in the menu bar or a widget. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id1538245904?platform=mac)
 * [Vanilla](https://matthewpalmer.net/vanilla/) - Hide menu bar icons on your Mac. ![Freeware][Freeware Icon]
 * [Week Number](https://sindresorhus.com/week-number) - The current week number in your menu bar. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id6502579523?platform=mac)

--- a/README.md
+++ b/README.md
@@ -1220,7 +1220,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [TextSniper](https://textsniper.app/) - Simple yet powerful OCR app in your Menu Bar. Instantly copy and paste text from anywhere. [![App Store][app-store Icon]](https://apps.apple.com/app/id1528890965?platform=mac)
 * [Today](https://sindresorhus.com/today) - View today’s schedule and calendar events from the menu bar. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id6443714928?platform=mac)
 * [TomatoBar](https://github.com/ivoronin/TomatoBar) - World's neatest Pomodoro timer for macOS menu bar. [![Open-Source Software][OSS Icon]](https://github.com/ivoronin/TomatoBar) ![Freeware][Freeware Icon]
-* [usage](https://github.com/aqua5230/usage) - Pin Claude Code and Codex quota, tokens, and cost to your menu bar. Local-only, no API calls. [![Open-Source Software][OSS Icon]](https://github.com/aqua5230/usage) ![Freeware][Freeware Icon]
+* [usage](https://github.com/aqua5230/usage) - Pin Claude Code, Codex, and Antigravity quota, tokens, and cost to your menu bar. No LLM API calls. [![Open-Source Software][OSS Icon]](https://github.com/aqua5230/usage) ![Freeware][Freeware Icon]
 * [UTC Time](https://sindresorhus.com/utc-time) - Show the time in UTC in the menu bar or a widget. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id1538245904?platform=mac)
 * [Vanilla](https://matthewpalmer.net/vanilla/) - Hide menu bar icons on your Mac. ![Freeware][Freeware Icon]
 * [Week Number](https://sindresorhus.com/week-number) - The current week number in your menu bar. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id6502579523?platform=mac)


### PR DESCRIPTION
Adds [usage](https://github.com/aqua5230/usage), a native macOS menu bar app that pins Claude Code and Codex quota, tokens, and cost to your screen.

- 147 ⭐ as of submission, actively maintained (currently v0.11.17)
- Local-only: reads a statusLine hook (Claude Code) and JSONL session logs (Codex); no API calls
- Includes HTML reports, a TUI mode, and 9 themes
- AGPL-3.0, Python + PyObjC

Inserted in alphabetical order in the Menu Bar Tools section, between `TomatoBar` and `UTC Time`.