### PR TITLE
Add Gantry

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,6 +537,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Docker](https://www.docker.com/) - Powerful, performs operating-system-level virtualization. [![Open-Source Software][OSS Icon]](https://github.com/docker) ![Freeware][Freeware Icon] [![Awesome List][awesome-list Icon]](https://github.com/veggiemonk/awesome-docker#readme)
 * [Cocoa-Way](https://github.com/J-x-Z/cocoa-way) - Wayland compositor for running Linux GUI apps without a virtual machine. [![Open-Source Software][OSS Icon]](https://github.com/J-x-Z/cocoa-way) ![Freeware][Freeware Icon]
 * [GhostVM](https://github.com/groundwater/GhostVM) - Virtualization tool for creating and managing isolated macOS virtual machine workspaces. ![Freeware][Freeware Icon]
+* [Gantry](https://getgantry.github.io/) - Native Docker management: containers, images, live logs and stats, exec terminal — for local and SSH hosts. [![Open-Source Software][OSS Icon]](https://github.com/getgantry/gantry) ![Freeware][Freeware Icon]
 * [MacVirtue](https://naden.co) - Run free and unlimited Virtual Machines on your Mac.
 * [Mocker](https://github.com/us/mocker) - Container manager built on Apple's Containerization framework. [![Open-Source Software][OSS Icon]](https://github.com/us/mocker) ![Freeware][Freeware Icon]
 * [Multipass](https://multipass.run/) - Ubuntu VMs on demand for any workstation. [![Open-Source Software][OSS Icon]](https://github.com/canonical/multipass)


### PR DESCRIPTION
Adds [Gantry](https://getgantry.github.io/) to Developer Tools → Virtualization (alphabetical order, after GhostVM).

Gantry is a free, MIT-licensed, fully native macOS app (SwiftUI, no Electron) for managing and monitoring Docker: containers, images, volumes, networks, live logs, stats charts, an exec terminal and a container file browser. It manages remote hosts over SSH exactly like `docker -H ssh://`, shows every host on one fleet dashboard, and includes App Intents (Shortcuts/Siri) plus a bundled MCP server for AI agents.

- Website: https://getgantry.github.io/
- Source: https://github.com/getgantry/gantry (MIT)