### PR TITLE
Add Bosun to Developer Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [BetterRename](http://www.publicspace.net/BetterRename/) - The most powerful and complete Mac file renaming application on the market. [![App Store][app-store Icon]](https://apps.apple.com/us/app/better-rename-11/id1501308038?platform=mac)
 * [Beyond Compare](http://www.scootersoftware.com/) - Compare files and folders with powerful commands. ![Freeware][Freeware Icon]
 * [Bidbar](https://www.getbidbar.com) - Manage bash commands from the menu bar and run them with keyboard shortcuts.
+* [Bosun](https://bosun.dev) - Menu bar tool that shows every open port, ngrok/Cloudflare tunnel, VPN connection, and Docker container mapped to its process, with one-click kill.
 * [Cacher](https://www.cacher.io/) - Cloud-based code snippet manager with Gist sync and multi-platform support.
 * [CodeKit](https://codekitapp.com/) - Web development tool for compiling and auto-refreshing.
 * [CodeMenu](https://extiri.com/codemenu.html) - Advanced snippets manager with IDE integration, natural language search, and more.


### PR DESCRIPTION
Bosun is a native macOS menu bar app that shows every listening port, ngrok/Cloudflare tunnel, active VPN connection, and Docker container mapped to its process, with one-click kill.

Closed-source, paid with a 14-day free trial (bosun.dev).