### PR TITLE
Add Keylight to Developer Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Integrity](http://peacockmedia.software/mac/integrity/free.html) - Free website link checker for Mac. ![Freeware][Freeware Icon]
 * [JsonStudio](https://jsonstudio.js.org/) - Local-first JSON workspace for formatting, editing, diffing, converting, validating, and extracting JSON from logs. [![Open-Source Software][OSS Icon]](https://github.com/sundegan/JsonStudio) ![Freeware][Freeware Icon]
 * [Kaleidoscope](https://www.kaleidoscopeapp.com/) - Compare text, images, and folders.
+* [Keylight](https://keylight.dev) - Licensing, device activations, and Stripe-native payments for Mac apps, with offline verification.
 * [Koala](http://koala-app.com) - GUI application for Less, Sass, Compass and CoffeeScript compilation. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/oklai/koala/)
 * [Loca Studio](https://www.cunningo.com/locastudio/index.html) - Analyze, review, and edit app translations. [![App Store][app-store Icon]](https://apps.apple.com/app/id1465684707?platform=mac)
 * [LINQPad](https://www.linqpad.net/) - .NET scratchpad for running code, queries, and database exploration. ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds **Keylight** (https://keylight.dev) to *Developer Tools → Developer Utilities*.

Keylight lets Mac app developers add licensing, device activations, and Stripe-native payments with offline (Ed25519) verification — finished SDKs for Swift and other stacks, so there's no backend to build.

- Placed alphabetically in the Developer Utilities list.
- No badge: it's a paid developer service (free tier available), not freeware/OSS/App Store.

Disclosure: I'm the developer of Keylight.