### PR TITLE
Add PointFlow to Remote Login Software

### DIFF
--- a/README.md
+++ b/README.md
@@ -1569,6 +1569,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [MoonProxy](https://github.com/MoonProxyHQ/moonproxy-desktop) - GUI desktop client for FRP that puts local services on the internet with one click. [![Open-Source Software][OSS Icon]](https://github.com/MoonProxyHQ/moonproxy-desktop) ![Freeware][Freeware Icon]
 * [Moonlight](https://github.com/moonlight-stream/moonlight-qt) - GameStream client for PCs (Windows, Mac, Linux, and Steam Link). [![Open-Source Software][OSS Icon]](https://github.com/moonlight-stream/moonlight-qt) ![Freeware][Freeware Icon]
 * [Parsec](https://parsec.app) - Low-latency remote desktop and game streaming tool.
+* [PointFlow](https://github.com/supreeth-Finsamudra/pointflow) - Use a phone as the Mac's trackpad, keyboard, and terminal; view and type into tmux panes from the phone browser. [![Open-Source Software][OSS Icon]](https://github.com/supreeth-Finsamudra/pointflow) ![Freeware][Freeware Icon]
 * [RealVNC](https://www.realvnc.com) - The original and best software for remote access across desktop and mobile.
 * [RoyalTSX](https://www.royalapps.com/ts/mac/features) - Remote connection manager for multiple protocols. ![Freeware][Freeware Icon]
 * [RustDesk](https://rustdesk.com/) - Yet another remote desktop software. [![Open-Source Software][OSS Icon]](https://github.com/rustdesk/rustdesk) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds [PointFlow](https://github.com/supreeth-Finsamudra/pointflow) — a single ~4 MB Rust binary that serves a phone-browser UI: trackpad/keyboard input injection plus full-color xterm.js views of tmux panes and Terminal.app tabs, typeable from the phone. Token-paired via QR; optional Cloudflare quick tunnel for remote use. Open source (MIT), free.

Placed alphabetically in *Remote Login Software* with the OSS/Freeware icons per the list format.

Disclosure: I'm one of the authors. Happy to adjust wording, category, or placement.