### PR TITLE
Update Screenpipe URL (repo renamed from mediar-ai to screenpipe)

### DIFF
--- a/README.md
+++ b/README.md
@@ -731,7 +731,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [ScreenKite](https://www.screenkite.com/) - Native screen recorder and editor with auto-zoom, AI enhancements, device mockups, and teleprompter. ![Freeware][Freeware Icon]
 * [ScreenSage Pro](https://screensage.pro/) - A screen recording tool for creating polished videos in minutes.
 * [Screenize](https://syi0808.github.io/screenize/) - Open-source screen recorder with auto-zoom, cursor effects, and timeline editing. [![Open-Source Software][OSS Icon]](https://github.com/syi0808/screenize) ![Freeware][Freeware Icon]
-* [Screenpipe](https://github.com/mediar-ai/screenpipe) - Local screen and microphone recorder with AI search. [![Open-Source Software][OSS Icon]](https://github.com/mediar-ai/screenpipe) ![Freeware][Freeware Icon]
+* [Screenpipe](https://github.com/screenpipe/screenpipe) - Local screen and microphone recorder with AI search. [![Open-Source Software][OSS Icon]](https://github.com/screenpipe/screenpipe) ![Freeware][Freeware Icon]
 * [Snagit](https://www.techsmith.com/screen-capture.html) - Screen Capture and Recording Software. Simple and Powerful.
 * [Tight Studio](https://tight.studio/) - Screen recorder with smart zoom, captions, and AI voiceovers.
 * [Zappy](https://zapier.com/zappy) - Zappy is a screenshot and screen recording app all in one. Has some simple editing tools built in.


### PR DESCRIPTION
The screenpipe GitHub org was renamed from `mediar-ai` to `screenpipe`. Both URLs still resolve via GitHub's redirect, but the canonical URL is now https://github.com/screenpipe/screenpipe. This PR updates the two references in the entry (the link text and the OSS Icon link) so the canonical URL is used directly.

The original entry (and its merged position in *Screencapturing Software*) is unchanged otherwise — same description, same icons, same alphabetical position.

Disclosure: this update was prepared by screenpipe's automated contribution agent; I'm the maintainer of screenpipe (louis@screenpi.pe) — happy to adjust or close if it isn't a fit.