### PR TITLE
Add Settle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1443,6 +1443,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Omni](https://github.com/BarutSRB/OmniWM) - Notorized Niri and Hyprland inspired tiling window manager with animations. [![Open-Source Software][OSS Icon]](https://github.com/BarutSRB/OmniWM) ![Freeware][Freeware Icon]
 * [rcmd](https://lowtechguys.com/rcmd/) - Use the <kbd>⌘ Right Command</kbd> key to switch applications based on their name. [![App Store][app-store Icon]](https://apps.apple.com/us/app/rcmd-app-switcher/id1596283165?platform=mac)
 * [Rectangle-app](https://github.com/rxhanson/Rectangle) - Rectangle is a window management app based on Spectacle, written in Swift. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/rxhanson/Rectangle)
+* [Settle](https://settle.gokhangokova.com/) - Saves window layouts and switches them automatically on monitor change, time of day, or app launch.
 * [ShiftIt](https://github.com/fikovnik/ShiftIt) - Managing window size and position in OSX. [![Open-Source Software][OSS Icon]](https://github.com/fikovnik/ShiftIt) ![Freeware][Freeware Icon]
 * [ShortcutCycle](https://shortcutcycle.vercel.app/) - Switch between context-based app groups with a single hotkey. [![Open-Source Software][OSS Icon]](https://github.com/xcv58/ShortcutCycle) ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/us/app/shortcutcycle/id6758281578?platform=mac)
 * [Sidebar](http://sidebarapp.net/) - The modern Dock replacement for your Mac.


### PR DESCRIPTION
### Types of Changes

- [x] New addition to list
- [ ] Fixing bug in existing item in list
- [ ] Removing item from list
- [ ] Changing structure (organization) of list

### Proposed Changes

Settle is a native macOS window manager for the Window Management section. It saves window layouts and applies them automatically on monitor connect/disconnect, a set time of day, or when a specific app launches. This automatic, trigger-based switching is a capability the existing snap and tiling entries do not cover. It is paid ($9.99 one-time, 7-day trial), closed-source, and distributed as a Developer ID signed and notarized DMG (not on the Mac App Store), so no badge applies per the freeware/open-source/App-Store legend. Homepage: https://settle.gokhangokova.com/

### PR Checklist

- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important
- [ ] I have added necessary documentation (if appropriate)

### Further Comments
