### PR TITLE
Add ccline to Terminal Apps - AI-powered zsh command_not_found handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -603,6 +603,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 
 * [alacritty](https://github.com/jwilm/alacritty) - A cross-platform, GPU-accelerated terminal emulator. [![Open-Source Software][OSS Icon]](https://github.com/jwilm/alacritty) ![Freeware][Freeware Icon]
 * [Awal Terminal](https://github.com/AwalTerminal/Awal-terminal) - AI-native terminal emulator with multi-provider profiles and voice input. [![Open-Source Software][OSS Icon]](https://github.com/AwalTerminal/Awal-terminal) ![Freeware][Freeware Icon]
+* [ccline](https://github.com/jianshuo/ccline) - Type a thought at your zsh prompt — no command, no prefix — get an AI answer (Claude/Codex) and run any suggested commands from an interactive menu. [![Open-Source Software][OSS Icon]](https://github.com/jianshuo/ccline) ![Freeware][Freeware Icon]
 * [Command Book](https://commandbookapp.com) - A terminal companion for long-running terminal commands (freemium)
 * [electerm](https://electerm.github.io/electerm/) - Terminal, SSH, and SFTP client. [![Open-Source Software][OSS Icon]](https://github.com/electerm/electerm) ![Freeware][Freeware Icon]
 * [Ghostty](https://github.com/ghostty-org/ghostty) - Fast GPU-accelerated terminal emulator. [![Open-Source Software][OSS Icon]](https://github.com/ghostty-org/ghostty) ![Freeware][Freeware Icon]


### PR DESCRIPTION
## What does this add?

[ccline](https://github.com/jianshuo/ccline) — a zsh tool that hijacks `command_not_found_handler`. Type a natural-language thought at your prompt and get an AI answer (Claude or Codex). If the response contains shell commands, an arrow-key menu lets you confirm and run them.

```
$ how do I find files bigger than 100MB here

    find . -maxdepth 1 -type f -size +100M

Commands found — ↑/↓ to choose, Enter to run, q to cancel:
 ❯ find . -maxdepth 1 -type f -size +100M
   ➤ Run all of them
   ✗ Cancel
```

- Open source (MIT), free to use
- One-line install: `curl -fsSL https://raw.githubusercontent.com/jianshuo/ccline/v0.2.2/install.sh | bash`
- Requires zsh (macOS default) + `claude` or `codex` CLI