### PR TITLE
Add Flitdrop to File Sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -880,6 +880,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 
 * [Cyberduck](https://cyberduck.io) - Free FTP, SFTP, WebDAV, S3, Backblaze B2, Azure and OpenStack Swift browser. ![Freeware][Freeware Icon]
 * [Dropshare](https://dropshare.app) - File sharing tool for screenshots, screen recordings, and other files.
+* [Flitdrop](https://flitdrop.com/) - Send files, photos and clipboard between any phone and any computer over your local Wi-Fi. Nothing to install on the phone, just scan a QR code once. End-to-end encrypted. ![Freeware][Freeware Icon]
 * [Flow](http://fivedetails.com/flow/) - Award-winning, beautiful, fast, and reliable FTP + SFTP client.
 * [LocalSend](https://localsend.org/) - An open-source cross-platform alternative to AirDrop. [![Open-Source Software][OSS Icon]](https://github.com/localsend/localsend) ![Freeware][Freeware Icon]
 * [NearDrop](https://github.com/grishka/NearDrop) - An unofficial Google Nearby Share/Quick Share app for macOS. [![Open-Source Software][OSS Icon]](https://github.com/localsend/localsend) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds **Flitdrop** under **File Sharing** (alphabetical, between Dropshare and Flow).

- **What it is:** a free tool to send files, photos and clipboard between any phone and any computer over the local Wi-Fi. Nothing to install on the phone — you just scan a QR code once. Transfers are end-to-end encrypted.
- **Homepage:** https://flitdrop.com/
- **License:** free (freeware icon used, not the OSS icon).
- Works alongside the already-listed LocalSend / NearDrop, cross-platform including macOS.

Single addition, alphabetically placed, icon reference reused from the existing list. Thanks for maintaining this list!