### PR TITLE
Add TopOff

### DIFF
--- a/README.md
+++ b/README.md
@@ -1230,6 +1230,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [TextSniper](https://textsniper.app/) - Simple yet powerful OCR app in your Menu Bar. Instantly copy and paste text from anywhere. [![App Store][app-store Icon]](https://apps.apple.com/app/id1528890965?platform=mac)
 * [Today](https://sindresorhus.com/today) - View today’s schedule and calendar events from the menu bar. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id6443714928?platform=mac)
 * [TomatoBar](https://github.com/ivoronin/TomatoBar) - World's neatest Pomodoro timer for macOS menu bar. [![Open-Source Software][OSS Icon]](https://github.com/ivoronin/TomatoBar) ![Freeware][Freeware Icon]
+* [TopOff](https://github.com/ihazgithub/TopOff) - Menu bar app for Homebrew — full beer mug when packages are fresh, half mug when it's time to refill. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/ihazgithub/TopOff)
 * [UTC Time](https://sindresorhus.com/utc-time) - Show the time in UTC in the menu bar or a widget. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id1538245904?platform=mac)
 * [Vanilla](https://matthewpalmer.net/vanilla/) - Hide menu bar icons on your Mac. ![Freeware][Freeware Icon]
 * [Week Number](https://sindresorhus.com/week-number) - The current week number in your menu bar. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id6502579523?platform=mac)


### PR DESCRIPTION
Adds TopOff to the Menu Bar Tools section.

TopOff is an open-source SwiftUI menu bar app that keeps macOS users' Homebrew packages up to date — full beer mug in the menu bar when packages are fresh, half mug when it's time to refill. Free, MIT licensed, signed and notarized, universal binary, macOS 14+.

Repo: https://github.com/ihazgithub/TopOff
