### PR TITLE
Add Helix (native macOS multi-pane terminal for Claude Code)

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,6 +604,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Command Book](https://commandbookapp.com) - A terminal companion for long-running terminal commands (freemium)
 * [electerm](https://electerm.github.io/electerm/) - Terminal, SSH, and SFTP client. [![Open-Source Software][OSS Icon]](https://github.com/electerm/electerm) ![Freeware][Freeware Icon]
 * [Ghostty](https://github.com/ghostty-org/ghostty) - Fast GPU-accelerated terminal emulator. [![Open-Source Software][OSS Icon]](https://github.com/ghostty-org/ghostty) ![Freeware][Freeware Icon]
+* [Helix](https://github.com/tomarai85/helix-releases) - Native macOS multi-pane terminal for running multiple Claude Code agents side by side. ![Freeware][Freeware Icon]
 * [hyper](https://hyper.is) - A terminal built on web technologies. [![Open-Source Software][OSS Icon]](https://github.com/zeit/hyper) ![Freeware][Freeware Icon]
 * [iTerm2](http://www.iterm2.com) - iTerm2 is an amazing terminal emulator for OS X. [![Open-Source Software][OSS Icon]](https://github.com/gnachman/iTerm2) ![Freeware][Freeware Icon]
 * [kitty](https://github.com/kovidgoyal/kitty) - A cross-platform, fast, feature full, GPU based terminal emulator. [![Open-Source Software][OSS Icon]](https://github.com/kovidgoyal/kitty) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds Helix to the **Terminal Apps** section (alphabetical, after Ghostty).

Helix is a native macOS terminal built for the Claude Code / agentic-coding workflow: several terminal panes plus a preview/browser pane in one window, so you can watch multiple agents work side by side, with panes + scrollback persisted across app restarts. Native (Swift/SwiftUI + SwiftTerm), free beta, macOS only.

- Repo / downloads: https://github.com/tomarai85/helix-releases

Freeware badge (closed-source). Thanks for maintaining the list!