### PR TITLE
Add Iwan Dock under Window Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1417,6 +1417,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Dissolv](https://www.7sols.com/dissolv/) - Hide and close inactive apps. [![App Store][app-store Icon]](https://apps.apple.com/app/dissolv/id1640893012?platform=mac)
 * [Divvy](http://mizage.com/divvy/) - Window management at its finest with its amazing Divvy Grid system.
 * [Hummingbird](https://finestructure.co/hummingbird) - Easily move and resize windows without mouse clicks, from anywhere within a window.  [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/finestructure/Hummingbird)
+* [Iwan Dock](https://riwaqlabs.com/iwan/) - A menu-bar launcher that keeps your apps in floating panels you can arrange, lock, and summon on demand. [![App Store][app-store Icon]](https://apps.apple.com/app/iwan-dock/id6768841093)
 * [IntelliDock](https://mightymac.app/intellidock/) - Hides the Dock, Automatically.
 * [JankyBorders](https://github.com/FelixKratz/JankyBorders) - A lightweight window border system for macOS. [![Open-Source Software][OSS Icon]](https://github.com/FelixKratz/JankyBorders) ![Freeware][Freeware Icon]
 * [Loop](https://github.com/MrKai77/Loop) - Window management made elegant. [Freeware][Freeware Icon] [![Open-Source Software][OSS Icon]](https://github.com/MrKai77/Loop)


### PR DESCRIPTION
NOTE: A similar PR may already be submitted! Please search among the Pull request before creating one.

### Types of Changes

**What types of changes does your PR introduce?** Put an x in all boxes that apply

- [X ] New addition to list
- [ ] Fixing bug in existing item in list
- [ ] Removing item from list
- [ ] Changing structure (organization) of list

### Proposed Changes

Adds Iwan Dock, a menu-bar app launcher that keeps your apps in floating panels you can arrange, lock, and summon on demand. It's a native macOS app (macOS 14+) on the Mac App Store, and fits the Window Management category alongside entries like Sidebar and Convoker. Placed alphabetically between Hummingbird and IntelliDock.

### PR Checklist

Put an x in the boxes once you've completed each step. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- [X ] I have read the CONTRIBUTING guide
- [ X] I have explained why this PR is important
- [ X] I have added necessary documentation (if appropriate)

### Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
