### PR TITLE
Add Orca

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [NetBeans IDE](https://netbeans.org/) - Free, open-source IDE for Java and other languages. [![OSS][OSS Icon]](https://github.com/apache/netbeans) ![Freeware][Freeware Icon]
 * [Nimbalyst](https://nimbalyst.com/) - A visual workspace for managing AI coding sessions, tasks, and project files.
 * [Nova](https://nova.app/) - Beautiful, fast, flexible Mac code editor from [Panic](https://panic.com/).
+* [Orca](https://onorca.dev) - An open-source IDE for running parallel AI coding agents (Claude Code, Codex, Cursor, Gemini, OpenCode), each in its own isolated git worktree. [![Open-Source Software][OSS Icon]](https://github.com/stablyai/orca) ![Freeware][Freeware Icon]
 * [Trae](https://www.trae.ai/) - AI-powered IDE for coding and software development.
 * [Visual Studio Code](https://code.visualstudio.com/) - Microsoft's free & open-source editor, TypeScript friendly, [VSCode Plugins](editor-plugin.md#vscode-plugin). [![Open-Source Software][OSS Icon]](https://github.com/Microsoft/vscode) ![Freeware][Freeware Icon] [![Awesome List][awesome-list Icon]](https://github.com/viatsko/awesome-vscode#readme)
 * [VSCodium](https://vscodium.com/) - Community-driven libre binaries of VS Code. [![Open-Source Software][OSS Icon]](https://github.com/vscodium/vscodium) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds **Orca** to `Developer Tools → IDEs`, in alphabetical order.

Orca is an open-source (MIT) macOS IDE/ADE (also Windows, Linux, and a mobile companion) for running a fleet of parallel AI coding agents — Claude Code, Codex, Cursor, Gemini, OpenCode and others — each in its own isolated git worktree, with a built-in terminal, source control, and SSH.

- Source: https://github.com/stablyai/orca
- Website: https://onorca.dev

Tagged with the Open-Source and Freeware icons (Orca is MIT-licensed), matching the existing IDE entries. Thanks!