### PR TITLE
Add Fluxlay to General Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1284,6 +1284,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Deskmark](https://apps.apple.com/app/Deskmark/6755948110?platform=mac) - Add watermarks to the desktop, ideal for recording videos. [![App Store][app-store Icon]](https://apps.apple.com/app/Deskmark/6755948110?platform=mac)
 * [Etcher](https://www.balena.io/etcher/) - Flash OS images to SD cards & USB drives, safely and easily. [![Open-Source Software][OSS Icon]](https://github.com/balena-io/etcher) ![Freeware][Freeware Icon]
 * [Equinox](https://github.com/rlxone/Equinox) - Create dynamic wallpapers for macOS. ![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/us/app/equinox-create-wallpaper/id1591510203?platform=mac)
+* [Fluxlay](https://fluxlay.com) - Live wallpaper app and marketplace; play animated wallpapers built with web tech, or create and sell your own with React. ![Freeware][Freeware Icon]
 * [HTTrack](http://www.httrack.com) - Useful tool for downloading a whole website and offline browsing. ![Freeware][Freeware Icon]
 * [Latest](https://github.com/mangerlahn/Latest) - A tiny app that checks if all your apps from any source are up to date. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/mangerlahn/Latest)
 * [Lungo](https://sindresorhus.com/lungo) - Prevent your Mac from going to sleep. [![App Store][app-store Icon]](https://apps.apple.com/us/app/lungo/id1263070803?platform=mac)


### PR DESCRIPTION
Added Fluxlay as a live wallpaper app and marketplace.

NOTE: A similar PR may already be submitted! Please search among the Pull request before creating one.

### Types of Changes

**What types of changes does your PR introduce?** Put an x in all boxes that apply

- [x] New addition to list
- [ ] Fixing bug in existing item in list
- [ ] Removing item from list
- [ ] Changing structure (organization) of list

### Proposed Changes

**Describe each of your changes here to communicate to the maintainers why we should accept this pull request.**

Adds **Fluxlay** to Utilities → General Tools (alphabetical order, between Equinox and HTTrack):

> `* [Fluxlay](https://fluxlay.com) - Live wallpaper app and marketplace; play animated wallpapers built
with web tech, or create and sell your own with React. ![Freeware][Freeware Icon]`

Why it should be added:

- The General Tools section already lists wallpaper apps (Plash, Equinox, Vidwall, WaifuX, lo-rain), and
Fluxlay covers a use case none of them do: a marketplace of animated/interactive live wallpapers built
with web tech (React/Vue components or video files), rendered with minimal resource usage and
auto-paused when an app goes fullscreen.
- The app is free to download and use (hence the Freeware icon; it is closed source, so no OSS icon).
- I searched existing PRs and issues — no prior Fluxlay submission.

### PR Checklist

Put an x in the boxes once you've completed each step. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important
- [x] I have added necessary documentation (if appropriate)

### Further Comments

Disclosure: I'm part of the Fluxlay team. Happy to adjust the entry wording, icons, or category to match
your guidelines.