### PR TITLE
Add StockDock (free open-source menu bar stock & portfolio tracker)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1086,6 +1086,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 
 * [SubManager](https://submanager.app) - Subscription tracker with renewal reminders. [![App Store][app-store Icon]](https://apps.apple.com/app/submanager-subscription-list/id1632853914?platform=mac)
 * [SubList](https://apps.apple.com/app/sublist-subscription-list/id6757860829?platform=mac) - Track subscriptions, renewals, and spending in one place with reminders, analytics, and iCloud sync.
+* [StockDock](https://github.com/simonsruggi/StockDock) - Menu bar app for real-time stocks, ETFs, crypto and portfolio P&L. Privacy-first, no account, multi-currency. [![Open-Source Software][OSS Icon]](https://github.com/simonsruggi/StockDock) ![Freeware][Freeware Icon]
 
 ## Encryption
 


### PR DESCRIPTION
Adds **StockDock** to the Finance section.

- Free & open source (MIT): https://github.com/simonsruggi/StockDock
- Native macOS menu bar app for real-time stocks, ETFs, crypto and portfolio P&L
- Privacy-first: no account, no API keys, no tracking

Entry follows the existing format with OSS + Freeware badges. Thanks for maintaining this list! 🙏