### PR TITLE
Add StayUp to System Related Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1510,6 +1510,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Sensei](https://sensei.app/) - Performance toolkit for monitoring, cleanup, and hardware diagnostics.
 * [Sleepr](https://sleepr.app/) - Sleepr brings back sleep timer on macOS. [![App Store][app-store Icon]](https://apps.apple.com/us/app/sleepr-app/id6465683427?platform=mac)
 * [Sloth](https://sveinbjorn.org/sloth/) - Shows all open files, directories, sockets, pipes and devices in use by all running processes. [![Open-Source Software][OSS Icon]](https://github.com/sveinbjornt/Sloth/) ![Freeware][Freeware Icon]
+* [StayUp](https://getstayup.app) - Keep your Mac awake on battery with the lid closed. [![Open-Source Software][OSS Icon]](https://github.com/NongKnot/StayUp) ![Freeware][Freeware Icon]
 * [SteerMouse](https://plentycom.jp/en/steermouse/) - Customize mouse buttons, wheel behavior, and cursor speed.
 * [SwiftQuit](https://github.com/onebadidea/swiftquit/) - Enables automatic quitting of macOS apps when closing their windows. [![Open-Source Software][OSS Icon]](https://github.com/onebadidea/swiftquit) ![Freeware][Freeware Icon]
 * [SwiftMTP](https://github.com/Neighbor-Z/SwiftMTP) - Open-source MTP device manager for browsing and transferring files between Mac and Android devices. [![Open-Source Software][OSS Icon]](https://github.com/Neighbor-Z/SwiftMTP) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adding **StayUp** alongside the other sleep/awake utilities (Amphetamine, KeepingYouAwake, Lungo).

- **What it is:** a free, open-source menu-bar app that keeps a Mac awake on **battery with the lid closed** — the Apple Silicon clamshell + battery case that `caffeinate`-based blockers can't cover.
- **Site:** https://getstayup.app
- **Source:** https://github.com/NongKnot/StayUp (MIT, no telemetry)

Placed alphabetically under `### System Related Tools`, formatted to match the existing OSS + Freeware entries.