### PR TITLE
Add ClipBear to Clipboard managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1150,6 +1150,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 
 * [Buffer](https://samirpatil2000.github.io/products/buffer/) - Lightweight native clipboard manager with bookmarks and OCR for images. [![Open-Source Software][OSS Icon]](https://github.com/samirpatil2000/Buffer) ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [CleanClip](https://cleanclip.cc) - The cleanest Clipboard Manager on macOS, ever! ![Freeware][Freeware Icon]
+* [ClipBear](https://clipbear.app) - Smart clipboard manager for developers that detects and transforms JWTs, JSON, colors, cron expressions, and timestamps on-device. ![Native App][Native Icon]
 * [Clipboard](https://getclipboard.app/) - Easy-to-use terminal clipboard manager for all platforms. [![Open-Source Software][OSS Icon]](https://github.com/Slackadays/Clipboard) ![Freeware][Freeware Icon]
 * [ClipMenu](http://www.clipmenu.com) - Clipboard manager for Mac OS X. [![Open-Source Software][OSS Icon]](https://github.com/naotaka/ClipMenu) ![Freeware][Freeware Icon]
 * [Clippy](https://github.com/yarasaa/Clippy) - Smart clipboard manager with content-aware previews, AI transformations, a built-in screenshot editor, and file converter. [![Open-Source Software][OSS Icon]](https://github.com/yarasaa/Clippy) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds ClipBear, a native macOS clipboard manager for developers that detects and transforms developer content (JWTs, JSON, colors, cron expressions, timestamps) on-device.

### Types of Changes

**What types of changes does your PR introduce?**

- [x] New addition to list
- [ ] Fixing bug in existing item in list
- [ ] Removing item from list
- [ ] Changing structure (organization) of list

### Proposed Changes

1. Adds **ClipBear** to the Clipboard section. It's a native macOS clipboard manager aimed at developers: beyond storing history, it auto-detects and transforms developer content — decoding JWTs, formatting JSON, converting colors (HEX/RGB/HSL), reading cron expressions, and extracting timestamps — all processed on-device. It fills a gap in the existing clipboard entries, none of which focus on developer content detection and transformation.
2. Placed alphabetically in the Clipboard section (after CleanClip, before Clipboard).
3. Description kept to a single factual line, matching the surrounding entries.
4. Badge: `Native App` only — it's a paid, closed-source app not on the Mac App Store, so no Freeware/OSS/App Store badges apply.

### PR Checklist

- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important
- [ ] I have added necessary documentation (if appropriate)

### Further Comments

Small change: a single new line added (1 addition, 0 deletions), placed in alphabetical order with a factual one-line description per the contribution guidelines. I searched the open pull requests and didn't find an existing PR adding ClipBear.