### PR TITLE
Add Markout (native macOS Markdown editor)

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -238,6 +238,7 @@ Awesome Mac
 * [LightPaper](https://getlightpaper.com/) - Mac用のシンプルで美しく、かつ強力なテキストエディタ。
 * [MacDown](https://macdown.uranusjr.com/) - ライブプレビューおよびHTML/PDF出力に対応した、macOS向けのオープンソースMarkdownエディタ。 [![Open-Source Software][OSS Icon]](https://github.com/MacDownApp/macdown) ![Freeware][Freeware Icon]
 * [Marked 2](http://marked2app.com/) - すべてのライターのための洗練された強力なツールセットを備えたMarkdownプレビュー。
+* [Markout](https://github.com/maxmilian/markout) - Apple Silicon向けのmacOSネイティブMarkdownエディタ。分割ライブプレビュー、KaTeXの数式、Mermaidの図表に対応し、すべてオフラインでレンダリング、HTML/PDF出力も可能。 [![Open-Source Software][OSS Icon]](https://github.com/maxmilian/markout) ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [MarkText](https://github.com/marktext/marktext) - macOS、Windows、Linuxで動作する次世代Markdownエディタ。 [![Open-Source Software][OSS Icon]](https://github.com/marktext/marktext) ![Freeware][Freeware Icon]
 * [MarkViewer](https://markviewer.com) - macOS向けのMarkdownビューア兼エディタ、AI支援編集機能付き。 ![Freeware][Freeware Icon]
 * [Marp](https://marp.app) - クロスプラットフォーム対応のMarkdownプレゼンテーション作成ツール。 [![Open-Source Software][OSS Icon]](https://github.com/marp-team/marp) ![Freeware][Freeware Icon]

--- a/README-ko.md
+++ b/README-ko.md
@@ -212,6 +212,7 @@ Awesome Mac
 * [LightPaper](https://getlightpaper.com/) - 단순하고 아름다우면서도 강력한 Mac용 텍스트 편집기.
 * [MacDown](https://macdown.uranusjr.com/) - 실시간 미리보기와 HTML/PDF 내보내기를 지원하는 macOS용 오픈 소스 마크다운 편집기. [![Open-Source Software][OSS Icon]](https://github.com/MacDownApp/macdown) ![Freeware][Freeware Icon]
 * [Marked 2](http://marked2app.com/) - 작가들을 위한 우아하고 강력한 도구 세트를 갖춘 마크다운 미리보기.
+* [Markout](https://github.com/maxmilian/markout) - Apple Silicon용 macOS 네이티브 마크다운 편집기. 분할 실시간 미리보기, KaTeX 수식, Mermaid 다이어그램을 지원하며 완전히 오프라인으로 렌더링하고 HTML/PDF로 내보낼 수 있습니다. [![Open-Source Software][OSS Icon]](https://github.com/maxmilian/markout) ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [MarkText](https://github.com/marktext/marktext) - 차세대 마크다운 편집기. [![Open-Source Software][OSS Icon]](https://github.com/marktext/marktext) ![Freeware][Freeware Icon]
 * [MarkViewer](https://markviewer.com) - macOS용 마크다운 뷰어 겸 에디터, AI 보조 편집 지원. ![Freeware][Freeware Icon]
 * [Marp](https://marp.app) - 교차 플랫폼을 지원하는 마크다운 프레젠테이션 작성기. [![Open-Source Software][OSS Icon]](https://github.com/marp-team/marp) ![Freeware][Freeware Icon]

--- a/README-zh.md
+++ b/README-zh.md
@@ -858,6 +858,7 @@ Awesome Mac
 * [LightPaper](https://getlightpaper.com/) - 简单的 Markdown 文本编辑器。
 * [MacDown](https://macdown.uranusjr.com/) - macOS 开源 Markdown 编辑器，支持实时预览以及导出为 HTML 或 PDF。 [![Open-Source Software][OSS Icon]](https://github.com/MacDownApp/macdown) ![Freeware][Freeware Icon]
 * [Marked 2](http://marked2app.com/) - Markdown 文本预览编辑，为所有作家提供一套优雅而强大的工具。
+* [Markout](https://github.com/maxmilian/markout) - 面向 Apple Silicon 的 macOS 原生 Markdown 编辑器，分栏实时预览，支持 KaTeX 数学公式与 Mermaid 图表——完全离线渲染，可导出 HTML/PDF。 [![Open-Source Software][OSS Icon]](https://github.com/maxmilian/markout) ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [MarkText](https://marktext.app/) - 简单而优雅的 Markdown 编辑器，专注于速度和可用性。 [![Open-Source Software][OSS Icon]](https://github.com/marktext/marktext) ![Freeware][Freeware Icon]
 * [MarkViewer](https://markviewer.com) - 适用于 macOS 的 Markdown 查看器和编辑器，支持 AI 辅助编辑。 ![Freeware][Freeware Icon]
 * [Marp](https://marp.app) - Markdown 制作幻灯片编辑器。[![Open-Source Software][OSS Icon]](https://github.com/marp-team/marp) ![Freeware][Freeware Icon]

--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [LightPaper](https://getlightpaper.com/) - Simple, beautiful, yet powerful text editor for your Mac.
 * [MacDown](https://macdown.uranusjr.com/) - Open source Markdown editor for macOS with live preview and HTML/PDF export. [![Open-Source Software][OSS Icon]](https://github.com/MacDownApp/macdown) ![Freeware][Freeware Icon]
 * [Marked 2](https://marked2app.com/) - This is the Markdown preview with an elegant and powerful set of tools for all writers.
+* [Markout](https://github.com/maxmilian/markout) - Native macOS Markdown editor for Apple Silicon with split live preview, KaTeX math, and Mermaid diagrams — renders entirely offline, HTML/PDF export. [![Open-Source Software][OSS Icon]](https://github.com/maxmilian/markout) ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [MarkText](https://github.com/marktext/marktext) - Next generation markdown editor, running on platforms of MacOS Windows and Linux. [![Open-Source Software][OSS Icon]](https://github.com/marktext/marktext) ![Freeware][Freeware Icon]
 * [MarkViewer](https://markviewer.com) - Markdown viewer and editor for macOS with AI-assisted editing. ![Freeware][Freeware Icon]
 * [Marp](https://marp.app) - Markdown presentation writer with cross-platform support. [![Open-Source Software][OSS Icon]](https://github.com/marp-team/marp) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds **Markout** to the *Markdown Tools* section (alphabetically between Marked 2 and MarkText).

[Markout](https://github.com/maxmilian/markout) is an MIT-licensed, native macOS Markdown editor for Apple Silicon — a spiritual successor to the unmaintained MacDown. Split live preview with KaTeX math and Mermaid diagrams, everything rendered offline (no CDN), with HTML/PDF export.

- Open source: https://github.com/maxmilian/markout (MIT)
- Free / Freeware

Badges used: `[![Open-Source Software][OSS Icon]]` + `![Freeware][Freeware Icon]`, matching the existing entries.