### PR TITLE
Add MoonProxy — GUI FRP desktop client for intranet penetration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1561,6 +1561,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 ## Remote Login Software
 
 * [AnyDesk](https://anydesk.com) - Provides remote access across multiple machines.
+* [MoonProxy](https://github.com/MoonProxyHQ/moonproxy-desktop) - GUI desktop client for FRP that puts local services on the internet with one click. [![Open-Source Software][OSS Icon]](https://github.com/MoonProxyHQ/moonproxy-desktop) ![Freeware][Freeware Icon]
 * [Moonlight](https://github.com/moonlight-stream/moonlight-qt) - GameStream client for PCs (Windows, Mac, Linux, and Steam Link). [![Open-Source Software][OSS Icon]](https://github.com/moonlight-stream/moonlight-qt) ![Freeware][Freeware Icon]
 * [Parsec](https://parsec.app) - Low-latency remote desktop and game streaming tool.
 * [RealVNC](https://www.realvnc.com) - The original and best software for remote access across desktop and mobile.


### PR DESCRIPTION
## What is MoonProxy?

MoonProxy is a cross-platform, GUI desktop client for [FRP (Fast Reverse Proxy)](https://github.com/fatedier/frp), built with Tauri v2 + Vue 3 + Rust. It lets non-technical users expose local services to the public internet with one click — no command line required.

## Why it fits

- **Category**: Remote Login Software — it provides remote access to local services (ERP, NAS, Minecraft servers, dev servers) via FRP tunnels
- **Platform**: macOS (Apple Silicon + Intel) ✅
- **Open Source**: MIT license ✅
- **Free**: /usr/bin/bash ✅
- **Native**: Tauri v2 (Rust backend), not Electron ✅

## Placement

Added under `## Remote Login Software`, alphabetically after AnyDesk.

## Links

- GitHub: https://github.com/MoonProxyHQ/moonproxy-desktop
- Homepage: https://moonproxy.app
- Downloads: https://github.com/MoonProxyHQ/moonproxy-desktop/releases/latest