### PR TITLE
Add Fabar — free per-app volume control for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -961,6 +961,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 ### Audio Record and Process
 
 * [CapSoftware](https://github.com/CapSoftware/) - An open-source alternative to Loom. Beautiful, shareable screen recording tool. [![Open-Source Software][OSS Icon]](https://github.com/CapSoftware/) ![Freeware][Freeware Icon]
+* [Fabar](https://fabar.gigaptera.com) - Per-app volume control from your menu bar. No virtual audio driver — uses Core Audio process taps. [![Open-Source Software][OSS Icon]](https://github.com/gigaptera/fabar) ![Freeware][Freeware Icon]
 * [GarageBand](https://www.apple.com/mac/garageband/) - Digital audio workstation for recording and music production. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/cn/app/garageband/id682658836?l=zh&ls=1&platform=mac)
 * [Logic Pro X](https://www.apple.com/logic-pro/) - Professional digital audio workstation for music and audio production. [![App Store][app-store Icon]](https://apps.apple.com/cn/app/logic-pro-x/id634148309?l=zh&platform=mac)
 * [Stargate DAW](https://github.com/stargatedaw/stargate) - An all-in-one digital audio workstation (DAW) and plugin suite. [![Open-Source Software][OSS Icon]](https://github.com/aria2) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Fabar is a free, open-source macOS menu bar app for per-app volume control.

Unlike traditional solutions that install a virtual audio driver, Fabar uses
the Core Audio process-tap API (macOS 14.4+), leaving unadjusted apps on the
native audio path.

- MIT licensed
- Swift / SwiftUI
- Signed & notarized DMG
- ~30 MB memory footprint

GitHub: https://github.com/gigaptera/fabar
Website: https://fabar.gigaptera.com