### PR TITLE
Add Cluxo to Screen Recording

### DIFF
--- a/README.md
+++ b/README.md
@@ -713,6 +713,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [BetterCapture](https://jsattler.github.io/BetterCapture/) - Free and open source screen recorder with professional encoding support. [![Open-Source Software][OSS Icon]](https://github.com/jsattler/BetterCapture) ![Freeware][Freeware Icon]
 * [Capty](https://capty.app/) - Screen capture and recording tool with built-in editing and annotations.
 * [Capso](https://github.com/lzhgus/Capso) - Open-source screenshot and screen recording tool with annotations, OCR, and webcam overlays. [![Open-Source Software][OSS Icon]](https://github.com/lzhgus/Capso) ![Freeware][Freeware Icon]
+* [Cluxo](https://github.com/kykim79/Cluxo) - Highlights your mouse cursor for screencasts, presentations, and demos, with spotlight, magnifier, and keystroke overlay. [![Open-Source Software][OSS Icon]](https://github.com/kykim79/Cluxo) ![Freeware][Freeware Icon]
 * [Gifox](https://gifox.app) - Gif Recording and Sharing.
 * [Kap](https://getkap.co/) - Open-source screen-recorder built with web technology. [![Open-Source Software][OSS Icon]](https://github.com/wulkano/kap) ![Freeware][Freeware Icon]
 * [KeyCastr](https://github.com/keycastr/keycastr) - KeyCastr, an open-source keystroke visualizer. [![Open-Source Software][OSS Icon]](https://github.com/keycastr/keycastr) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds **Cluxo**, an open-source macOS app that highlights the mouse cursor for screencasts, presentations, and demos (cursor ring, spotlight, dim/highlight, magnifier, keystroke overlay, drawing mode). Similar in spirit to KeyCastr already listed in this section.

- Repo: https://github.com/kykim79/Cluxo
- License: MIT (open source) · Swift/SwiftUI · macOS 13+
- Install: `brew install --cask kykim79/tap/cluxo`

Added one entry under **Screen Recording**, alphabetical order, with Open-Source + Freeware badges per the existing format.