### PR TITLE
Add pyimgtag to command-line-apps Media section

### DIFF
--- a/command-line-apps.md
+++ b/command-line-apps.md
@@ -97,6 +97,7 @@ A curated list of useful command line apps
 ## Media
 
 * [cmus](https://cmus.github.io/) - Small, fast and powerful console music player for Unix-like operating systems. [![Open-Source Software][OSS Icon]](https://github.com/cmus) ![Freeware][Freeware Icon]
+* [pyimgtag](https://github.com/kurok/pyimgtag) - Command-line photo tagger that uses a local vision model (local by default) to add searchable tags, scene categories, and EXIF-GPS-derived location to images, then lets you query, score, and clean up the library from the terminal. [![Open-Source Software][OSS Icon]](https://github.com/kurok/pyimgtag) ![Freeware][Freeware Icon]
 * [youtube-dl](https://ytdl-org.github.io/youtube-dl/) - Download videos from YouTube.com and a few more sites. [![Open-Source Software][OSS Icon]](https://github.com/ytdl-org/youtube-dl)
 
 ## Developer


### PR DESCRIPTION
## What is being added

[pyimgtag](https://github.com/kurok/pyimgtag) — a command-line photo tagger that uses a local vision model (Gemma via Ollama, local by default) to automatically add searchable tags, scene categories, and EXIF-GPS-derived location to images. Also supports remote Ollama servers and cloud vision backends (Anthropic/OpenAI/Google Gemini) via `--backend`. On macOS it reads and writes back to the Apple Photos library.

- PyPI: https://pypi.org/project/pyimgtag/
- License: MIT
- Language: Python 3.11–3.14
- Platforms: macOS, Linux, Windows

## Why it belongs here

It is a pure CLI tool with no GUI, which fits `command-line-apps.md`. The photo-tagging functionality is media-oriented, so the **Media** section is the most relevant category. Placed alphabetically between `cmus` and `youtube-dl`.

## Checklist

- [x] Single entry, one PR
- [x] Alphabetical order within section
- [x] Matches existing row format (`[![Open-Source Software][OSS Icon]]` + `![Freeware][Freeware Icon]`)
- [x] No trailing whitespace introduced
- [x] Description is one sentence, factually accurate, no overclaiming
- [x] Table of Contents not affected (no new section added)