### PR TITLE
Add Clavio to Voice-to-Text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1023,6 +1023,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Aiko](https://sindresorhus.com/aiko) - High-quality on-device transcription. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id1666327168?platform=mac)
 * [Azex Speech](https://github.com/azex-ai/speech) - Voice input tuned for mixed Chinese-English dictation in AI and crypto work. [![Open-Source Software][OSS Icon]](https://github.com/azex-ai/speech) ![Freeware][Freeware Icon]
 * [buzz](https://github.com/chidiwilliams/buzz) - Transcribes and translates audio offline on your personal computer. Powered by OpenAI's Whisper. [![Open-Source Software][OSS Icon]](https://github.com/chidiwilliams/buzz)
+* [Clavio](https://clavioapp.com) - AI hands-free dictation that adapts to every app, with wake word, per-app tone, and optional auto-send. [`brew install --cask zhingel/clavio/clavio`]
 * [EnviousWispr](https://enviouswispr.com) - Sub-second dictation running Whisper/Parakeet locally with privacy-first AI text polish. ![Freeware][Freeware Icon]
 * [FnKey](https://github.com/evoleinik/fnkey) - Push-to-talk voice input tool that pastes transcribed text instantly. [![Open-Source Software][OSS Icon]](https://github.com/evoleinik/fnkey) ![Freeware][Freeware Icon]
 * [OpenDictation](https://github.com/kdcokenny/OpenDictation) - Open-source dictation utility with local and cloud speech-to-text. [![Open-Source Software][OSS Icon]](https://github.com/kdcokenny/OpenDictation) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds Clavio to the Voice-to-Text section. Clavio is an AI dictation app for macOS: hold a key or say a wake word, speak in any app, and it types clean, punctuated text in the tone that app calls for, with optional auto-send. Installs via a Homebrew cask (brew install --cask zhingel/clavio/clavio); notarized, macOS 14+. Free tier — https://clavioapp.com