### PR TITLE
Add Ghostwriter to Note-taking

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Email Me](https://emailmeapp.net/) - Email yourself and much more with just one tap, native on macOS, iOS and WatchOS. [![App Store][app-store Icon]](https://apps.apple.com/us/app/email-me-notes-in-one-tap/id1090744587?platform=mac)
 * [Evernote](https://evernote.com/) - Infamous note-taking app, available on many platforms. ![Freeware][Freeware Icon]
 * [FSNotes](https://fsnot.es/) - File System Notes is a modern notes manager, native on macOS and iOS. [![Open-Source Software][OSS Icon]](https://github.com/glushchenko/fsnotes) [![App Store][app-store Icon]](https://apps.apple.com/gb/app/fsnotes/id1277179284?platform=mac)
+* [Ghostwriter](https://evanpizzolato.github.io/ghostwriter/) - Privacy-focused notes overlay that stays hidden from screenshots and screen shares. [![Open-Source Software][OSS Icon]](https://github.com/evanpizzolato/ghostwriter) ![Freeware][Freeware Icon]
 * [Gooba](https://goobapp.com/) - Writing app and task manager with a simple and interactive design.
 * [Inkdrop](https://www.inkdrop.info/) - Notebook app for Markdown lovers built on top of Electron.
 * [Joplin](https://joplinapp.org/) - Cross-platform open-source notepad with markdown support and to-do list management. [![Open-Source Software][OSS Icon]](https://github.com/laurent22/joplin) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds [Ghostwriter](https://evanpizzolato.github.io/ghostwriter/) — a privacy-focused notes overlay for macOS that stays hidden from screenshots, recordings, and screen shares (OS-level content protection). Always-on-top with adjustable transparency and click-through mode.

- Open source (GPL-3.0): https://github.com/evanpizzolato/ghostwriter
- Free; signed & notarized universal build (Intel + Apple Silicon)
- Entry placed alphabetically in Note-taking; follows the existing format with OSS and Freeware icons

🤖 Generated with [Claude Code](https://claude.com/claude-code)