### PR TITLE
Add Spit to Voice-to-Text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1025,6 +1025,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [OpenTypeless](https://github.com/tover0314-w/opentypeless) - Open-source AI voice input that types polished text into any app. [![Open-Source Software][OSS Icon]](https://github.com/tover0314-w/opentypeless) ![Freeware][Freeware Icon]
 * [Ottex](https://ottex.ai) - AI dictation tool that formats text for the app or site you are using.
 * [Parakey](https://github.com/rcourtman/parakey) - Native push-to-talk local dictation app for Apple Silicon Macs using Parakeet TDT v3 (CoreML/ANE). [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/rcourtman/parakey)
+* [Spit](https://getspit.app) - Free, open-source dictation app that transcribes 100% on-device with WhisperKit — no cloud, no account. [![Open-Source Software][OSS Icon]](https://github.com/rafaellopes/spit) ![Freeware][Freeware Icon]
 * [Spokenly](https://spokenly.app/) - Voice-to-text with 100+ languages, offline mode, and AI-powered formatting.
 * [Tambourine](https://tambourinevoice.com/) - Open-source, customizable AI voice dictation that works in any app. [![Open-Source Software][OSS Icon]](https://github.com/kstonekuan/tambourine-voice/) ![Freeware][Freeware Icon]
 * [TypeWhisper](https://www.typewhisper.com) - Local Whisper-based speech-to-text with a global hotkey. [![Open-Source Software][OSS Icon]](https://github.com/TypeWhisper/typewhisper-mac) ![Freeware][Freeware Icon]


### PR DESCRIPTION
[Spit](https://getspit.app) is a free, open-source (MIT) macOS menu-bar dictation app. Transcription runs 100% on-device via WhisperKit — no cloud, no account, no subscription. Repo: https://github.com/rafaellopes/spit