### PR TITLE
Add Vuvuzela (Menu Bar Tools)

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -1242,6 +1242,7 @@ Awesome Mac
 * [SketchyBar](https://github.com/FelixKratz/SketchyBar) - A highly customizable macOS status bar replacement. [![Open-Source Software][OSS Icon]](https://github.com/FelixKratz/SketchyBar) ![Freeware][Freeware Icon]
 * [stats](https://github.com/exelban/stats) - 免费的 Mac 系统监视器，显示在菜单栏中。 [![Open-Source Software][OSS Icon]](https://github.com/exelban/stats) ![Freeware][Freeware Icon]
 * [Vanilla](https://matthewpalmer.net/vanilla/) - 隐藏系统菜单栏。 ![Freeware][Freeware Icon]
+* [Vuvuzela](https://github.com/bsnkhua/vuvuzela) - FIFA 世界杯 2026 桌面小组件：在菜单栏管理的可调节窗口中实时显示比赛成绩、积分榜与淘汰赛对阵。 [![Open-Source Software][OSS Icon]](https://github.com/bsnkhua/vuvuzela) ![Freeware][Freeware Icon]
 * [Xbar](https://xbarapp.com/) - 将任何脚本或程序的输出作为小工具放入 macOS 菜单栏(原 BitBar)[![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/matryer/xbar)
 
 ### 待办事项工具

--- a/README.md
+++ b/README.md
@@ -1234,6 +1234,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [TomatoBar](https://github.com/ivoronin/TomatoBar) - World's neatest Pomodoro timer for macOS menu bar. [![Open-Source Software][OSS Icon]](https://github.com/ivoronin/TomatoBar) ![Freeware][Freeware Icon]
 * [UTC Time](https://sindresorhus.com/utc-time) - Show the time in UTC in the menu bar or a widget. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id1538245904?platform=mac)
 * [Vanilla](https://matthewpalmer.net/vanilla/) - Hide menu bar icons on your Mac. ![Freeware][Freeware Icon]
+* [Vuvuzela](https://github.com/bsnkhua/vuvuzela) - FIFA World Cup 2026 desktop widget: live match scores, group standings, and knockout bracket in a resizable window managed from the menu bar. [![Open-Source Software][OSS Icon]](https://github.com/bsnkhua/vuvuzela) ![Freeware][Freeware Icon]
 * [Week Number](https://sindresorhus.com/week-number) - The current week number in your menu bar. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id6502579523?platform=mac)
 * [Work Hours](https://github.com/niteoweb/work-hours-mac) - Simple app that tracks your work hours from the menu bar. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/niteoweb/work-hours-mac)
 * [Xbar](https://xbarapp.com/) - Put the output from any script or program into your macOS Menu Bar (the BitBar reboot). [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/matryer/xbar)


### PR DESCRIPTION
Vuvuzela is a free, open-source (MIT) macOS desktop widget for FIFA World Cup 2026 that shows live match scores, group standings, and the knockout bracket in a resizable window managed from the menu bar.

- Repo: https://github.com/bsnkhua/vuvuzela
- Install: `brew install bsnkhua/tap/vuvuzela`

Added to both README.md and README-zh.md in alphabetical order (between Vanilla and Week Number / Xbar).