### PR TITLE
Add FileNav to Finder Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1481,6 +1481,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Command X](https://sindresorhus.com/command-x) - Cut and paste files in Finder. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id1666327168?platform=mac)
 * [Default Folder X](https://www.stclairsoft.com/DefaultFolderX/index.html) - Quick access to your files and folders in every app.
 * [FileMinutes](https://www.fileminutes.com/) - Find files and take actions, all in one.
+* [FileNav](https://www.filenav.app/) - Windows Explorer-style file manager with dual-pane browsing, a folder tree sidebar, and a built-in disk visualizer.
 * [FinderFix](https://synappser.github.io/apps/finderfix/) - Finally, a lasting solution for Finder windows size and position. ![Freeware][Freeware Icon].
 * [SaneClick](https://saneclick.com) - Finder extension that adds right-click actions for file tasks, conversion, and developer tools. [![Open-Source Software][OSS Icon]](https://github.com/sane-apps/SaneClick) ![Freeware][Freeware Icon]
 * [FlowVision](https://github.com/netdcy/FlowVision) - RWaterfall-style Image Viewer for macOS. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/netdcy/FlowVision)


### PR DESCRIPTION
### Types of Changes

- [x] New addition to list
- [ ] Fixing bug in existing item in list
- [ ] Removing item from list
- [ ] Changing structure (organization) of list

### Proposed Changes

Adds **FileNav**, a native macOS file manager with a Windows Explorer-style
workflow — dual-pane browsing, a folder tree sidebar, an editable address bar,
and a built-in disk visualizer. It targets people switching from Windows who
want familiar file-management behavior on macOS, plus power features Finder
lacks.

Placed in **Finder Tools** in alphabetical order (between FileMinutes and
FinderFix), with no icon badge — matching other paid, closed-source apps sold
from their own site such as ForkLift and Path Finder.

Website: https://www.filenav.app

### PR Checklist

- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important
- [x] I have added necessary documentation (if appropriate)

### Further Comments

Single-line addition following the existing entry format. Happy to also add it
to the zh / ja / ko README versions if preferred.