### PR TITLE
Add ChaBox to encryption lists

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1091,6 +1091,7 @@ Awesome Mac
 
 ## 暗号化
 
+* [ChaBox](https://github.com/huanguan1978/chacrypt/tree/main/chabox) - ChaCha20-Poly1305 ベースのオープンソースなクロスプラットフォーム対応ファイル暗号化ツール。一括暗号化/復号、アーカイブ/展開、安全削除、セキュア日記機能を備えています。 [![Open-Source Software][OSS Icon]](https://github.com/huanguan1978/chacrypt) ![Freeware][Freeware Icon]
 * [Cryptomator](https://cryptomator.org/) - クラウド上のファイルのマルチプラットフォーム透過型クライアントサイド暗号化。 [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/cryptomator/cryptomator/)
 * [Deadbolt](https://github.com/alichtman/deadbolt) - オープンソースのファイル暗号化ツール。 [![Open-Source Software][OSS Icon]](https://github.com/alichtman/deadbolt) ![Freeware][Freeware Icon]
 

--- a/README-ko.md
+++ b/README-ko.md
@@ -822,6 +822,7 @@ Awesome Mac
 
 ## 암호화
 
+* [ChaBox](https://github.com/huanguan1978/chacrypt/tree/main/chabox) - ChaCha20-Poly1305 기반의 오픈 소스 크로스 플랫폼 파일 암호화 도구로, 일괄 암호화/복호화, 아카이브/해제, 안전 삭제, 보안 일기 기능을 제공합니다. [![Open-Source Software][OSS Icon]](https://github.com/huanguan1978/chacrypt) ![Freeware][Freeware Icon]
 * [Cryptomator](https://cryptomator.org/) - 클라우드 파일의 투명한 클라이언트 측 암호화. [![Open-Source Software][OSS Icon]](https://github.com/cryptomator/cryptomator) ![Freeware][Freeware Icon]
 
 ## 보안 도구

--- a/README-zh.md
+++ b/README-zh.md
@@ -1036,6 +1036,7 @@ Awesome Mac
 
 ## 安全工具
 
+* [ChaBox](https://github.com/huanguan1978/chacrypt/tree/main/chabox) - 开源跨平台文件加密工具，基于 ChaCha20-Poly1305，支持批量加解密、归档/解档、安全擦除和安全日记等实用功能。 [![Open-Source Software][OSS Icon]](https://github.com/huanguan1978/chacrypt) ![Freeware][Freeware Icon]
 * [Deadbolt](https://github.com/alichtman/deadbolt) - 开源文件加密工具。 [![Open-Source Software][OSS Icon]](https://github.com/alichtman/deadbolt) ![Freeware][Freeware Icon]
 * [Antivirus One](https://cleanerone.trendmicro.com/antivirus-one-for-mac/?utm_source=github&utm_medium=referral&utm_campaign=githubproject) - 用于扫描恶意软件、广告软件和网页威胁的安全工具。 ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/cn/app/apple-store/id1068435535?pt=444218&ct=GitHub&mt=8&platform=mac)
 * [BlockBlock](https://objective-see.com/products/blockblock.html) - 恶意软件会自行安装，以确保它在重新引导时自动重新执行。

--- a/README.md
+++ b/README.md
@@ -1094,6 +1094,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 
 ## Encryption
 
+* [ChaBox](https://github.com/huanguan1978/chacrypt/tree/main/chabox) - Open-source cross-platform file encryption tool based on ChaCha20-Poly1305, with batch encrypt/decrypt, archive/unarchive, secure wipe, and secure journal features. [![Open-Source Software][OSS Icon]](https://github.com/huanguan1978/chacrypt) ![Freeware][Freeware Icon]
 * [Cryptomator](https://cryptomator.org/) -  Multi-platform transparent client-side encryption of your files in the cloud. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/cryptomator/cryptomator/)
 * [Deadbolt](https://github.com/alichtman/deadbolt) - Open-source file encryption tool. [![Open-Source Software][OSS Icon]](https://github.com/alichtman/deadbolt) ![Freeware][Freeware Icon]
 


### PR DESCRIPTION
NOTE: A similar PR may already be submitted! Please search among the Pull request before creating one.

### Types of Changes

**What types of changes does your PR introduce?** Put an x in all boxes that apply

- [x] New addition to list
- [ ] Fixing bug in existing item in list
- [ ] Removing item from list
- [ ] Changing structure (organization) of list

### Proposed Changes

**Describe each of your changes here to communicate to the maintainers why we should accept this pull request.**

1. Added ChaBox to the Encryption sections in the English, Chinese, Japanese, and Korean README files.
2. ChaBox is a cross-platform file encryption tool based on ChaCha20-Poly1305, so it fits the Encryption category.
3. The localized descriptions were kept concise and aligned with each README’s existing style.
4. ChaBox also provides batch encrypt/decrypt, archive/unarchive, secure wipe, and secure journal features, which makes it a broader file security tool rather than a single-purpose encryptor.

### PR Checklist

Put an x in the boxes once you've completed each step. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important
- [x] I have added necessary documentation (if appropriate)

### Further Comments

This is a small localized list update only. No structural changes were made.
