### PR TITLE
Add Panels to Ebooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Kindle App](https://www.amazon.com/l/16571048011) - Amazon official reading app of kindle.
 * [Klib](http://klib.me/) - New way to manage highlights for Kindle and iBooks. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id1196268448?platform=mac)
 * [Koodo Reader](https://www.koodoreader.com/en) - All-in-one eBook reader supporting over 15 formats. ![Freeware][Freeware Icon] [![OSS][OSS Icon]](https://github.com/koodo-reader/koodo-reader)
+* [Panels](https://panels.app) - DRM-free comic reader for CBR, CBZ, CB7, PDF, and comic ePUB, with iCloud library sync across Mac and iOS. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/us/app/panels-comic-reader/id1236567663)
 * [Readest](https://github.com/readest/readest) - Open-source ebook reader with a clean interface and powerful reading tools. [![Open-Source Software][OSS Icon]](https://github.com/readest/readest) ![Freeware][Freeware Icon]
 * [ReadAny](https://codedogqby.github.io/ReadAny/) - AI-powered e-book reader with semantic search, chat, and note management. [![Open-Source Software][OSS Icon]](https://github.com/codedogQBY/ReadAny) ![Freeware][Freeware Icon]
 * [Scribus](https://www.scribus.net/) - Professional layout and publishing software. [![OSS][OSS Icon]](https://sourceforge.net/projects/scribus/) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds **Panels** (comic reader) to the Ebooks section, alongside peers like Simple Comic.

> [Panels](https://panels.app) - DRM-free comic reader for CBR, CBZ, CB7, PDF, and comic ePUB, with iCloud library sync across Mac and iOS. ![Freeware] [![App Store]]

- Inserted in alphabetical order (between Koodo Reader and Readest).
- One sentence description, title-cased name. Free to download with optional premium (Freeware badge), and on the Mac App Store (App Store badge). Closed-source, so no OSS badge.
- Disclosure: I'm the developer of Panels.

Single-app PR per the contributing guidelines.