### PR TITLE
Add Envkeep to Password Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1447,6 +1447,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Buttercup](https://buttercup.pw/) - The Password Manager You Deserve ![Freeware][Freeware Icon]
 * [Dashlane](https://www.dashlane.com) - Cloud-based password manager with award-winning design.
 * [Enpass](https://www.enpass.io/) - Cross-platform password management tool with cloud integration. [![App Store][app-store Icon]](https://apps.apple.com/us/app/enpass-password-manager/id455566716?platform=mac)
+* [Envkeep](https://github.com/jackofshadowz/envkeep) - Encrypted ENV-secret manager with a native app and a CLI for AI coding agents. [![Open-Source Software][OSS Icon]](https://github.com/jackofshadowz/envkeep) ![Freeware][Freeware Icon]
 * [Keyzer](https://apps.apple.com/app/Keyzer/6500434773?platform=mac) - Simple password manager that supports saving portable password files.
 * [Keeweb](https://keeweb.info/) - Free, cross-platform password manager compatible with KeePass. [![Open-Source Software][OSS Icon]](https://github.com/keeweb/keeweb) ![Freeware][Freeware Icon]
 * [KeepassXC](https://keepassxc.org/) - Free, open source, cross-platform password manager. [![Open-Source Software][OSS Icon]](https://github.com/keepassxreboot/keepassxc) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds [Envkeep](https://github.com/jackofshadowz/envkeep) to **Password Management**.

Envkeep is an open-source (MIT) age-encrypted ENV-secret manager for macOS: a native app (Swift/WKWebView) to manage secrets, plus a zero-dependency CLI built for AI coding agents (`envkeep get project/KEY`). Decrypt-on-demand, optional Keychain cache with auto-lock, Touch ID + TOTP 2FA, project folders.

- Repo: https://github.com/jackofshadowz/envkeep
- License: MIT (Open-Source icon included)
- Placed alphabetically after Enpass; format matches surrounding entries (OSS + Freeware icons).