### PR TITLE
Add Posturio to Productivity section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1376,6 +1376,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Pie Menu](https://www.pie-menu.com) – Control your tools with a radial menu customized for your active app.
 * [Perplexity](https://apps.apple.com/us/app/perplexity-ask-anything/id6714467650?platform=mac) - Search and discovery with AI.
 * [Pomodoro Cycle](https://github.com/jet8a/pomodoro-cycle-app) - Pomodoro tracker
+* [Posturio](https://raghababa.github.io/Posturio/) - Smart desk wellness app that uses active-time tracking instead of traditional timers to deliver posture, eye care, movement, hydration, and guided stretch reminders.
 * [ProBoard](https://apps.apple.com/app/id6748314346?platform=mac) - Use one board to manage all your project information efficiently.[![App Store][app-store Icon]](https://apps.apple.com/app/id6748314346?platform=mac)
 * [Qbserve](https://qotoqot.com/qbserve/) - Automatic time tracking with projects, timesheets, and productivity insights.
 * [Raycast](https://raycast.com?via=ae02) - Launcher and command palette with extensions, snippets, notes, and AI.


### PR DESCRIPTION
## Types of Changes

- [x] New addition to list

## Proposed Changes

Add Posturio to the Productivity section.

Posturio is a native macOS desk wellness application that uses active-time tracking instead of traditional timers. It helps users build healthier desk habits through posture reminders, eye breaks, movement reminders, hydration reminders, and guided stretch exercises.

The application is designed specifically for macOS and fits within the Productivity category alongside other workflow and habit-building tools.

## PR Checklist

- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important
- [x] I have added necessary documentation (if appropriate)