### PR TITLE
Add SlimSnap to Screenshot Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -699,6 +699,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Scap](https://wangchujiang.com/scap/) - Screenshot annotation and canvas tool with blur, mosaic, and watermark features. [![App Store][app-store Icon]](https://apps.apple.com/app/Scap/6758053530?platform=mac)
 * [Shottr](https://shottr.cc/) - Screen capture application with features like Scrolling capture, OCR and markup.
 * [Skitch](https://evernote.com/skitch/) - Screen capture application with a powerful annotation capabilities. ![Freeware][Freeware Icon]
+* [SlimSnap](https://slimsnap.ai/) - Turns annotated screenshots into structured JSON for terminal AI coding agents like Claude Code, Aider, and Codex CLI. About 700 tokens per capture instead of 8000 for the raw image. On-device OCR via Apple Vision. ![Freeware][Freeware Icon]
 * [Snip](http://snip.qq.com/) - Application for sharing captured images on QQ Mail. ![Freeware][Freeware Icon]
 * [Snipaste](https://www.snipaste.com) -  Simple but powerful snipping tool. ![Freeware][Freeware Icon]
 * [Teampaper Snap](http://teampaper.me/snap/) - Let your screenshots speak up. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/monosnap/id1199502670?platform=mac)


### PR DESCRIPTION
SlimSnap turns annotated screenshots into structured JSON for terminal AI coding agents (Claude Code, Aider, Codex CLI). About 700 tokens per capture vs ~8000 for a raw vision input. On-device OCR via Apple Vision, no cloud, no telemetry. Free, signed, notarized. https://slimsnap.ai

### Types of Changes

**What types of changes does your PR introduce?**

- [x] New addition to list
- [ ] Fixing bug in existing item in list
- [ ] Removing item from list
- [ ] Changing structure (organization) of list

### Proposed Changes

Adds SlimSnap to the Screenshot Tools section.

SlimSnap is a free Mac app that converts annotated screenshots into structured JSON for terminal AI coding agents like Claude Code, Aider, and Codex CLI. The differentiator vs the other entries in the Screenshot Tools section (Skitch, CleanShot X, Shottr, Scap, etc.) is the JSON export: a typical retina screenshot runs about 8000 vision tokens when pasted to an AI agent, while the same screen as SlimSnap JSON runs about 700 tokens. The JSON contains bounding boxes (normalized 0-1), OCR text, hex colors, and optional annotations with target_ref and intent fields. OCR runs on-device via Apple Vision; nothing leaves the machine.

The app is signed and Apple-notarized, free during launch, with the JSON schema (https://github.com/bickov/slimsnap-schema) and Claude Code skill (https://github.com/bickov/slimsnap-skill) both open MIT.

### PR Checklist

- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important
- [x] I have made sure the proposed addition has not been submitted before
- [x] All links work and point to the right destinations