### PR TITLE
Add Inscribe to Note-taking

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [FSNotes](https://fsnot.es/) - File System Notes is a modern notes manager, native on macOS and iOS. [![Open-Source Software][OSS Icon]](https://github.com/glushchenko/fsnotes) [![App Store][app-store Icon]](https://apps.apple.com/gb/app/fsnotes/id1277179284?platform=mac)
 * [Gooba](https://goobapp.com/) - Writing app and task manager with a simple and interactive design.
 * [Inkdrop](https://www.inkdrop.info/) - Notebook app for Markdown lovers built on top of Electron.
+* [Inscribe](https://get-inscribe.com) - Private, on-device AI transcription and note-taking that records meetings, lectures, and interviews 100% offline, with AI summaries, action items, and Q&A. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id6754086711?platform=mac)
 * [Joplin](https://joplinapp.org/) - Cross-platform open-source notepad with markdown support and to-do list management. [![Open-Source Software][OSS Icon]](https://github.com/laurent22/joplin) ![Freeware][Freeware Icon]
 * [Logseq](https://logseq.com/) - Privacy-first, open-source knowledge base. [![OSS][OSS Icon]](https://github.com/logseq/logseq) ![Freeware][Freeware Icon]
 * [MarginNote 4](https://marginnote.com/) - In-depth PDF and EPUB reading, learning, managing and note taking app.


### PR DESCRIPTION
### Types of Changes

**What types of changes does your PR introduce?** Put an x in all boxes that apply

- [x] New addition to list
- [ ] Fixing bug in existing item in list
- [ ] Removing item from list
- [ ] Changing structure (organization) of list

### Proposed Changes

**Describe each of your changes here to communicate to the maintainers why we should accept this pull request.**

1. Adds **Inscribe** to the **Note-taking** section, placed alphabetically between `Inkdrop` and `Joplin`.
2. Inscribe is a private, on-device AI transcription and note-taking app for macOS (and iPhone/iPad). It records and transcribes meetings, lectures, and interviews **100% offline** — audio never leaves the device, no cloud upload, no account — and adds AI summaries, automatic action items, and natural-language Q&A about your notes. It's a strong fit for the list's privacy-first note-taking apps (e.g., Standard Notes, Logseq), and offers something they don't: fully on-device transcription.
   - Website: https://get-inscribe.com
   - Mac App Store: https://apps.apple.com/app/id6754086711?platform=mac
   - Badges used: `Freeware` (free to use, with optional paid tiers) + `App Store`, following the existing format.

### PR Checklist

Put an x in the boxes once you've completed each step. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important
- [x] I have added necessary documentation (if appropriate)

### Further Comments

Single-item addition that follows the existing format, badge conventions, and alphabetical ordering of the Note-taking section. I searched existing/open PRs and didn't find a duplicate for Inscribe. Working links verified. Happy to adjust the description, section placement, or badges if you'd prefer.
