### PR TITLE
Add VocAI to Voice-to-Text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1035,6 +1035,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Spokenly](https://spokenly.app/) - Voice-to-text with 100+ languages, offline mode, and AI-powered formatting.
 * [Tambourine](https://tambourinevoice.com/) - Open-source, customizable AI voice dictation that works in any app. [![Open-Source Software][OSS Icon]](https://github.com/kstonekuan/tambourine-voice/) ![Freeware][Freeware Icon]
 * [TypeWhisper](https://www.typewhisper.com) - Local Whisper-based speech-to-text with a global hotkey. [![Open-Source Software][OSS Icon]](https://github.com/TypeWhisper/typewhisper-mac) ![Freeware][Freeware Icon]
+* [VocAI](https://vocai.net) - Private meeting notes and dictation; records calls without a bot, transcribes on-device. ![Freeware][Freeware Icon]
 * [VoiceInk](https://tryvoiceink.com/) - Real-time speech-to-text app. [![Open-Source Software][OSS Icon]](https://github.com/Beingpax/VoiceInk) ![Freeware][Freeware Icon]
 * [VoxFlow](https://github.com/xingbofeng/VoxFlow) - Open-source voice input workspace with local and cloud ASR, OCR, history, and coding-agent workflows. [![Open-Source Software][OSS Icon]](https://github.com/xingbofeng/VoxFlow) ![Freeware][Freeware Icon]
 * [Voxt](https://github.com/hehehai/voxt) - Hold-to-talk voice input tool with AI transcription rules per app and URL, and built-in translation. [![Open-Source Software][OSS Icon]](https://github.com/hehehai/voxt) ![Freeware][Freeware Icon]


### PR DESCRIPTION
- [VocAI](https://vocai.net) - Private meeting notes and dictation for Mac; records calls without a bot, transcribes on-device (WhisperKit/Parakeet).

Checked:
- Alphabetical order within the Voice-to-Text section (between TypeWhisper and VoiceInk)
- Format matches existing entries; Freeware icon (free tier: 60 min/mo, no account)
- macOS 15+, Apple Silicon, notarized, direct DMG download