### PR TITLE
Add Glyph to Markdown Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 
 * [Archimedes](https://furnacecreek.org/archimedes/) - Native macOS Markdown editor geared toward mathematical writing with inline LaTeX support.
 * [EME](https://github.com/egoist/eme) - Open-source Markdown editor with an interface like Chrome. ![Open-Source Software][OSS Icon]
+* [Glyph](https://github.com/hamidfzm/glyph) - Cross-platform Markdown viewer and editor with native styling, live preview, KaTeX math, Mermaid diagrams, and AI assistance. [![Open-Source Software][OSS Icon]](https://github.com/hamidfzm/glyph) ![Freeware][Freeware Icon]
 * [iA Writer](https://ia.net/writer/) - Writing app with an emphasis on simplicity and design.
 * [LightPaper](https://getlightpaper.com/) - Simple, beautiful, yet powerful text editor for your Mac.
 * [MacDown](https://macdown.uranusjr.com/) - Open source Markdown editor for macOS with live preview and HTML/PDF export. [![Open-Source Software][OSS Icon]](https://github.com/MacDownApp/macdown) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds **Glyph** to the **Markdown Tools** section, placed alphabetically (after EME, before iA Writer).

`* [Glyph](https://github.com/hamidfzm/glyph) - Cross-platform Markdown viewer and editor with native styling, live preview, KaTeX math, Mermaid diagrams, and AI assistance. [![Open-Source Software][OSS Icon]](https://github.com/hamidfzm/glyph) ![Freeware][Freeware Icon]`

Glyph is open source (MIT) and free, runs natively on macOS (also Windows/Linux), built with Tauri 2 + React 19. Open-Source and Freeware icons included; entry kept in alphabetical order.
