### PR TITLE
Add Data Maestro to Developer Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Cutter](https://cutter.re/) - Powerful multi-platform reverse engineering tool. ![Open-Source Software][OSS Icon]
 * [DevHub](https://wangchujiang.com/DevHub/) - Feature-rich offline app for developers. ![OSS][OSS Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/devhub/id6476452351?platform=mac)
 * [Dash](https://kapeli.com/dash) - Awesome API documentation browser and code snippet manager. ![Freeware][Freeware Icon]
+* [Data Maestro](https://datamaestro.rbstech.app) - Generates realistic fake data and anonymizes PII in files or live databases, with direct connectors for 14 databases. ![Native App][Native Icon]
 * [Deeplink Buddy](https://deeplinkbuddy.com) - Deeplink managers, made by developer for developers.
 * [DiffMerge](http://sourcegear.com/diffmerge/) - Application to visually compare and merge files. ![Freeware][Freeware Icon]
 * [EnvPane](https://github.com/hschmidt/EnvPane) - OS X preference pane for environment variables. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/hschmidt/EnvPane)


### PR DESCRIPTION
Adding [Data Maestro](https://datamaestro.rbstech.app), a native macOS app (SwiftUI + Rust core) for generating realistic fake test data and anonymizing PII in files or live databases, with direct connectors for 14 databases (Postgres, MongoDB, ClickHouse, etc.).

Placed alphabetically in Developer Utilities between Dash and Deeplink Buddy, tagged as a native app (not Electron).