### PR TITLE
Add Ncored to Reading and Writing Tools (Others)

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [CHM Reader](http://www.hewbo.com/chm-reader.html) - Read Compiled HTML (.chm) documents on your Mac. ![Freeware][Freeware Icon]
 * [Chmox](http://chmox.sourceforge.net/) - Read CHM documents on your Mac. ![Freeware][Freeware Icon]
 * [Highlights](https://highlightsapp.net) - The PDF Reader for Research on Mac, iPad & iPhone. ![Freeware][Freeware Icon]
+* [Ncored](https://ncored.com/?utm_source=github&utm_medium=awesome-mac) - Fast PDF editor for large CAD and construction drawings, with markup, page management, and full-text search.
 * [PDF Auditor](https://pura-vida.in/apps/pdf-auditor/?utm_source=github&utm_medium=awesome-mac) - PDF inspection tool for analyzing metadata, structure, and security risks. [![App Store][app-store Icon]](https://apps.apple.com/app/apple-store/id6738956506?pt=127483661&ct=GitHub&mt=8&platform=mac)
 * [PDF Expert](https://pdfexpert.com/) - Read, annotate and edit PDFs, change text and images.
 * [PDF Pals](https://pdfpals.com) - Chat with PDF app for Mac. No file size limits!


### PR DESCRIPTION
### Add: Ncored (Reading and Writing Tools → Others)

Adds [Ncored](https://ncored.com/) alongside the other PDF editors in the Others section.

**What it is:** A desktop PDF editor for macOS (Apple Silicon) and Windows, focused on large CAD and construction drawings — fast scroll and zoom on heavy vector PDFs, markup and annotation, page management (rearrange, rotate, merge), and full-text search. Runs fully local, no cloud.

**Marker:** none (commercial app with a 14-day free trial; not freeware, open-source, or App Store), matching the other paid PDF editors here (PDF Expert, SwifDoo, PDFsail).

Placed alphabetically between Highlights and PDF Auditor. Single-line addition to `README.md`.

_Disclosure: I am the founder and maintainer._