### PR TITLE
Add RuSwitcher (Input Methods)

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1001,6 +1001,7 @@ Awesome Mac
 * [Kawa](https://github.com/utatti/kawa) - OS X用のより良い入力ソース切り替え。 [![Open-Source Software][OSS Icon]](https://github.com/utatti/kawa) ![Freeware][Freeware Icon]
 * [LangSwitcher](https://github.com/reg2005/langSwitcher) - 間違ったキーボード配列で入力した文字を変換するツール。 [![Open-Source Software][OSS Icon]](https://github.com/reg2005/langSwitcher) ![Freeware][Freeware Icon]
 * [Rocket](http://matthewpalmer.net/rocket/) - Slackスタイルのショートカットを使用して絵文字入力をより速く簡単にする。 ![Freeware][Freeware Icon]
+* [RuSwitcher](https://github.com/rashn/RuSwitcher) - 間違ったキーボード配列で入力した文字を変換するレイアウトスイッチャー。任意の2つの配列に対応、テレメトリなし。 [![Open-Source Software][OSS Icon]](https://github.com/rashn/RuSwitcher) ![Freeware][Freeware Icon]
 * [Touch Emoji](https://github.com/lessmess-dev/touch-emoji) - MacBook Pro Touch Bar用の絵文字ピッカー。 [![Open-Source Software][OSS Icon]](https://github.com/lessmess-dev/touch-emoji)
 * [Type2Phone](https://www.houdah.com/type2Phone/) - MacをiPhone、iPad、Apple TVのキーボードとして使用。
 * [betterglobekey](https://github.com/Serpentiel/betterglobekey) - macOSのGlobeキーをもっと便利に！ [![Open-Source Software][OSS Icon]](https://github.com/Serpentiel/betterglobekey) ![Freeware][Freeware Icon]

--- a/README-ko.md
+++ b/README-ko.md
@@ -762,6 +762,7 @@ Awesome Mac
 * [Kawa](https://github.com/utatti/kawa) - OS X용 단축키 기반 입력 소스 전환기. [![Open-Source Software][OSS Icon]](https://github.com/utatti/kawa) ![Freeware][Freeware Icon]
 * [LangSwitcher](https://github.com/reg2005/langSwitcher) - 잘못된 키보드 레이아웃으로 입력한 텍스트를 고쳐주는 변환 도구. [![Open-Source Software][OSS Icon]](https://github.com/reg2005/langSwitcher) ![Freeware][Freeware Icon]
 * [Rocket](https://matthewpalmer.net/rocket/) - Slack 스타일의 단축키를 사용하여 이모지를 더 빠르게 입력. ![Freeware][Freeware Icon]
+* [RuSwitcher](https://github.com/rashn/RuSwitcher) - 잘못된 키보드 레이아웃으로 입력한 텍스트를 변환하는 레이아웃 전환기. 임의의 두 레이아웃 지원, 텔레메트리 없음. [![Open-Source Software][OSS Icon]](https://github.com/rashn/RuSwitcher) ![Freeware][Freeware Icon]
 * [InputSourcePro](https://inputsource.pro/) - 앱이나 웹사이트별로 입력 소스를 자동 전환하는 도구. [![Open-Source Software][OSS Icon]](https://github.com/runjuu/InputSourcePro) ![Freeware][Freeware Icon]
 
 ## 음성 텍스트 변환 (Voice-to-Text)

--- a/README-zh.md
+++ b/README-zh.md
@@ -960,6 +960,7 @@ Awesome Mac
 * [LangSwitcher](https://github.com/reg2005/langSwitcher) - 用于纠正错误键盘布局输入文本的转换工具。 [![Open-Source Software][OSS Icon]](https://github.com/reg2005/langSwitcher) ![Freeware][Freeware Icon]
 * [RIME](http://rime.im/) - 中州韻輸入法引擎。[![Open-Source Software][OSS Icon]](https://github.com/rime) ![Freeware][Freeware Icon]
 * [Rocket](http://matthewpalmer.net/rocket/) - 使用冒号快捷键可以更快捷地输入表情符号。![Freeware][Freeware Icon]
+* [RuSwitcher](https://github.com/rashn/RuSwitcher) - 纠正用错误键盘布局输入文本的布局切换器，支持任意两种布局，无遥测。 [![Open-Source Software][OSS Icon]](https://github.com/rashn/RuSwitcher) ![Freeware][Freeware Icon]
 * [Type2Phone](https://www.houdah.com/support/) - 把 Macbook 键盘变为 iPhone 的蓝牙键盘。 [![App Store][app-store Icon]](https://apps.apple.com/cn/app/type2phone-bluetooth-keyboard/id472717129?platform=mac)
 * [WBIM](http://www.glamtime.com.cn/wbim) - 五笔输入法。[![App Store][app-store Icon]](https://apps.apple.com/cn/app/wbim-%E5%86%99%E5%AD%97%E6%9D%BF/id929844708?platform=mac)
 * [搜狗输入法](http://pinyin.sogou.com/mac/) - 搜狗输入法。![Freeware][Freeware Icon]

--- a/README.md
+++ b/README.md
@@ -1004,6 +1004,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Kawa](https://github.com/utatti/kawa) - Better input source switcher for OS X. [![Open-Source Software][OSS Icon]](https://github.com/utatti/kawa) ![Freeware][Freeware Icon]
 * [LangSwitcher](https://github.com/reg2005/langSwitcher) - Keyboard layout converter for mistyped text. [![Open-Source Software][OSS Icon]](https://github.com/reg2005/langSwitcher) ![Freeware][Freeware Icon]
 * [Rocket](http://matthewpalmer.net/rocket/) - Makes typing emoji faster and easier using Slack-style shortcuts. ![Freeware][Freeware Icon]
+* [RuSwitcher](https://github.com/rashn/RuSwitcher) - Keyboard layout switcher that converts mistyped text; works with any two layouts, no telemetry. [![Open-Source Software][OSS Icon]](https://github.com/rashn/RuSwitcher) ![Freeware][Freeware Icon]
 * [Touch Emoji](https://github.com/lessmess-dev/touch-emoji) - Emoji picker for MacBook Pro Touch Bar. [![Open-Source Software][OSS Icon]](https://github.com/lessmess-dev/touch-emoji)
 * [Type2Phone](https://www.houdah.com/type2Phone/) - Use Your Mac as Keyboard for iPhone, iPad & Apple TV.
 * [betterglobekey](https://github.com/Serpentiel/betterglobekey) - Make macOS Globe key great again! [![Open-Source Software][OSS Icon]](https://github.com/Serpentiel/betterglobekey) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds **RuSwitcher** to the *Input Methods* section.

A lightweight, open-source (MIT) macOS keyboard layout switcher that converts text typed in the wrong layout (e.g. `ηελλο` → `hello`). Works with any two installed layouts via `UCKeyTranslate`, remembers layout per app, zero telemetry, zero dependencies, signed & notarized.

- Repo: https://github.com/rashn/RuSwitcher
- Placed alphabetically (after Rocket) in **Input Methods**, next to LangSwitcher/Kawa.
- Synced across all four READMEs: `README.md`, `README-zh.md`, `README-ja.md`, `README-ko.md`.
- Marked Open-Source + Freeware per the icon legend.
