### PR TITLE
Add Glance to Markdown Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 
 * [Archimedes](https://furnacecreek.org/archimedes/) - Native macOS Markdown editor geared toward mathematical writing with inline LaTeX support.
 * [EME](https://github.com/egoist/eme) - Open-source Markdown editor with an interface like Chrome. ![Open-Source Software][OSS Icon]
+* [Glance](https://glance.md/) - Native Markdown viewer and Quick Look extension with Mermaid and LaTeX. ![Freeware][Freeware Icon]
 * [iA Writer](https://ia.net/writer/) - Writing app with an emphasis on simplicity and design.
 * [LightPaper](https://getlightpaper.com/) - Simple, beautiful, yet powerful text editor for your Mac.
 * [MacDown](https://macdown.uranusjr.com/) - Open source Markdown editor for macOS with live preview and HTML/PDF export. [![Open-Source Software][OSS Icon]](https://github.com/MacDownApp/macdown) ![Freeware][Freeware Icon]


### PR DESCRIPTION
## Summary
Adds [Glance](https://glance.md/) — native macOS Markdown viewer with Quick Look extension.

- Swift/SwiftUI, ~8 MB, offline, no telemetry
- Finder Quick Look preview with Mermaid, LaTeX, and syntax-highlighted code
- Free download from glance.md

Placed alphabetically in Markdown Tools.