### PR TITLE
Add Core (AI writing environment for macOS)

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -284,6 +284,7 @@ Awesome Mac
 
 ### ライティング
 
+* [Core](https://corewrite.app/) - 原稿全体を読む AI エディタで批評と整合性チェックを行い、縦書き組版と蔵書検索を内蔵したライティングアプリ。 ![Native App][Native Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/core-ai-writing-studio/id6761600363?platform=mac)
 * [Retrotype](https://retrotype.ink/) - 本物のタイプライターのような感覚の楽しくミニマルなライティングアプリ。 ![Freeware][Freeware Icon]
 * [novelWriter](https://github.com/vkbo/novelWriter) - 最小限のMarkdown風構文で小説を書くためのオープンソースプレーンテキストエディタ。 [![OSS][OSS Icon]](https://github.com/vkbo/novelWriter) ![Freeware][Freeware Icon]
 * [Scrivener](https://www.literatureandlatte.com/scrivener/overview/) - ライターのための定番ワードプロセッサ。

--- a/README-ko.md
+++ b/README-ko.md
@@ -258,6 +258,7 @@ Awesome Mac
 
 ### 쓰기
 
+* [Core](https://corewrite.app/) - 원고 전체를 읽는 AI 편집기로 비평과 일관성을 검사하고, 세로쓰기 조판과 도서관 검색을 갖춘 글쓰기 앱. ![Native App][Native Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/core-ai-writing-studio/id6761600363?platform=mac)
 * [Retrotype](https://retrotype.ink/) - 실제 타자기 느낌을 주는 미니멀한 쓰기 앱. ![Freeware][Freeware Icon]
 * [novelWriter](https://github.com/vkbo/novelWriter) - 소설 작성을 위한 오픈 소스 일반 텍스트 편집기. [![OSS][OSS Icon]](https://github.com/vkbo/novelWriter) ![Freeware][Freeware Icon]
 * [Scrivener](https://www.literatureandlatte.com/scrivener/overview/) - 작가를 위한 전형적인 워드 프로세서.

--- a/README-zh.md
+++ b/README-zh.md
@@ -869,6 +869,7 @@ Awesome Mac
 
 ### 写作
 
+* [Core](https://corewrite.app/) - AI 编辑器通读整篇稿件进行批评与连贯性检查的写作应用，内置竖排排版与图书馆藏书检索。 ![Native App][Native Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/core-ai-writing-studio/id6761600363?platform=mac)
 * [Retrotype](https://retrotype.ink/) - 有趣且极简的写作应用，带来真实打字机的手感。 ![Freeware][Freeware Icon]
 * [novelWriter](https://github.com/vkbo/novelWriter) - 一个开源的纯文本编辑器，专为写小说设计。它支持类似 Markdown 的最小语法来格式化文本。 [![Open-Source Software][OSS Icon]](https://github.com/vkbo/novelWriter) ![Freeware][Freeware Icon]
 * [THORN](https://thorn.red) - 一站式个人写作与建站平台

--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 
 ### Writing
 
+* [Core](https://corewrite.app/) - Writing app whose AI editor reads the full manuscript for critique and continuity checks, with vertical Japanese typography and built-in library search. ![Native App][Native Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/core-ai-writing-studio/id6761600363?platform=mac)
 * [Retrotype](https://retrotype.ink/) - A fun and minimalist writing app that feels like a real typewriter. ![Freeware][Freeware Icon]
 * [novelWriter](https://github.com/vkbo/novelWriter) - Open-source plain text editor for writing novels with minimal markdown-like syntax. [![OSS][OSS Icon]](https://github.com/vkbo/novelWriter) ![Freeware][Freeware Icon]
 * [Scrivener](https://www.literatureandlatte.com/scrivener/overview/) - The quintessential word processor for writers.


### PR DESCRIPTION
Adds **Core** to the **Writing** section.

Core is a native macOS writing app whose AI editor reads the full manuscript — not just the visible paragraph — to critique drafts and check continuity, rather than generate prose. It has first-class vertical Japanese typography (tategaki, ruby, emphasis dots) and built-in search across the Library of Congress, the Internet Archive, Open Library, and Japan's National Diet Library. Files are stored locally.

- Synced across `README.md`, `README-zh.md`, `README-ja.md`, and `README-ko.md`, with a one-sentence description per language following each document's local section structure.
- Placed alphabetically in each Writing section (before `Retrotype`).
- Badges: `![Native App][Native Icon]` + App Store, matching the surrounding paid, closed-source entries.
- Rebased onto current `master`; single commit, 4-line diff.

Disclosure: I am the developer of Core.

Website: https://corewrite.app
Mac App Store: https://apps.apple.com/app/core-ai-writing-studio/id6761600363
