### PR TITLE
Add ClipHistory — lightweight native macOS clipboard manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
     <img alt="ScreenSage Pro" width="400" src="https://jaywcjlove.github.io/sponsor/screensage.png">
   </a>
   <br>
-  <a href="https://screensage.pro/">ScreenSage Pro, recrd beautiful screen recordings in minutes on macOS</a>
+  <a href="https://screensage.pro/">ScreenSage Pro, record beautiful screen recordings in minutes on macOS</a>
   <br><br>
 
   <a href="https://ip.im/">

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
     <img alt="ScreenSage Pro" width="400" src="https://jaywcjlove.github.io/sponsor/screensage.png">
   </a>
   <br>
-  <a href="https://screensage.pro/">ScreenSage Pro, record beautiful screen recordings in minutes on macOS</a>
+  <a href="https://screensage.pro/">ScreenSage Pro, recrd beautiful screen recordings in minutes on macOS</a>
   <br><br>
 
   <a href="https://ip.im/">
@@ -1157,6 +1157,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [PasteBot](https://tapbots.com/pastebot/) - Powerful clipboard manager. [![App Store][app-store Icon]](https://apps.apple.com/us/app/pastebot/id1179623856?platform=mac)
 * [Pure Paste](https://sindresorhus.com/pure-paste) - Paste as plain text by default. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id1611378436?platform=mac)
 * [SaneClip](https://saneclip.com) - Clipboard manager with history, privacy protections, and sensitive data detection. [![Open-Source Software][OSS Icon]](https://github.com/sane-apps/SaneClip) ![Freeware][Freeware Icon]
+* [ClipHistory](https://weiykong.github.io/ClipHistory) - Lightweight native macOS clipboard manager. Instant hotkey popup, captures text & images, pin favourites, per-app privacy exclusions. [![Open-Source Software][OSS Icon]](https://github.com/weiykong/ClipHistory) ![Freeware][Freeware Icon]
 * [Flycut](https://github.com/TermiT/Flycut) - Clean and simple clipboard manager for developers. [![Open-Source Software][OSS Icon]](https://github.com/TermiT/Flycut) ![Freeware][Freeware Icon]
 * [Maccy](https://maccy.app/) - Lightweight clipboard manager for macOS. [![Open-Source Software][OSS Icon]](https://github.com/p0deje/Maccy) ![Freeware][Freeware Icon]
 * [OneClip](https://github.com/Wcowin/OneClip) - A simple and professional macOS clipboard manager. [![Open-Source Software][OSS Icon]](https://github.com/Wcowin/OneClip) ![Freeware][Freeware Icon]


### PR DESCRIPTION
### Types of Changes

- [x] New addition to list
### Proposed Changes

Adding **ClipHistory** to the Clipboard Tools section.

**What it is:** A lightweight, native macOS clipboard manager built with Swift + SwiftUI. ~1 MB binary, no Electron, no subscription.

**Key features:**
- Instant hotkey popup (⌥V, customisable) that appears at the cursor from any app
- - Captures text **and** images (screenshots, Finder copies, browser "Copy Image")
- - Search as you type
- - Pin favourites — they float to the top and are never evicted
- - Per-app privacy exclusions (e.g. password managers)
- - Launch at Login, persisted history
**Links:**
- Homepage: https://weiykong.github.io/ClipHistory
- - GitHub: https://github.com/weiykong/ClipHistory
- - License: MIT / Free