### PR TITLE
Add TurboWhisper - privacy-first dictation app for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1020,6 +1020,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Parakey](https://github.com/rcourtman/parakey) - Native push-to-talk local dictation app for Apple Silicon Macs using Parakeet TDT v3 (CoreML/ANE). [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/rcourtman/parakey)
 * [Spokenly](https://spokenly.app/) - Voice-to-text with 100+ languages, offline mode, and AI-powered formatting.
 * [Tambourine](https://tambourinevoice.com/) - Open-source, customizable AI voice dictation that works in any app. [![Open-Source Software][OSS Icon]](https://github.com/kstonekuan/tambourine-voice/) ![Freeware][Freeware Icon]
+* [TurboWhisper](https://turbowhisper.com) - Privacy-first dictation app for macOS with local-only processing, global hotkey control, system-wide input, and one-time pricing. No subscriptions, no account required.
 * [TypeWhisper](https://www.typewhisper.com) - Local Whisper-based speech-to-text with a global hotkey. [![Open-Source Software][OSS Icon]](https://github.com/TypeWhisper/typewhisper-mac) ![Freeware][Freeware Icon]
 * [VoiceInk](https://tryvoiceink.com/) - Real-time speech-to-text app. [![Open-Source Software][OSS Icon]](https://github.com/Beingpax/VoiceInk) ![Freeware][Freeware Icon]
 * [Voxt](https://github.com/hehehai/voxt) - Hold-to-talk voice input tool with AI transcription rules per app and URL, and built-in translation. [![Open-Source Software][OSS Icon]](https://github.com/hehehai/voxt) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adding [TurboWhisper](https://turbowhisper.com) to the Voice-to-Text section.

TurboWhisper is a macOS dictation app focused on privacy and speed:
- 100% local processing (voice never leaves your Mac)
- Global hotkey (⌘ Space) for system-wide input
- One-time pricing (no subscriptions)
- Cleans up filler words and awkward phrasing
- 30+ languages with automatic detection
- Works in any app including Cursor, Claude, ChatGPT, Notion, and terminal

It fits naturally in the Voice-to-Text section as a privacy-first alternative to subscription-based dictation tools.