### PR TITLE
Add Burrete

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1582,6 +1582,7 @@ Awesome Mac
 
 > [![Awesome List][awesome-list Icon]](https://github.com/sindresorhus/quick-look-plugins#readme)
 
+* [Burrete](https://burrete-landing.vercel.app/) - PDB、SDF、mmCIF、XYZ、トラジェクトリ、化学テーブルを Finder のクイックルックで表示できるオープンソースの分子ワークスペース。 [![Open-Source Software][OSS Icon]](https://github.com/SergeiNikolenko/Burrete) ![Freeware][Freeware Icon]
 * [CSV Quick Look](https://github.com/adamorad/csv-quick-look) - 仮想スクロール、並べ替え、フィルター、ダークモードに対応した CSV/TSV 用 Quick Look 拡張。 [![Open-Source Software][OSS Icon]](https://github.com/adamorad/csv-quick-look) ![Freeware][Freeware Icon]
 * [QLMarkdown](https://github.com/sbarex/QLMarkdown) - Markdownファイル用のクイックルック拡張機能。 - ![Freeware][Freeware Icon] ![Open-Source Software][OSS Icon]
 * [FluxMarkdown](https://github.com/xykong/flux-markdown) - Mermaid や KaTeX にも対応した Markdown 用 Quick Look 拡張。 [![Open-Source Software][OSS Icon]](https://github.com/xykong/flux-markdown) ![Freeware][Freeware Icon]

--- a/README-ko.md
+++ b/README-ko.md
@@ -1041,6 +1041,7 @@ Awesome Mac
 
 ## QuickLook 플러그인
 
+* [Burrete](https://burrete-landing.vercel.app/) - PDB, SDF, mmCIF, XYZ, 트래젝터리 및 화학 테이블을 Finder Quick Look으로 미리 보는 오픈 소스 분자 작업 공간. [![Open-Source Software][OSS Icon]](https://github.com/SergeiNikolenko/Burrete) ![Freeware][Freeware Icon]
 * [CSV Quick Look](https://github.com/adamorad/csv-quick-look) - 가상 스크롤, 정렬, 필터, 다크 모드를 지원하는 CSV/TSV용 Quick Look 확장. [![Open-Source Software][OSS Icon]](https://github.com/adamorad/csv-quick-look) ![Freeware][Freeware Icon]
 * [QLMarkdown](https://github.com/sbarex/QLMarkdown) - 마크다운 파일을 위한 Quick Look 도구. [![Open-Source Software][OSS Icon]](https://github.com/sbarex/QLMarkdown) ![Freeware][Freeware Icon]
 * [FluxMarkdown](https://github.com/xykong/flux-markdown) - Markdown, Mermaid, KaTeX 등을 미리 보는 Quick Look 확장. [![Open-Source Software][OSS Icon]](https://github.com/xykong/flux-markdown) ![Freeware][Freeware Icon]

--- a/README-zh.md
+++ b/README-zh.md
@@ -1453,6 +1453,7 @@ Awesome Mac
 
 *使用 [Homebrew Cask](https://github.com/phinze/homebrew-cask) 将通过命令安装即为简单。开发人员使用的[Quick Look](http://en.wikipedia.org/wiki/Quick_Look)插件列表。如果手动安装，你可将下载的 `.qlgenerator` 文件移动到 `~/Library/QuickLook` 运行 `qlmanage -r`*
 
+* [Burrete](https://burrete-landing.vercel.app/) - 开源分子工作区，可通过 Finder 快速查看 PDB、SDF、mmCIF、XYZ、轨迹和化学数据表。 [![Open-Source Software][OSS Icon]](https://github.com/SergeiNikolenko/Burrete) ![Freeware][Freeware Icon]
 * [CSV Quick Look](https://github.com/adamorad/csv-quick-look) - 支持虚拟滚动、排序、筛选和深色模式的 CSV/TSV Quick Look 预览扩展。 [![Open-Source Software][OSS Icon]](https://github.com/adamorad/csv-quick-look) ![Freeware][Freeware Icon]
 * [QuicklookStephen](https://github.com/whomwah/qlstephen) - 可以让您查看没有文件扩展名的纯文本文件，如 README、INSTALL、Capfile、CHANGELOG...`brew install --cask install qlstephen`
 * [FluxMarkdown](https://github.com/xykong/flux-markdown) - 支持 Mermaid、KaTeX 等内容的 Markdown 快速预览插件。 [![Open-Source Software][OSS Icon]](https://github.com/xykong/flux-markdown) ![Freeware][Freeware Icon]

--- a/README.md
+++ b/README.md
@@ -1586,6 +1586,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 
 > [![Awesome List][awesome-list Icon]](https://github.com/sindresorhus/quick-look-plugins#readme)
 
+* [Burrete](https://burrete-landing.vercel.app/) - Open-source molecular workspace with Finder Quick Look previews for PDB, SDF, mmCIF, XYZ, trajectories, and chemistry tables. [![Open-Source Software][OSS Icon]](https://github.com/SergeiNikolenko/Burrete) ![Freeware][Freeware Icon]
 * [CSV Quick Look](https://github.com/adamorad/csv-quick-look) - Quick Look extension for CSV and TSV files with virtual scrolling, sorting, filtering, and dark mode. [![Open-Source Software][OSS Icon]](https://github.com/adamorad/csv-quick-look) ![Freeware][Freeware Icon]
 * [QLMarkdown](https://github.com/sbarex/QLMarkdown) - Quick Look extension for Markdown files. - ![Freeware][Freeware Icon] ![Open-Source Software][OSS Icon]
 * [FluxMarkdown](https://github.com/xykong/flux-markdown) - Quick Look extension for Markdown previews with Mermaid, KaTeX, GFM, TOC, and charts. [![Open-Source Software][OSS Icon]](https://github.com/xykong/flux-markdown) ![Freeware][Freeware Icon]


### PR DESCRIPTION
## Summary

Adds Burrete to the QuickLook Plugins section in the English, Chinese, Japanese, and Korean README files.

Burrete is a free open-source molecular workspace with Finder Quick Look previews for common chemistry and structural-biology file formats.

## Affiliation

I maintain Burrete. This submission follows the repository multilingual curation rules and changes only the four listing files.