### PR TITLE
Add SilentAirDrop utility to Finder Tools

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -1390,6 +1390,7 @@ Awesome Mac
 * [QSpace](https://qspace.awehunt.com) - 一款简洁高效的多视图文件管理器。 [![App Store][app-store Icon]](https://apps.apple.com/cn/app/id1469774098?platform=mac)
 * [RClick](https://github.com/wflixu/RClick) - 一款简洁实用的 Finder 右键菜单增强工具 [![Open-Source Software][OSS Icon]](https://github.com/wflixu/RClick) ![Freeware][Freeware Icon]
 * [SaneClick](https://saneclick.com) - 为 Finder 右键菜单增加文件处理、转换和开发者操作。 [![Open-Source Software][OSS Icon]](https://github.com/sane-apps/SaneClick) ![Freeware][Freeware Icon]
+* [SilentAirDrop](https://github.com/gaptriko/SilentAirDrop) - 防止在通过 AirDrop 接收文件后 Finder 自动打开“下载”文件夹。 [![Open-Source Software][OSS Icon]](https://github.com/gaptriko/SilentAirDrop) ![Freeware][Freeware Icon]
 * [SwiftyMenu](https://apps.apple.com/us/app/swiftymenu/id1567748223?platform=mac) - 用常用应用快速打开所选文件或文件夹的 Finder 扩展。
 * [TotalFinder](http://totalfinder.binaryage.com/) - 强大的 Finder 替代者，界面风格像 Chrome。
 * [XtraFinder](https://www.trankynam.com/xtrafinder/) - 给 Finder 添加有用的新特性。![Freeware][Freeware Icon]

--- a/README.md
+++ b/README.md
@@ -1462,6 +1462,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [FileMinutes](https://www.fileminutes.com/) - Find files and take actions, all in one.
 * [FinderFix](https://synappser.github.io/apps/finderfix/) - Finally, a lasting solution for Finder windows size and position. ![Freeware][Freeware Icon].
 * [SaneClick](https://saneclick.com) - Finder extension that adds right-click actions for file tasks, conversion, and developer tools. [![Open-Source Software][OSS Icon]](https://github.com/sane-apps/SaneClick) ![Freeware][Freeware Icon]
+* [SilentAirDrop](https://github.com/gaptriko/SilentAirDrop) - Prevent Finder from auto-opening the Downloads folder after receiving files via AirDrop. [![Open-Source Software][OSS Icon]](https://github.com/gaptriko/SilentAirDrop) ![Freeware][Freeware Icon]
 * [FlowVision](https://github.com/netdcy/FlowVision) - RWaterfall-style Image Viewer for macOS. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/netdcy/FlowVision)
 * [fman](https://fman.io) - The first dual-pane file manager to integrate features from Sublime Text.
 * [ForkLift](http://binarynights.com/forklift/) - The most advanced dual pane file manager and file transfer client for macOS.


### PR DESCRIPTION
SilentAirDrop is a lightweight, open-source macOS menu bar utility that prevents the Finder 'Downloads' window from auto-opening and stealing focus after receiving files via AirDrop. It is written natively in Swift and uses FSEvents and Accessibility APIs.