### PR TITLE
Add Editorio to Markdown tools lists

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -217,6 +217,7 @@ Awesome Mac
 
 * [Archimedes](https://furnacecreek.org/archimedes/) - インラインLaTeXをサポートした数学的記述向けのネイティブmacOS Markdownエディタ。
 * [EME](https://github.com/egoist/eme) - Chromeのようなインターフェースを持つオープンソースMarkdownエディタ。 ![Open-Source Software][OSS Icon]
+* [Editorio](https://apps.apple.com/br/app/editorio/id6759334075?l=en-GB&mt=12) - AppKitで構築された高速なネイティブMarkdownエディタ。左右分割のライブプレビューに対応。 ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/br/app/editorio/id6759334075?l=en-GB&mt=12)
 * [iA Writer](https://ia.net/writer/) - シンプルさとデザインを重視したライティングアプリ。
 * [LightPaper](https://getlightpaper.com/) - Mac用のシンプルで美しく、かつ強力なテキストエディタ。
 * [MacDown](https://macdown.uranusjr.com/) - ライブプレビューおよびHTML/PDF出力に対応した、macOS向けのオープンソースMarkdownエディタ。 [![Open-Source Software][OSS Icon]](https://github.com/MacDownApp/macdown) ![Freeware][Freeware Icon]

--- a/README-ko.md
+++ b/README-ko.md
@@ -192,6 +192,7 @@ Awesome Mac
 
 * [Archimedes](https://furnacecreek.org/archimedes/) - 인라인 LaTeX를 지원하는 수학 쓰기에 최적화된 마크다운 편집기.
 * [EME](https://github.com/egoist/eme) - Chrome과 같은 인터페이스를 가진 오픈 소스 마크다운 편집기. ![Open-Source Software][OSS Icon]
+* [Editorio](https://apps.apple.com/br/app/editorio/id6759334075?l=en-GB&mt=12) - AppKit으로 제작된 빠른 네이티브 마크다운 에디터로, 좌우 분할 라이브 미리보기를 지원합니다. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/br/app/editorio/id6759334075?l=en-GB&mt=12)
 * [iA Writer](https://ia.net/writer/) - 단순함과 디자인에 강조를 둔 쓰기 앱.
 * [LightPaper](https://getlightpaper.com/) - 단순하고 아름다우면서도 강력한 Mac용 텍스트 편집기.
 * [MacDown](https://macdown.uranusjr.com/) - 실시간 미리보기와 HTML/PDF 내보내기를 지원하는 macOS용 오픈 소스 마크다운 편집기. [![Open-Source Software][OSS Icon]](https://github.com/MacDownApp/macdown) ![Freeware][Freeware Icon]

--- a/README-zh.md
+++ b/README-zh.md
@@ -805,6 +805,7 @@ Awesome Mac
 * [Cmd Markdown](https://www.zybuluo.com/) - Cmd Markdown 编辑阅读器，支持实时同步预览，区分写作和阅读模式，支持在线存储，分享文稿网址。 ![Freeware][Freeware Icon]
 * [Effie](https://www.effie.co/) - 轻量级 Markdown 写作软件，支持大纲笔记和思维导图。![Freeware][Freeware Icon]
 * [EME](https://github.com/egoist/eme) - 一款 Markdown 编辑器，界面很像 Chrome 浏览器的界面，很简约。
+* [Editorio](https://apps.apple.com/br/app/editorio/id6759334075?l=en-GB&mt=12) - 基于 AppKit 的高速原生 Markdown 编辑器，支持左右分栏实时预览。 ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/br/app/editorio/id6759334075?l=en-GB&mt=12)
 * [iA Writer](https://ia.net/writer/) - Markdown 文本预览编辑，注重语法检查，专门为作家提供的编辑器。
 * [Joplin](https://joplinapp.org/) - 跨平台开源记事本，支持 Markdown 和待办事项管理。 [![Open-Source Software][OSS Icon]](https://github.com/laurent22/joplin) ![Freeware][Freeware Icon]
 * [LightPaper](https://getlightpaper.com/) - 简单的 Markdown 文本编辑器。

--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 
 * [Archimedes](https://furnacecreek.org/archimedes/) - Native macOS Markdown editor geared toward mathematical writing with inline LaTeX support.
 * [EME](https://github.com/egoist/eme) - Open-source Markdown editor with an interface like Chrome. ![Open-Source Software][OSS Icon]
+* [Editorio](https://apps.apple.com/br/app/editorio/id6759334075?l=en-GB&mt=12) - Fast native AppKit Markdown editor for Mac with live side-by-side preview. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/br/app/editorio/id6759334075?l=en-GB&mt=12)
 * [iA Writer](https://ia.net/writer/) - Writing app with an emphasis on simplicity and design.
 * [LightPaper](https://getlightpaper.com/) - Simple, beautiful, yet powerful text editor for your Mac.
 * [MacDown](https://macdown.uranusjr.com/) - Open source Markdown editor for macOS with live preview and HTML/PDF export. [![Open-Source Software][OSS Icon]](https://github.com/MacDownApp/macdown) ![Freeware][Freeware Icon]


### PR DESCRIPTION
   NOTE: I searched existing pull requests for "Editorio" and didn't find a similar PR.

   ### Types of Changes

   **What types of changes does your PR introduce?** Put an x in all boxes that apply

   - [x] New addition to list
   - [ ] Fixing bug in existing item in list
   - [ ] Removing item from list
   - [ ] Changing structure (organization) of list

   ### Proposed Changes

   **Describe each of your changes here to communicate to the maintainers why we should accept this pull request.**

   1. Added **Editorio** to the Markdown editors list in the main `README.md`.
   1. Added the same entry to localized lists: `README-ja.md`, `README-ko.md`, and `README-zh.md` for consistency across translations.
   1. Editorio is a native AppKit-based Markdown editor for macOS with side-by-side live preview, and is available on the App Store.

   ### PR Checklist

   Put an x in the boxes once you've completed each step. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

   - [x] I have read the CONTRIBUTING guide
   - [x] I have explained why this PR is important
   - [x] I have added necessary documentation (if appropriate)

   ### Further Comments

   This PR focuses on adding one new app entry and keeping the Markdown tools section aligned across the English, Japanese, Korean, and Chinese lists.
