### PR TITLE
Add Whisper by Remskill to Voice-to-Text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1024,6 +1024,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [TypeWhisper](https://www.typewhisper.com) - Local Whisper-based speech-to-text with a global hotkey. [![Open-Source Software][OSS Icon]](https://github.com/TypeWhisper/typewhisper-mac) ![Freeware][Freeware Icon]
 * [VoiceInk](https://tryvoiceink.com/) - Real-time speech-to-text app. [![Open-Source Software][OSS Icon]](https://github.com/Beingpax/VoiceInk) ![Freeware][Freeware Icon]
 * [Voxt](https://github.com/hehehai/voxt) - Hold-to-talk voice input tool with AI transcription rules per app and URL, and built-in translation. [![Open-Source Software][OSS Icon]](https://github.com/hehehai/voxt) ![Freeware][Freeware Icon]
+* [Whisper by Remskill](https://whisper.remskill.com) - Hotkey dictation that pastes polished text at your cursor in any app; transcribes offline with local Whisper/Parakeet or via OpenAI cloud. ![Freeware][Freeware Icon]
 * [Whispering](https://epicenter.md/whispering/) - Multi-provider speech-to-text with AI transformations and keyboard shortcuts. [![Open-Source Software][OSS Icon]](https://github.com/EpicenterHQ/epicenter/tree/main/apps/whispering) ![Freeware][Freeware Icon]
 * [Willow Voice](https://willowvoice.com/) - AI dictation with automatic editing, style-matching, and noise optimization.
 


### PR DESCRIPTION
Adds **Whisper by Remskill** — a hotkey voice-to-text app for macOS (Apple Silicon) with built-in real-time web search.

**Differentiator vs existing entries:** bundles local Whisper, local Parakeet (NVIDIA TDT), and cloud OpenAI in one app so users pick the engine per task. Built-in real-time web search lets you speak a question and get the answer pasted at the cursor — not just transcription.

- Homepage: https://whisper.remskill.com
- Platforms: macOS Apple Silicon + Windows
- Free for the entire local pipeline; Pro tier for cloud features

Disclosure: I'm the maintainer.