### PR TITLE
Add Awake to the Utilities section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1503,6 +1503,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 
 * [AlDente](https://apphousekitchen.com/) - Battery charge limiter for MacBooks. [![Open-Source Software][OSS Icon]](https://github.com/davidwernhart/AlDente)
 * [Amphetamine](https://apps.apple.com/us/app/amphetamine/id937984704?platform=mac) - Keep your Mac awake. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/us/app/amphetamine/id937984704?platform=mac)
+* [Awake](https://github.com/pistachionet/awake) - Keep your Mac awake with the lid closed. Perfect for running agents, SSH sessions, downloads, and background tasks overnight. [![Open-Source Software][OSS Icon]](https://github.com/pistachionet/awake) ![Freeware][Freeware Icon]
 * [AdBlock One](https://cleanerone.trendmicro.com/ad-block-one-for-mac/?utm_source=github&utm_medium=referral&utm_campaign=githubproject) - Free ad blocker for Safari.![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/apple-store/id1491889901?pt=444218&ct=GitHub&mt=8&platform=mac)
 * [Apple Silicon App Test](https://doesitarm.com/apple-silicon-app-test/) - Check Apple Silicon app compatibility. [![Open-Source Software][OSS Icon]](https://github.com/ThatGuySam/doesitarm) ![Freeware][Freeware Icon]
 * [AirBattery](https://lihaoyun6.github.io/airbattery/) - View all device batteries in the Dock, menu bar, or widgets. [![Open-Source Software][OSS Icon]](https://github.com/lihaoyun6/AirBattery) ![Freeware][Freeware Icon]


### PR DESCRIPTION
## Summary

Add Awake to the Utilities section.

## Project

Awake is an open-source macOS menu bar app that keeps a MacBook awake with the
lid closed. It uses `pmset disablesleep` (the only mechanism that survives a
lid close) so you can run agents, SSH in from your phone, keep downloads going,
or play music without leaving the lid propped open.

Repository: https://github.com/pistachionet/awake