### PR TITLE
Add AI Usage Ball

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 
 ### Developer Utilities
 
+* [AI Usage Ball](https://aiusageball.com) - A source-available macOS desktop app that shows how much of your AI coding-tool quota you have left. [![Open-Source Software][OSS Icon]](https://github.com/aiusageball/ai-usage-ball) ![Freeware][Freeware Icon]
 * [AXe](https://github.com/cameroncooke/AXe) - CLI tool for controlling iOS Simulators through Accessibility APIs and HID automation. [![Open-Source Software][OSS Icon]](https://github.com/cameroncooke/AXe) ![Freeware][Freeware Icon]
 * [BetterRename](http://www.publicspace.net/BetterRename/) - The most powerful and complete Mac file renaming application on the market. [![App Store][app-store Icon]](https://apps.apple.com/us/app/better-rename-11/id1501308038?platform=mac)
 * [Beyond Compare](http://www.scootersoftware.com/) - Compare files and folders with powerful commands. ![Freeware][Freeware Icon]


### PR DESCRIPTION
Add AI Usage Ball to Developer Utilities. It is a source-available macOS desktop app that shows how much of your AI coding-tool quota you have left, as animated liquid gauges.