### PR TITLE
Add Git Menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,6 +515,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Cornerstone](http://www.zennaware.com/cornerstone/) - Powerful version control with a gorgeous interface.
 * [Fork](https://git-fork.com/) - Fast and friendly Git client for Mac.
 * [Git Cola](https://git-cola.github.io/) - Powerful, Fast, Lightweight and Friendly Git GUI. For those caffeine adicting users. ![Open-Source Software][OSS Icon]
+* [Git Menu](https://github.com/Artim-Nayas/git-menu) - Your GitHub PRs, reviews, inbox, and Actions in the menu bar, powered by the gh CLI. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/Artim-Nayas/git-menu)
 * [Gitbar](https://github.com/Shikkic/gitbar) - Open-source，display GitHub contribution statistics on your menu bar. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/Shikkic/gitbar)
 * [GitButler](https://gitbutler.com/) - Change management with parallel and stacked branches, unlimited undo, agent integrations. [![Open-Source Software][OSS Icon]](https://github.com/gitbutlerapp/gitbutler) ![Freeware][Freeware Icon]
 * [GitFinder](https://gitfinder.com/) - Fast and lightweight Git client for Mac with Finder integration.


### PR DESCRIPTION
Adds **[Git Menu](https://github.com/Artim-Nayas/git-menu)** to *Developer Tools → Version Control* (placed alphabetically between Git Cola and Gitbar).

Git Menu is a lightweight, open-source (MIT) macOS menu-bar app for your GitHub work — pull requests, review requests, a notifications inbox, GitHub Actions runs, and your contribution streak — powered entirely by the `gh` CLI. The repo has an English README with a screenshot/animated demo and ships a macOS binary (`.dmg` + Homebrew cask).

- Open source: https://github.com/Artim-Nayas/git-menu
- Marked Open-Source + Freeware, matching nearby entries (e.g. Gitbar).