### PR TITLE
Add Drobu to Clipboard Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1179,6 +1179,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Yippy](https://github.com/mattDavo/Yippy) - Clipboard manager with user-friendly UI. [![Open-Source Software][OSS Icon]](https://github.com/mattDavo/Yippy) ![Freeware][Freeware Icon]
 * [ClipFlow](https://github.com/praneeth552/clipflow) - Free clipboard history manager with terminal-style navigation. [![Open-Source Software][OSS Icon]](https://github.com/praneeth552/clipflow) ![Freeware][Freeware Icon]
 * [Pesty](https://github.com/momenbasel/pesty) - Free and open-source clipboard manager inspired by Paste, with a slide-up color-coded strip, pinboards, and search. [![Open-Source Software][OSS Icon]](https://github.com/momenbasel/pesty) ![Freeware][Freeware Icon] ![Native App][Native Icon]
+* [Drobu](https://drobu.app) - A clipboard manager you can edit: capture text, images, GIFs, files, and screen recordings, then crop, trim, and paste them. Local-only, one-time purchase. ![Native App][Native Icon]
 
 ### Menu Bar Tools
 


### PR DESCRIPTION
Adds **Drobu** to the Clipboard Tools section.

[Drobu](https://drobu.app) is a native macOS clipboard manager you can edit: it captures text, images, GIFs, files, and screen recordings into one searchable history, lets you crop, trim, and clean them in place, and pastes one item or many with a keystroke. It runs entirely on the Mac (local-only, no account) and is a one-time purchase.

- Native macOS app (Swift/AppKit), so it carries the Native App badge.
- Not on the Mac App Store and not open source, so no App Store / OSS / Freeware badge.
- Added at the end of the Clipboard Tools section, matching the most recent entries.