### PR TITLE
Add CSV Quick Look — QuickLook extension for CSV/TSV files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1554,6 +1554,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 
 > [![Awesome List][awesome-list Icon]](https://github.com/sindresorhus/quick-look-plugins#readme)
 
+* [CSV Quick Look](https://github.com/adamorad/csv-quick-look) - QuickLook extension for CSV and TSV files — virtual scroll, sort, filter, dark mode. [![Open-Source Software][OSS Icon]](https://github.com/adamorad/csv-quick-look) ![Freeware][Freeware Icon]
 * [QLMarkdown](https://github.com/sbarex/QLMarkdown) - Quick Look extension for Markdown files. - ![Freeware][Freeware Icon] ![Open-Source Software][OSS Icon]
 * [FluxMarkdown](https://github.com/xykong/flux-markdown) - Quick Look extension for Markdown previews with Mermaid, KaTeX, GFM, TOC, and charts. [![Open-Source Software][OSS Icon]](https://github.com/xykong/flux-markdown) ![Freeware][Freeware Icon]
 * [markdown-quicklook](https://github.com/ruspg/markdown-quicklook) - Quick Look plugin for rendered Markdown previews with syntax highlighting. [![Open-Source Software][OSS Icon]](https://github.com/ruspg/markdown-quicklook) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds [CSV Quick Look](https://github.com/adamorad/csv-quick-look), a free open-source QuickLook extension for `.csv` and `.tsv` files.

The only existing plugin for this file type (quicklook-csv) broke when macOS Sequoia removed the `.qlgenerator` format. This is a modern replacement using the `.appex` extension format.

Features: virtual scroll (500k+ rows), column sort, live filter, auto-delimiter detection, dark mode. macOS 12+.

Install: `brew install --cask adamorad/tap/csv-quick-look`