### PR TITLE
Add Leafy (vocabulary builder) to Education

### DIFF
--- a/README.md
+++ b/README.md
@@ -1080,6 +1080,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 
 ## Education
 
+* [Leafy](https://leafyapp.uk) - Vocabulary builder: press ⌥A to scan any word on screen (PDFs, ebooks, and images via OCR), see the definition in place, and save it to a searchable local library. ![Freeware][Freeware Icon]
 * [Wokabulary](https://wokabulary.com/) - Collect, practice, and organize your individual foreign language vocabulary. [![App Store][app-store Icon]](https://apps.apple.com/app/apple-store/id1667619825?platform=mac)
 
 ## Finance

--- a/README.md
+++ b/README.md
@@ -1080,7 +1080,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 
 ## Education
 
-* [Leafy](https://leafyapp.uk) - Vocabulary builder: press ⌥A to scan any word on screen (PDFs, ebooks, and images via OCR), see the definition in place, and save it to a searchable local library. ![Freeware][Freeware Icon]
+* [Leafy](https://leafyapp.uk/) - Look up any word on screen with ⌥A, including in PDFs and images, and save it to a searchable local library. ![Freeware][Freeware Icon]
 * [Wokabulary](https://wokabulary.com/) - Collect, practice, and organize your individual foreign language vocabulary. [![App Store][app-store Icon]](https://apps.apple.com/app/apple-store/id1667619825?platform=mac)
 
 ## Finance


### PR DESCRIPTION
Adds **[Leafy](https://leafyapp.uk)** to the Education section.

Leafy is a vocabulary builder for macOS 14+, Apple Silicon only (Intel Macs should stay on version 1.14). Press ⌥A to scan any word on screen, including inside PDFs, ebooks and images via OCR, see the definition and pronunciation in place, and save the word to a searchable personal library organised in folders. No account required, and vocabulary data stays on the device.

Free tier with a daily scan limit; paid plans from $6.99/mo.

- Entry follows the list format (`* [Name](link) - Description. ![Freeware][Freeware Icon]`) and is placed alphabetically.
- Website: https://leafyapp.uk

_Description corrected 2026-08-23: the original said "Free", which was written before paid plans were published, and it did not mention that version 1.15 dropped Intel support._
