### PR TITLE
Add Fabar - per-app volume control for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -896,6 +896,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Cog](http://cogx.org/) - Free, open-source audio player. [![Open-Source Software][OSS Icon]](https://github.com/losnoco/cog) ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/us/app/cog-kode54/id1630499622?platform=mac)
 * [DaVinci Resolve](https://www.blackmagicdesign.com/products/davinciresolve/)  - Free, cross-platform video editing, color grading, video effects and audio editing software.
 * [Elmedia Player](https://mac.eltima.com/media-player.html) - Media player with broad audio and video format support.
+* [Fabar](https://github.com/gigaptera/fabar) - Per-app volume control from the menu bar using Core Audio process taps, no virtual driver needed. [![Open-Source Software][OSS Icon]](https://github.com/gigaptera/fabar) ![Freeware][Freeware Icon]
 * [Fader](https://github.com/pantafive/fader) - Menu bar volume mixer with per-app volume, one-click output switching, and Bluetooth headphone control. [![Open-Source Software][OSS Icon]](https://github.com/pantafive/fader) ![Freeware][Freeware Icon]
 * [FineTune](https://github.com/ronitsingh10/FineTune) - Per-app volume controller with multi-device output and 10-band EQ. [![Open-Source Software][OSS Icon]](https://github.com/ronitsingh10/FineTune) ![Freeware][Freeware Icon]
 * [FreeTube](https://freetubeapp.io/) - Open source desktop YouTube client built with privacy in mind. [![Open-Source Software][OSS Icon]](https://github.com/FreeTubeApp/FreeTube) ![Freeware][Freeware Icon]


### PR DESCRIPTION
**[Fabar](https://github.com/gigaptera/fabar)** — Free, MIT-licensed, open-source per-app volume control for macOS.

- Menu bar app with a volume slider for every app playing audio
- Uses Core Audio process taps (macOS 14.4+) — no virtual audio driver, nothing added to your output device list
- Apps you never adjust stay on the native audio path
- Boost quiet apps up to 200%
- Swift / SwiftUI, signed & notarized DMG

Added to the **Audio and Video Tools** section in alphabetical order.