### PR TITLE
Add Learn To Play It

### DIFF
--- a/README.md
+++ b/README.md
@@ -915,6 +915,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Jellyfin](https://github.com/jellyfin/jellyfin) - The Free Software Media System. [![Open-Source Software][OSS Icon]](https://jellyfin.org) ![Freeware][Freeware Icon]
 * [Kaset](https://github.com/sozercan/kaset) - Native YouTube Music client for macOS. [![Open-Source Software][OSS Icon]](https://github.com/sozercan/kaset) ![Freeware][Freeware Icon]
 * [Kodi](https://kodi.tv/) - Open-source media center for video, music, pictures, and more. [![Open-Source Software][OSS Icon]](https://github.com/xbmc/xbmc) ![Freeware][Freeware Icon]
+* [Learn To Play It](https://learntoplayit.com) - Isolate any instrument from a song, slow it down, and practice your part. [![Open-Source Software][OSS Icon]](https://github.com/tobycmurray/learn-to-play-it) ![Freeware][Freeware Icon]
 * [LMMS](https://lmms.io) - Open-source digital audio workstation for music production. [![Open-Source Software][OSS Icon]](https://github.com/lmms/lmms) ![Freeware][Freeware Icon]
 * [LosslessCut](https://github.com/mifi/lossless-cut) - Cross platform tool for quick and lossless video and audio trimming using ffmpeg. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/mifi/lossless-cut)
 * [LyricGlow](https://github.com/ateymoori/lyricglow) - Synced lyrics player with word-by-word glow effects. [![Open-Source Software][OSS Icon]](https://github.com/ateymoori/lyricglow) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds [Learn To Play It](https://github.com/tobycmurray/learn-to-play-it) to **Audio and Video Tools** — an open-source macOS app that isolates any instrument from a song (AI stem separation), slows it down, pitch-shifts, and loops sections so you can practice your part. In the same vein as *Stringed 2* already in this section.

- Free & open source (GPL-2.0), Apple Silicon
- Added alphabetically (between Kodi and LMMS), with the OSS + Freeware icons per the list's format.