### PR TITLE
Add InfyniDock

### DIFF
--- a/README.md
+++ b/README.md
@@ -1420,6 +1420,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Dissolv](https://www.7sols.com/dissolv/) - Hide and close inactive apps. [![App Store][app-store Icon]](https://apps.apple.com/app/dissolv/id1640893012?platform=mac)
 * [Divvy](http://mizage.com/divvy/) - Window management at its finest with its amazing Divvy Grid system.
 * [Hummingbird](https://finestructure.co/hummingbird) - Easily move and resize windows without mouse clicks, from anywhere within a window.  [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/finestructure/Hummingbird)
+* [InfyniDock](https://infyniclick.com/) - Window-level Dock that previews and switches to the exact app window, with Option + Tab, FloatDock, and workspaces.
 * [IntelliDock](https://mightymac.app/intellidock/) - Hides the Dock, Automatically.
 * [JankyBorders](https://github.com/FelixKratz/JankyBorders) - A lightweight window border system for macOS. [![Open-Source Software][OSS Icon]](https://github.com/FelixKratz/JankyBorders) ![Freeware][Freeware Icon]
 * [Loop](https://github.com/MrKai77/Loop) - Window management made elegant. [Freeware][Freeware Icon] [![Open-Source Software][OSS Icon]](https://github.com/MrKai77/Loop)


### PR DESCRIPTION
Adds InfyniDock to the Window Management section.

InfyniDock is a window-level Dock for macOS: it makes individual app windows first-class Dock targets with live previews, Option+Tab, FloatDock, and workspaces.

- Inserted in alphabetical order (between Hummingbird and IntelliDock)
- One-sentence description, title-case link
- Paid app, so no Freeware/OSS icon (consistent with contexts, Moom, Divvy in the same section)
- Checked for duplicates: not currently listed