### PR TITLE
Add Copsy to Cloud Storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -993,6 +993,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 
 * [Arq](https://www.arqbackup.com/) - Cloud storage backup client that supports AWS, GCP, DropBox, and more.
 * [Carbonite](https://www.carbonite.com/learn/how-to-backup-mac/) - Carbonite can protect your Mac from all of the most common forms of data loss.
+* [Copsy](https://copsy.app) - Offload and back up camera footage: copies SD/CFexpress cards to a drive and the cloud (Google Drive/Dropbox) at once, and verifies every file with ASC-MHL checksums. ![Freeware][Freeware Icon]
 * [Dropbox](https://www.dropbox.com/) - Cloud storage and file synchronization service. ![Freeware][Freeware Icon]
 * [Mega](https://mega.nz) - Free cloud service, offers 50GB free storage. ![Freeware][Freeware Icon]
 * [NextCloud](https://nextcloud.com/) - Actively maintained fork of ownCloud, faster and completely open-source [![Open-Source Software][OSS Icon]](https://github.com/nextcloud)


### PR DESCRIPTION
Adding **Copsy** under **Cloud Storage** (alphabetical, between Carbonite and Dropbox).

Copsy is a free macOS app that offloads and backs up camera footage: it copies SD/CFexpress cards to a drive and the cloud (Google Drive/Dropbox) in parallel and verifies every file with ASC-MHL checksums. Native, free to use, macOS 13+.

- Website: https://copsy.app
- Badge: `![Freeware][Freeware Icon]` (matches neighboring entries)
- One line added to README.md, alphabetical order preserved.