### PR TITLE
Add Markup to Markdown Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [MacDown](https://macdown.uranusjr.com/) - Open source Markdown editor for macOS with live preview and HTML/PDF export. [![Open-Source Software][OSS Icon]](https://github.com/MacDownApp/macdown) ![Freeware][Freeware Icon]
 * [Marked 2](http://marked2app.com/) - This is the Markdown preview with an elegant and powerful set of tools for all writers.
 * [MarkText](https://github.com/marktext/marktext) - Next generation markdown editor, running on platforms of MacOS Windows and Linux. [![Open-Source Software][OSS Icon]](https://github.com/marktext/marktext) ![Freeware][Freeware Icon]
+* [Markup](https://github.com/oratis/Markup) - Reader-first, native macOS Markdown editor: renders notes like a web page and edits on demand, with vault, backlinks, graph, and full-text search. [![Open-Source Software][OSS Icon]](https://github.com/oratis/Markup) ![Freeware][Freeware Icon]
 * [MarkViewer](https://markviewer.com) - Markdown viewer and editor for macOS with AI-assisted editing. ![Freeware][Freeware Icon]
 * [Marp](https://marp.app) - Markdown presentation writer with cross-platform support. [![Open-Source Software][OSS Icon]](https://github.com/marp-team/marp) ![Freeware][Freeware Icon]
 * [Marxico](https://marxi.co/) - Delicate Markdown editor for Evernote. Reliable storage and sync.


### PR DESCRIPTION
Adds **Markup** to the *Markdown Tools* section.

- **Repo:** https://github.com/oratis/Markup
- **What it is:** a free, open-source (MIT), native macOS Markdown editor built with Tauri.
- **Why it fits:** reader-first — renders Markdown like a clean web page by default and edits on demand; includes a vault with wikilinks/backlinks/graph and full-text search.

Placed alphabetically between `MarkText` and `MarkViewer`, with the open-source and freeware icons, matching the existing entry format.