### PR TITLE
Add Dusty (open-source, allowlist-only disk cleaner) to Cleanup and Uninstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -1240,6 +1240,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Cleaner for Xcode](https://github.com/waylybaye/XcodeCleaner-SwiftUI) - Remove unwanted Xcode files. [![Open-Source Software][OSS Icon]](https://github.com/waylybaye/XcodeCleaner-SwiftUI) ![Freeware][Freeware Icon]
 * [ClearDisk](https://github.com/bysiber/cleardisk) - Visualize and clean developer caches to quickly reclaim disk space. [![Open-Source Software][OSS Icon]](https://github.com/bysiber/cleardisk) ![Freeware][Freeware Icon]
 * [DaisyDisk](https://daisydiskapp.com/) - Disk usage analyzer and cleaner.
+* [Dusty](https://github.com/yagcioglutoprak/dusty) - Menu bar disk cleaner that only deletes from a fixed allowlist and shows every path and size before removing it. [![Open-Source Software][OSS Icon]](https://github.com/yagcioglutoprak/dusty) ![Freeware][Freeware Icon]
 * [Mac Cache Cleaner](https://github.com/kaunteya/MacCacheCleaner) - Cache cleaner for Mac [![Open-Source Software][OSS Icon]](https://github.com/kaunteya/MacCacheCleaner) ![Freeware][Freeware Icon]
 * [MacSift](https://lcharvol.github.io/MacSift/) - Open-source disk cleaner that groups files by app and moves them to the Trash. [![Open-Source Software][OSS Icon]](https://github.com/Lcharvol/MacSift) ![Freeware][Freeware Icon]
 * [OmniDiskSweeper](https://www.omnigroup.com/more) - Scans files by size so you can quickly find space hogs. ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds Dusty, a free and open-source (MIT) macOS menu bar disk cleaner, to the Cleanup and Uninstall section.

It is allowlist-only: it can only delete from a fixed set of known-safe paths, shows every path and its size before acting, supports a dry run, can move to Trash with undo, and keeps a deletion log. No account, no telemetry. Signed and notarized, installable via Homebrew.

Repo: https://github.com/yagcioglutoprak/dusty

Kept the entry to a single line with the standard Open-Source and Freeware badges, placed alphabetically within Cleanup and Uninstall.
