### PR TITLE
Add N1KO-STATE - Native Swift macOS system monitor

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -1310,6 +1310,7 @@ Awesome Mac
 * [gfxCardStatus](https://gfx.io/) - 控制Mac独立显卡与集成显卡之间的切换。![Freeware][Freeware Icon]
 * [HandShaker](http://www.smartisan.com/apps/handshaker) - Mac 电脑上也可以方便自如地管理您在 Android 手机中的内容。 ![Freeware][Freeware Icon]
 * [iStat Menus](https://bjango.com/mac/istatmenus/) - 菜单栏上的高级 Mac 系统监视器。
+* [N1KO-STATE](https://github.com/baogutang/N1KO-STATE) - 原生 Swift 开发的 macOS 菜单栏系统监控，支持 CPU/GPU/内存/温度/风扇转速。 [![Open-Source Software][OSS Icon]](https://github.com/baogutang/N1KO-STATE) ![Freeware][Freeware Icon]
 * [iStats](https://github.com/Chris911/iStats) - iStats 是一个可以让你快速查看电脑 CPU 温度，磁盘转速和电池等信息的命令行工具。[![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/Chris911/iStats)
 * [Juice](https://github.com/brianmichel/Juice) - 让电池显示更有趣 [![Open-Source Software][OSS Icon]](https://github.com/brianmichel/Juice) ![Freeware][Freeware Icon]
 * [KeepingYouAwake](https://github.com/newmarcel/KeepingYouAwake) - 替代咖啡因，更好地支持Mac中的暗模式。 [![Open-Source Software][OSS Icon]](https://github.com/newmarcel/KeepingYouAwake)

--- a/README.md
+++ b/README.md
@@ -1509,6 +1509,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Gray](https://github.com/zenangst/Gray) - Per-app light/dark mode switcher. ![Freeware][Freeware Icon] [![Open-Source Software][OSS Icon]](https://github.com/zenangst/Gray)
 * [HandShaker](http://www.smartisan.com/apps/handshaker) - Manage Android phone content on Mac. ![Freeware][Freeware Icon]
 * [iStat Menus](https://bjango.com/mac/istatmenus/) - Advanced system monitor for menubar.
+* [N1KO-STATE](https://github.com/baogutang/N1KO-STATE) - Native Swift menu bar system monitor for CPU, GPU, memory, temperature and fan speed. [![Open-Source Software][OSS Icon]](https://github.com/baogutang/N1KO-STATE) ![Freeware][Freeware Icon]
 * [iStats](https://github.com/Chris911/iStats) - Command-line system information tool. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/Chris911/iStats)
 * [Juice](https://github.com/brianmichel/Juice) - Enhanced battery information display. [![Open-Source Software][OSS Icon]](https://github.com/brianmichel/Juice) ![Freeware][Freeware Icon]
 * [KeepingYouAwake](https://github.com/newmarcel/KeepingYouAwake) - Caffeine alternative with dark mode support. [![Open-Source Software][OSS Icon]](https://github.com/newmarcel/KeepingYouAwake)


### PR DESCRIPTION
Adding N1KO-STATE — a native Swift macOS menu bar system monitor 
(CPU, GPU, memory, temperature, fan RPM). It's open source, free, 
and has zero Electron/web view overhead.

GitHub: https://github.com/baogutang/N1KO-STATE