### PR TITLE
Add Pesty (open-source clipboard manager)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1159,6 +1159,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [uPaste](https://okaapps.com/product/1503649026) - Clipboard history and snippets manager for organizing reusable copied content. [![App Store][app-store Icon]](https://apps.apple.com/app/id1503649026?pt=119209922&ct=github)
 * [Yippy](https://github.com/mattDavo/Yippy) - Clipboard manager with user-friendly UI. [![Open-Source Software][OSS Icon]](https://github.com/mattDavo/Yippy) ![Freeware][Freeware Icon]
 * [ClipFlow](https://github.com/praneeth552/clipflow) - Free clipboard history manager with terminal-style navigation. [![Open-Source Software][OSS Icon]](https://github.com/praneeth552/clipflow) ![Freeware][Freeware Icon]
+* [Pesty](https://github.com/momenbasel/pesty) - Free and open-source clipboard manager inspired by Paste, with a slide-up color-coded strip, pinboards, and search. [![Open-Source Software][OSS Icon]](https://github.com/momenbasel/pesty) ![Freeware][Freeware Icon] ![Native App][Native Icon]
 
 ### Menu Bar Tools
 


### PR DESCRIPTION
Adds **Pesty** to the Clipboard Tools section.

- Free and open-source clipboard manager for macOS, inspired by Paste
- Repo: https://github.com/momenbasel/pesty
- Native SwiftUI, signed + notarized, Homebrew cask available, MIT licensed
- Entry includes Open-Source, Freeware, and Native App badges