### PR TITLE
Add Open Source Projects to Genuine Sites

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1615,6 +1615,7 @@ Awesome Mac
 * App Shopper：[http://appshopper.com/](http://appshopper.com/)
 * [Buy software, once](https://buyoncesoftware.com/) - 一度購入すれば一生使えるソフトウェアが見つかる場所。
 * [Open Alternative](https://openalternative.co/) - 人気ソフトウェアのオープンソース代替を発見。日常のSaaS製品に最適なオープンソースの代替品を厳選したコレクション。信頼性の高いツールで費用を節約。
+* [Open Source Projects](https://opensourceprojects.cc/) - オープンソースプロジェクトやプロプライエタリソフトウェアのオープンソース代替を発見。カテゴリ別に自己ホスト可能なコミュニティ主導のツールを探せる検索可能なディレクトリ。
 * MacUpdate：[https://www.macupdate.com/](https://www.macupdate.com/)
 * [MacStories](https://www.macstories.net/)、[LifeHacker](http://lifehacker.com/)、[ProductHunt](https://www.producthunt.com/topics/mac)などのサイトも素晴らしいリソースです。
 

--- a/README-ko.md
+++ b/README-ko.md
@@ -1058,6 +1058,7 @@ Awesome Mac
 * [alternativeTo](http://alternativeto.net/) - 소프트웨어 대안 검색 커뮤니티.
 * [ProductHunt](https://www.producthunt.com/topics/mac) - 새로운 최고의 Mac 앱을 발견하는 곳.
 * [Slant](https://www.slant.co) - 소프트웨어를 비교하고 커뮤니티 추천을 살펴볼 수 있는 플랫폼.
+* [Open Source Projects](https://opensourceprojects.cc/) - 오픈소스 프로젝트와 독점 소프트웨어의 오픈소스 대안을 발견하세요. 카테고리별로 자체 호스팅 가능한 커뮤니티 기반 도구를 찾을 수 있는 검색형 디렉터리.
 
 ## 팟캐스트
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -1495,6 +1495,7 @@ Awesome Mac
 * [Buy software, once](https://buyoncesoftware.com/) - 收集买断制软件的网站。
 * [Slant](https://www.slant.co) - 用于比较软件并查看社区推荐的平台。
 * [Open Alternative](https://openalternative.co/) - 发现流行软件的开源替代品。一个精心策划的最佳开源替代品集合 ，替代日常的SaaS产品。使用为您精心挑选的可靠工具节省金钱。
+* [Open Source Projects](https://opensourceprojects.cc/) - 发现开源项目和专有软件的开源替代品。一个可按分类搜索的目录，帮你找到可自托管的社区驱动工具。
 
 
 ### 盗版软件下载网站黑名单

--- a/README.md
+++ b/README.md
@@ -1618,6 +1618,7 @@ If you come across websites offering pirated software or cracks, please post [HE
 * App Shopper：[http://appshopper.com/](http://appshopper.com/)
 * [Buy software, once](https://buyoncesoftware.com/) - The place to find all the software you can buy one time, and own for a lifetime.
 * [Open Alternative](https://openalternative.co/) - Discover Open Source Alternatives to Popular Software. A curated collection of the best open source alternatives to everyday SaaS products. Save money with reliable tools hand-picked for you.
+* [Open Source Projects](https://opensourceprojects.cc/) - Discover open source projects and open source alternatives to proprietary software. A searchable directory to find self-hostable, community-driven tools by category.
 * MacUpdate：[https://www.macupdate.com/](https://www.macupdate.com/)
 * Other sites like [MacStories](https://www.macstories.net/), [LifeHacker](http://lifehacker.com/), [ProductHunt](https://www.producthunt.com/topics/mac) are great resources.
 


### PR DESCRIPTION
Adds [Open Source Projects](https://opensourceprojects.cc/) to the **Genuine Sites** section.

It is a searchable directory for discovering open source projects and open source alternatives to proprietary software, organized by category — a natural fit alongside the existing alternativeTo / Open Alternative / Slant entries in that section.

- Added in alphabetical order after `Open Alternative`
- Synced across all four READMEs (`README.md`, `README-zh.md`, `README-ja.md`, `README-ko.md`) with localized descriptions, per the contributing guidelines
- One-sentence description, title-cased link name