### PR TITLE
Add Pier to Menu Bar Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1220,6 +1220,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [OnlySwitch](https://github.com/jacklandrin/OnlySwitch) - ⚙️ All-in-One menu bar app, hide 💻MacBook Pro's notch, dark mode, AirPods, Shortcuts[![Open-Source Software][OSS Icon]](https://github.com/jacklandrin/OnlySwitch) ![Freeware][Freeware Icon]
 * [Pandan](https://sindresorhus.com/pandan) - Time awareness in your menu bar. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id1569600264?platform=mac)
 * [Peninsula](https://github.com/Celve/Peninsula) - Dynamic Peninsula for macOS, focusing on window switching, notifications, and file storage. [![Open-Source Software][OSS Icon]](https://github.com/Celve/Peninsula) ![Freeware][Freeware Icon]
+* [Pier](https://afive.dev/pier) - Watch your servers' Docker Compose stacks, container health, host metrics and live logs over your existing SSH, from the menu bar. Read-only by default.
 * [PowerMeister](https://naden.co) - Conserve energy and improve Battery-Life on your MacBook.
 * [Quickgif](https://quickgif.app/) - Quickly Find and Share GIFs. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id6744745027?platform=mac)
 * [Reminders MenuBar](https://github.com/DamascenoRafael/reminders-menubar/) -  Simple macOS menu bar app to view and interact with reminders. [![Open-Source Software][OSS Icon]](https://github.com/DamascenoRafael/reminders-menubar/) ![Freeware][Freeware Icon]


### PR DESCRIPTION
## What is this app?

[Pier](https://afive.dev/pier) is a macOS menu-bar app that watches your servers over your existing SSH: Docker Compose stacks, container health, host metrics, live logs and image-update hints. No agent to install on servers; read-only by default (container actions are opt-in). macOS 14+, notarized, universal.

Disclosure: I'm the developer.

- Added under **Menu Bar Tools**, alphabetical order (between Peninsula and PowerMeister)
- Paid app ($4.99 one-time), so no Freeware icon per list conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)