### PR TITLE
Add AI Notebook to Note-taking

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 
 * [Affine](https://affine.pro/) - Affine is the next-generation collaborative knowledge base for professionals. [![Open-Source Software][OSS Icon]](https://github.com/toeverything/AFFiNE) ![Freeware][Freeware Icon]
 * [Agenda](https://agenda.com/) - Date-focused note taking app for both planning and documenting your projects. [![App Store][app-store Icon]](https://apps.apple.com/app/id1287445660?platform=mac)
+* [AI Notebook](https://github.com/lukoplt/AI-notebook) - Offline NotebookLM alternative: chat with your own documents and get answers with citations, powered by Ollama. [![Open-Source Software][OSS Icon]](https://github.com/lukoplt/AI-notebook) ![Freeware][Freeware Icon]
 * [Anytype](https://anytype.io/) - Local-first note-taking and knowledge management app. ![Freeware][Freeware Icon]
 * [AppFlowy](https://www.appflowy.io/) - Open-source alternative to Notion. [![Open-Source Software][OSS Icon]](https://github.com/AppFlowy-IO/appflowy) ![Freeware][Freeware Icon]
 * [Bear Writer](http://www.bear-writer.com/) - Beautiful, flexible writing app for crafting notes and prose. [![App Store][app-store Icon]](https://apps.apple.com/us/app/bear-beautiful-writing-app/id1091189122?ls=1&platform=mac)


### PR DESCRIPTION
Adds **AI Notebook** to the Note-taking section (alphabetical, between Agenda and Anytype), with the Open-Source and Freeware icons.

AI Notebook is a free, MIT-licensed native macOS app — an offline alternative to Google NotebookLM. Chat with your own documents (PDF, Office, web) and get answers with inline citations, all running locally via Ollama. Includes a WYSIWYG notes editor and local hybrid retrieval.

Repo: https://github.com/lukoplt/AI-notebook

(I'm the author.) Thanks for maintaining awesome-mac!