### PR TITLE
Add Nod to Note-taking

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -254,6 +254,7 @@ Awesome Mac
 * [MarginNote 4](https://marginnote.com/) - PDFとEPUBの深い読書、学習、管理、メモ取りアプリ。
 * [massCode](https://masscode.io/) - MarkdownとMermaidをサポートしたクロスプラットフォームオープンソースコードスニペット管理ツール。 [![Open-Source Software][OSS Icon]](https://github.com/massCodeIO/massCode) ![Freeware][Freeware Icon]
 * [MiaoYan](https://miaoyan.app/) - 素晴らしい文章を書くのに役立つ軽量Markdownアプリ。
+* [Nod](https://hellonod.app/) - 会議、通話、ボイスメモを自動的に録音・文字起こし・要約するAIミーティングメモアプリ。ボットとして参加せず、13言語に対応。 ![Native App][Native Icon]
 * [Notable](https://github.com/notable/notable) - 優れたMarkdownベースのメモアプリ。
 * [Notebook](https://www.zoho.com/notebook/notebook-for-mac.html) - メモ取りアプリ。 ![Freeware][Freeware Icon]
 * [Notes](http://www.get-notes.com/) - クリーンでシンプルなメモ取りアプリ。 [![Open-Source Software][OSS Icon]](https://github.com/nuttyartist/notes) ![Freeware][Freeware Icon]

--- a/README-ko.md
+++ b/README-ko.md
@@ -228,6 +228,7 @@ Awesome Mac
 * [MarginNote 4](https://marginnote.com/) - 심도 있는 PDF 및 EPUB 읽기, 학습 및 노트 앱.
 * [massCode](https://masscode.io/) - 마크다운 및 Mermaid를 지원하는 오픈 소스 코드 스니펫 관리자. [![Open-Source Software][OSS Icon]](https://github.com/massCodeIO/massCode) ![Freeware][Freeware Icon]
 * [MiaoYan](https://miaoyan.app/) - 좋은 문장을 쓰도록 돕는 경량 마크다운 앱.
+* [Nod](https://hellonod.app/) - 회의, 통화, 음성 메모를 자동으로 녹음·전사·요약하는 AI 미팅 메모 앱. 봇으로 참여하지 않으며 13개 언어를 지원. ![Native App][Native Icon]
 * [Notable](https://github.com/notable/notable) - 마크다운 기반의 괜찮은 노트 앱.
 * [Notebook](https://www.zoho.com/notebook/notebook-for-mac.html) - 노트 작성 앱. ![Freeware][Freeware Icon]
 * [Notes](http://www.get-notes.com/) - 깔끔하고 단순한 노트 앱. [![Open-Source Software][OSS Icon]](https://github.com/nuttyartist/notes) ![Freeware][Freeware Icon]

--- a/README-zh.md
+++ b/README-zh.md
@@ -846,6 +846,7 @@ Awesome Mac
 * [Logseq](https://logseq.com/) - 一个以隐私为先的开源平台，用于知识管理和协作。 [![Open-Source Software][OSS Icon]](https://github.com/logseq/logseq) ![Freeware][Freeware Icon]
 * [MarginNote 4](https://apps.apple.com/cn/app/marginnote-4/id1531657269?platform=mac) - 笔记界的瑞士军刀，功能强大的笔记软件工具[![App Store][app-store Icon]](https://apps.apple.com/cn/app/marginnote-4/id1531657269?platform=mac)
 * [massCode](https://github.com/massCodeIO/massCode) - 跨平台开源代码片段管理器，支持 Markdown 和 Mermaid。 [![Open-Source Software][OSS Icon]](https://github.com/massCodeIO/massCode) ![Freeware][Freeware Icon]
+* [Nod](https://hellonod.app/) - 自动录制、转写并总结会议、通话和语音备忘录的 AI 会议记忆应用，支持 13 种语言，无需作为机器人加入。 ![Native App][Native Icon]
 * [NotePlan 3](https://noteplan.co/) - 您的任务、笔记和日历、纯文本 Markdown 文件。 [![App Store][app-store Icon]](https://apps.apple.com/cn/app/noteplan-3/id1505432629?platform=mac)
 * [Noteship](https://noteship.com) - 本地优先的笔记应用，可将笔记整理为结构化知识。 [![App Store][app-store Icon]](https://apps.apple.com/us/app/noteship/id1571711347?platform=mac)
 * [Notebook](https://www.zoho.com/notebook/notebook-for-mac.html) 漂亮的笔记本应用程序。 ![Freeware][Freeware Icon]

--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [MarginNote 4](https://marginnote.com/) - In-depth PDF and EPUB reading, learning, managing and note taking app.
 * [massCode](https://masscode.io/) - Cross-platform open-source code snippets manager with markdown and mermaid support. [![Open-Source Software][OSS Icon]](https://github.com/massCodeIO/massCode) ![Freeware][Freeware Icon]
 * [MiaoYan](https://miaoyan.app/) - Lightweight Markdown app to help you write great sentences.
+* [Nod](https://hellonod.app/) - AI meeting memory app that automatically records, transcribes and summarizes meetings, calls and voice notes in 13 languages, without joining as a bot. ![Native App][Native Icon]
 * [Notable](https://github.com/notable/notable) - The markdown-based note-taking app that doesn't suck.
 * [Notebook](https://www.zoho.com/notebook/notebook-for-mac.html) - Note-taking app. ![Freeware][Freeware Icon]
 * [Notes](http://www.get-notes.com/) - Clean, simple note-taking app. [![Open-Source Software][OSS Icon]](https://github.com/nuttyartist/notes) ![Freeware][Freeware Icon]


### PR DESCRIPTION
### What is it
Nod (https://hellonod.app/) is a native macOS (Swift) app that automatically records, transcribes and summarizes meetings, calls and voice notes. It works across 22+ communication tools (Zoom, Google Meet, Teams, Slack, etc.) without joining as a meeting bot.

### Why it fits this list
- Native macOS app, actively maintained
- Useful for solo professionals: a searchable memory of every conversation ("Ask Nod")
- Privacy-first: audio is never stored, EU-based storage, no training on user data

### Checklist
- [x] Added in alphabetical order in the Note-taking category
- [x] Description is a single sentence ending with a period
- [x] Synced across README.md, README-zh.md, README-ja.md, README-ko.md
- [x] Searched the list to confirm it is not a duplicate