### PR TITLE
Add gridgallery

### DIFF
--- a/README.md
+++ b/README.md
@@ -752,6 +752,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Diffusion Bee](https://diffusionbee.com/) - The easiest way to generate AI art on your computer with Stable Diffusion. [![Open-Source Software][OSS Icon]](https://github.com/divamgupta/diffusionbee-stable-diffusion-ui/) ![Freeware][Freeware Icon]
 * [Eagle App](https://en.eagle.cool/) - Asset manager for images, videos, audio, fonts, and design files.
 * [ExifCleaner](https://exifcleaner.com) - Remove exif metadata from images and videos with drag and drop. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/szTheory/exifcleaner)
+* [GridGallery](https://apps.apple.com/us/app/gridgallery/id6745476787) - Arrange photos into a precision grid mosaic with automatic curation and seamless tiling. [![App Store][app-store Icon]](https://apps.apple.com/us/app/gridgallery/id6745476787)
 * [HEIC Converter](https://sindresorhus.com/heic-converter) - Convert HEIC images to JPEG or PNG. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/us/app/heic-converter-to-jpeg-or-png/id1294126402?platform=mac)
 * [Iconset](https://iconset.io) - Free, cross-platform and fast SVG icon organizer and manager for Mac and Windows.
 * [Iconjar](http://geticonjar.com/) - Icon management tool to organize or search your icons.

--- a/README.md
+++ b/README.md
@@ -752,7 +752,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Diffusion Bee](https://diffusionbee.com/) - The easiest way to generate AI art on your computer with Stable Diffusion. [![Open-Source Software][OSS Icon]](https://github.com/divamgupta/diffusionbee-stable-diffusion-ui/) ![Freeware][Freeware Icon]
 * [Eagle App](https://en.eagle.cool/) - Asset manager for images, videos, audio, fonts, and design files.
 * [ExifCleaner](https://exifcleaner.com) - Remove exif metadata from images and videos with drag and drop. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/szTheory/exifcleaner)
-* [GridGallery](https://apps.apple.com/us/app/gridgallery/id6745476787) - Arrange photos into a precision grid mosaic with automatic curation and seamless tiling. [![App Store][app-store Icon]](https://apps.apple.com/us/app/gridgallery/id6745476787)
+* [GridGallery](https://www.isleofthekakapo.com/gridgallery.html) - Arrange photos into a precision grid mosaic with automatic curation and seamless tiling. [![App Store][app-store Icon]](https://apps.apple.com/us/app/gridgallery/id6745476787)
 * [HEIC Converter](https://sindresorhus.com/heic-converter) - Convert HEIC images to JPEG or PNG. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/us/app/heic-converter-to-jpeg-or-png/id1294126402?platform=mac)
 * [Iconset](https://iconset.io) - Free, cross-platform and fast SVG icon organizer and manager for Mac and Windows.
 * [Iconjar](http://geticonjar.com/) - Icon management tool to organize or search your icons.


### PR DESCRIPTION
Adds GridGallery, a macOS app for arranging photos into grid mosaics, under Design and Product > Other Tools. 
Title links to the app's site, badge links to the App Store page, following the pattern used elsewhere in this section. Placed alphabetically between ExifCleaner and HEIC Converter. 
Kept the description to one sentence per the contributing guide.