### PR TITLE
Add Agent CLI Menu to AI Tools

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -771,6 +771,7 @@ Awesome Mac
 
 ## AIツール
 
+* [Agent CLI Menu](https://github.com/roypadina/AgentCliMenu) - Claude Code と Codex のセッションを起動・再開するための TUI とメニューバー ランチャー。過去セッションの全文ファジー検索に対応。 [![Open-Source Software][OSS Icon]](https://github.com/roypadina/AgentCliMenu) ![Freeware][Freeware Icon]
 * [Agenttrace](https://luoyuctl.github.io/agenttrace/) - AIコーディングエージェントのセッション、コスト、トークン、遅延、ツール失敗、健全性、差分を確認できるローカルファーストTUI。 [![Open-Source Software][OSS Icon]](https://github.com/luoyuctl/agenttrace) ![Freeware][Freeware Icon]
 * [AppleAi](https://www.theappleai.tech/) - メニューバーから1つのショートカットで複数のAIアシスタントにアクセス。 [![Open-Source Software][OSS Icon]](https://github.com/bunnysayzz/AppleAI)
 * [Apple On-Device OpenAI](https://github.com/gety-ai/apple-on-device-openai) - AppleのオンデバイスモデルをOpenAI互換APIとして公開するツール。 [![Open-Source Software][OSS Icon]](https://github.com/gety-ai/apple-on-device-openai) ![Freeware][Freeware Icon]

--- a/README-ko.md
+++ b/README-ko.md
@@ -601,6 +601,7 @@ Awesome Mac
 
 ## AI 도구
 
+* [Agent CLI Menu](https://github.com/roypadina/AgentCliMenu) - Claude Code와 Codex 세션을 시작하거나 재개하는 TUI 및 메뉴 막대 런처. 과거 세션의 전체 기록을 퍼지 검색할 수 있습니다. [![Open-Source Software][OSS Icon]](https://github.com/roypadina/AgentCliMenu) ![Freeware][Freeware Icon]
 * [Agenttrace](https://luoyuctl.github.io/agenttrace/) - AI 코딩 에이전트 세션, 비용, 토큰, 지연, 도구 실패, 상태, diff를 점검하는 로컬 우선 TUI. [![Open-Source Software][OSS Icon]](https://github.com/luoyuctl/agenttrace) ![Freeware][Freeware Icon]
 * [AppleAi](https://www.theappleai.tech/) - 메뉴바에서 여러 AI 어시스턴트 접근. [![Open-Source Software][OSS Icon]](https://github.com/bunnysayzz/AppleAI)
 * [Apple On-Device OpenAI](https://github.com/gety-ai/apple-on-device-openai) - Apple 온디바이스 모델을 OpenAI 호환 API 뒤에서 실행하는 도구. [![Open-Source Software][OSS Icon]](https://github.com/gety-ai/apple-on-device-openai) ![Freeware][Freeware Icon]

--- a/README-zh.md
+++ b/README-zh.md
@@ -574,6 +574,7 @@ Awesome Mac
 
 ## AI 工具
 
+* [Agent CLI Menu](https://github.com/roypadina/AgentCliMenu) - 用于启动或恢复 Claude Code 和 Codex 会话的 TUI 和菜单栏启动器，支持对历史会话进行全文模糊搜索。 [![Open-Source Software][OSS Icon]](https://github.com/roypadina/AgentCliMenu) ![Freeware][Freeware Icon]
 * [Agenttrace](https://luoyuctl.github.io/agenttrace/) - 本地优先的 TUI，可检查 AI 编程代理会话、成本、Token、延迟、工具失败、健康度和差异。 [![Open-Source Software][OSS Icon]](https://github.com/luoyuctl/agenttrace) ![Freeware][Freeware Icon]
 * [AppleAi](https://www.theappleai.tech/) - 一键快捷访问菜单栏中的多款 AI 助手。 [![Open-Source Software][OSS Icon]](https://github.com/bunnysayzz/AppleAI)
 * [Apple On-Device OpenAI](https://github.com/gety-ai/apple-on-device-openai) - 将 Apple 端侧模型封装为 OpenAI 兼容 API 的工具。 [![Open-Source Software][OSS Icon]](https://github.com/gety-ai/apple-on-device-openai) ![Freeware][Freeware Icon]

--- a/README.md
+++ b/README.md
@@ -772,6 +772,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 
 ## AI Tools
 
+* [Agent CLI Menu](https://github.com/roypadina/AgentCliMenu) - TUI and menu-bar launcher to start or resume Claude Code and Codex sessions, with full-transcript fuzzy search of past sessions. [![Open-Source Software][OSS Icon]](https://github.com/roypadina/AgentCliMenu) ![Freeware][Freeware Icon]
 * [Agenttrace](https://luoyuctl.github.io/agenttrace/) - Local-first TUI for inspecting AI coding agent sessions, costs, tokens, latency, tool failures, health, and diffs. [![Open-Source Software][OSS Icon]](https://github.com/luoyuctl/agenttrace) ![Freeware][Freeware Icon]
 * [AppleAi](https://www.theappleai.tech/) - Access multiple AI assistants from your menu bar with one shortcut. [![Open-Source Software][OSS Icon]](https://github.com/bunnysayzz/AppleAI)
 * [Apple On-Device OpenAI](https://github.com/gety-ai/apple-on-device-openai) - Runs Apple on-device models behind an OpenAI-compatible API. [![Open-Source Software][OSS Icon]](https://github.com/gety-ai/apple-on-device-openai) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds [Agent CLI Menu](https://github.com/roypadina/AgentCliMenu) to **AI Tools**, alphabetically (it sorts just above `Agenttrace`). Mirrored into all four READMEs (en / zh / ja / ko) with localized descriptions.

A free, open-source macOS TUI **and** menu-bar app to start or resume Claude Code / Codex coding-agent sessions: frecency project launcher, full-transcript fuzzy search of past sessions, inline transcript peek. MIT, `brew install --cask roypadina/tap/agentclimenu`.

- [x] One app, alphabetical order, description ends with a period
- [x] Open-Source + Freeware icons included
- [x] Searched for duplicates (none)
- [x] Disclosure: I'm the author