### PR TITLE
Add BetterClip - native macOS clipboard manager with FTS search and snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1148,6 +1148,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 
 ### Clipboard Tools
 
+- [BetterClip](https://github.com/yarin-mag/BetterClip) - Native menu-bar clipboard manager with full-text search history and a snippet library. Global ⌘⇧V hotkey, auto-paste, and folder-organized snippets. [![Open-Source Software][OSS Icon]](https://github.com/yarin-mag/BetterClip) ![Freeware][Freeware Icon]
 * [Buffer](https://samirpatil2000.github.io/products/buffer/) - Lightweight native clipboard manager with bookmarks and OCR for images. [![Open-Source Software][OSS Icon]](https://github.com/samirpatil2000/Buffer) ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [CleanClip](https://cleanclip.cc) - The cleanest Clipboard Manager on macOS, ever! ![Freeware][Freeware Icon]
 * [Clipboard](https://getclipboard.app/) - Easy-to-use terminal clipboard manager for all platforms. [![Open-Source Software][OSS Icon]](https://github.com/Slackadays/Clipboard) ![Freeware][Freeware Icon]


### PR DESCRIPTION
## Description

Adds BetterClip to the Clipboard Tools section.

- Native Swift, menu-bar only
- Full-text search across clipboard history (FTS5)
- Snippet library with folder organization
- Global ⌘⇧V hotkey with auto-paste
- Free and open source

## Checklist

- [x] Added in alphabetical order
- [x] Correct format with OSS and Freeware icons
- [x] Link works and points to the correct page
