### PR TITLE
Add Plan4Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1372,6 +1372,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [PaletteBrain](https://palettebrain.com) - Access the power of ChatGPT across all your Mac applications with the press of a shortcut.
 * [Pie Menu](https://www.pie-menu.com) – Control your tools with a radial menu customized for your active app.
 * [Perplexity](https://apps.apple.com/us/app/perplexity-ask-anything/id6714467650?platform=mac) - Search and discovery with AI.
+* [Plan4Projects](https://plan4projects.com) - Free, native Gantt charts and project planning; opens Microsoft Project (.mpp) files. ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [Pomodoro Cycle](https://github.com/jet8a/pomodoro-cycle-app) - Pomodoro tracker
 * [ProBoard](https://apps.apple.com/app/id6748314346?platform=mac) - Use one board to manage all your project information efficiently.[![App Store][app-store Icon]](https://apps.apple.com/app/id6748314346?platform=mac)
 * [Qbserve](https://qotoqot.com/qbserve/) - Automatic time tracking with projects, timesheets, and productivity insights.


### PR DESCRIPTION
Adds **Plan4Projects** to the Productivity section.

Plan4Projects is a free, native macOS app for Gantt charts and project planning — critical-path scheduling, resources and leveling, baselines — that opens Microsoft Project (.mpp) files and exports Project XML.

- Free (`![Freeware]`)
- Native macOS app (`![Native App]`), universal (Apple Silicon + Intel), signed & notarized by Apple
- Added alphabetically within the Productivity list
- Website: https://plan4projects.com

Thanks for maintaining this list!