### PR TITLE
Add WinDock to Window Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1437,6 +1437,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Tiles](https://freemacsoft.net/tiles/) - Snap and rearrange windows with screen edges, shortcuts, or the menu bar. ![Freeware][Freeware Icon]
 * [Topit](https://github.com/lihaoyun6/Topit) - Pin any window to the top of your screen [![Open-Source Software][OSS Icon]](https://github.com/lihaoyun6/Topit) ![Freeware][Freeware Icon]
 * [Total Spaces](http://totalspaces.binaryage.com/) - Workspace manager with hotkeys and spatial overview.
+* [WinDock](https://github.com/Songhoonma/WinDock) - Menu-bar app that makes the Dock minimize or hide the active app when you re-click its icon, like the Windows taskbar. [![Open-Source Software][OSS Icon]](https://github.com/Songhoonma/WinDock) ![Freeware][Freeware Icon]
 * [yabai](https://github.com/koekeishiya/yabai) - Keyboard-driven tiling window manager. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/koekeishiya/yabai/wiki)
 
 ### Password Management


### PR DESCRIPTION
Adds **WinDock** to the Window Management section.

WinDock is a free, open-source (MIT), Apple-notarized menu-bar app that makes the macOS Dock behave like the Windows taskbar: re-click an app's Dock icon to minimize or hide it (the behavior macOS lacks). It also offers optional single-app focus and is multilingual (EN/KO/JA/ZH).

Repo: https://github.com/Songhoonma/WinDock

- [x] Entry added alphabetically in the Window Management section
- [x] Includes Open-Source Software and Freeware badges