### PR TITLE
Add Walter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1401,6 +1401,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Trello](https://trello.com) - A collaboration tool that organizes your projects into Kanban boards.![Freeware][Freeware Icon][![App Store][app-store Icon]](https://apps.apple.com/app/trello/id1278508951?ls=1&platform=mac)
 * [Ukelele](http://scripts.sil.org/ukelele) - Unicode Keyboard Layout Editor.
 * [Velja](https://sindresorhus.com/velja) - Browser picker that lets you open links in a specific browser or a desktop app.  [![App Store][app-store Icon]](https://apps.apple.com/app/id1607635845?platform=mac)
+* [Walter](https://walterlauncher.com) - Native launcher and Spotlight/Alfred/Raycast alternative; no Electron, no accounts, no telemetry, configured in a TOML file. [![Open-Source Software][OSS Icon]](https://github.com/ekinertac/walter) ![Freeware][Freeware Icon]
 * [xScope](http://xscopeapp.com/) - Toolset for measuring, inspecting, and testing on-screen layouts and graphics.
 * [Z](https://github.com/rupa/z) - Jump to frequently used directories by typing part of the path.
 


### PR DESCRIPTION
Adds [Walter](https://walterlauncher.com) to the Productivity section (placed alphabetically between Velja and xScope).

Walter is a native, open-source (MIT) macOS launcher — a Spotlight/Alfred/Raycast alternative written in pure Swift + AppKit (~4.3 MB, no Electron, no accounts, no telemetry), configured in a plain-text TOML file. Source: https://github.com/ekinertac/walter