### PR TITLE
docs: add Hapo Ndani to AI tools lists

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -786,6 +786,7 @@ Awesome Mac
 * [Flock](https://github.com/Divagation/flock) - 1つのワークスペースで複数のClaude Codeとシェルセッションを並列実行できるターミナルマルチプレクサ。 [![Open-Source Software][OSS Icon]](https://github.com/Divagation/flock) ![Freeware][Freeware Icon]
 * [Fluent](https://fluentmac.app) - 各種アプリでモデルとコンテキストを使えるAIアシスタント。
 * [GroAsk](https://groask.com) - 選択したテキストをAIアシスタントやCLIエージェントに送れるメニューバーランチャー。
+* [Hapo Ndani](https://nibiashara.biz/ndani/) - 明示的なフォルダ権限、ジャーナリング、クラウドへのプロンプト送信なしを備えた Mac 向けプライベートローカル AI アプリ。 [![App Store][app-store Icon]](https://apps.apple.com/us/app/hapo-ndani/id6763682362?mt=12)
 * [RecurseChat](https://recurse.chat) - カスタマイズ可能なローカルファーストのAIチャットアプリ。
 * [Runtime](https://github.com/runtime-org/runtime) - AIタスクメイトでWebとオフィスツールをコントロール。
 * [TokenMeter](https://priyans-hu.github.io/tokenmeter/) - Claude Codeの使用量、レート制限、コスト、アクティビティのヒートマップを追跡するツール。 [![Open-Source Software][OSS Icon]](https://github.com/Priyans-hu/tokenmeter) ![Freeware][Freeware Icon]

--- a/README-ko.md
+++ b/README-ko.md
@@ -616,6 +616,7 @@ Awesome Mac
 * [Flock](https://github.com/Divagation/flock) - 하나의 작업 공간에서 여러 Claude Code와 셸 세션을 병렬로 실행하는 터미널 멀티플렉서. [![Open-Source Software][OSS Icon]](https://github.com/Divagation/flock) ![Freeware][Freeware Icon]
 * [Fluent](https://fluentmac.app) - 여러 앱에서 모델과 컨텍스트를 활용하는 AI 어시스턴트.
 * [GroAsk](https://groask.com) - 선택한 텍스트를 AI 어시스턴트와 CLI 에이전트로 보내는 메뉴 막대 런처.
+* [Hapo Ndani](https://nibiashara.biz/ndani/) - 명시적 폴더 권한, 저널링, 클라우드 프롬프트 로깅 없음에 초점을 맞춘 Mac용 프라이빗 로컬 AI 앱. [![App Store][app-store Icon]](https://apps.apple.com/us/app/hapo-ndani/id6763682362?mt=12)
 * [Jan](https://jan.ai/) - 완전히 오프라인으로 실행 가능한 ChatGPT 오픈 소스 대안. [![Open-Source Software][OSS Icon]](https://github.com/menloresearch/jan) ![Freeware][Freeware Icon]
 * [Maestro](https://runmaestro.ai) - 명세 기반 워크플로로 여러 AI 코딩 에이전트를 협업시키는 도구. [![Open-Source Software][OSS Icon]](https://github.com/pedramamini/Maestro)
 * [RecurseChat](https://recurse.chat) - 사용자화 가능한 로컬 우선 AI 채팅 앱.

--- a/README-zh.md
+++ b/README-zh.md
@@ -589,6 +589,7 @@ Awesome Mac
 * [Flock](https://github.com/Divagation/flock) - 可在同一工作区并行运行多个 Claude Code 与 Shell 会话的终端多路复用工具。 [![Open-Source Software][OSS Icon]](https://github.com/Divagation/flock) ![Freeware][Freeware Icon]
 * [Fluent](https://fluentmac.app) - 可在各类应用中调用模型和上下文的 AI 助手。
 * [GroAsk](https://groask.com) - 可将选中文本发送给 AI 助手和命令行 Agent 的菜单栏启动器。
+* [Hapo Ndani](https://nibiashara.biz/ndani/) - 面向 Mac 的私有本地 AI 应用，具备明确的文件夹权限、日记能力，并且不会将提示发送到云端。 [![App Store][app-store Icon]](https://apps.apple.com/us/app/hapo-ndani/id6763682362?mt=12)
 * [Jan](https://jan.ai/) - 开源的 ChatGPT 替代方案，可完全离线在你的电脑上运行。 [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/menloresearch/jan)
 * [Maestro](https://runmaestro.ai) - 采用规格驱动工作流的多 AI 编码代理协作工具。 [![Open-Source Software][OSS Icon]](https://github.com/pedramamini/Maestro)
 * [RecurseChat](https://recurse.chat) - 支持自定义工作流的本地优先 AI 聊天应用。

--- a/README.md
+++ b/README.md
@@ -788,6 +788,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Flock](https://github.com/Divagation/flock) - Terminal multiplexer for running multiple Claude Code and shell sessions in one workspace. [![Open-Source Software][OSS Icon]](https://github.com/Divagation/flock) ![Freeware][Freeware Icon]
 * [Fluent](https://fluentmac.app) - AI assistant that works across apps with model and context integration.
 * [GroAsk](https://groask.com) - Menu bar launcher that sends selected text to AI assistants and CLI agents.
+* [Hapo Ndani](https://nibiashara.biz/ndani/) - Private local AI app for Mac with explicit folder permissions, journaling, and no cloud prompt logging. [![App Store][app-store Icon]](https://apps.apple.com/us/app/hapo-ndani/id6763682362?mt=12)
 * [RecurseChat](https://recurse.chat) - Local-first AI chat app with customizable workflows.
 * [Runtime](https://github.com/runtime-org/runtime) - AI taskmate and take control of the web & your office tools
 * [TokenMeter](https://priyans-hu.github.io/tokenmeter/) - Track Claude Code usage, rate limits, costs, and activity heatmaps. [![Open-Source Software][OSS Icon]](https://github.com/Priyans-hu/tokenmeter) ![Freeware][Freeware Icon]


### PR DESCRIPTION
## Summary
- add Hapo Ndani to the AI Tools section
- include the product site and Mac App Store badge
- add matching entries to the English, Chinese, Japanese, and Korean readmes

## Why
Hapo Ndani is a native paid Mac app focused on local/private AI, which fits the existing AI Tools section and the repo's support for commercial macOS apps.