### PR TITLE
Add TickerNotch to Finance

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1098,7 +1098,7 @@ Awesome Mac
 * [SubManager](https://submanager.app) - 更新通知に対応したサブスクリプション管理ツール。 [![App Store][app-store Icon]](https://apps.apple.com/app/submanager-subscription-list/id1632853914?platform=mac)
 * [SubList](https://apps.apple.com/app/sublist-subscription-list/id6757860829?platform=mac) - リマインダー、分析、iCloud同期でサブスクリプション、更新、支出を1か所で追跡。
 * [StockDock](https://github.com/simonsruggi/StockDock) - メニューバーで株・ETF・暗号資産のリアルタイム相場を表示するツール。ポートフォリオ損益と多通貨に対応し、プライバシー重視でアカウント不要。 [![Open-Source Software][OSS Icon]](https://github.com/simonsruggi/StockDock) ![Freeware][Freeware Icon]
-* [TickerNotch](https://bitvibelabs.com/tickernotch/) - MacBookのノッチ横の黒い領域に株・暗号資産の相場、ニュース、天気、SNSフォロワー数を表示。ローソク足チャートと価格アラート付き。 ![Native App][Native Icon]
+* [TickerNotch](https://bitvibelabs.com/tickernotch/) - MacBookのノッチ横の黒い領域に株・暗号資産の相場、ニュース、天気、SNSフォロワー数を表示。メニューバーにピン留めも可能。ローソク足チャートと価格アラート付き。 ![Native App][Native Icon]
 
 ## 暗号化
 

--- a/README-ja.md
+++ b/README-ja.md
@@ -1098,7 +1098,7 @@ Awesome Mac
 * [SubManager](https://submanager.app) - 更新通知に対応したサブスクリプション管理ツール。 [![App Store][app-store Icon]](https://apps.apple.com/app/submanager-subscription-list/id1632853914?platform=mac)
 * [SubList](https://apps.apple.com/app/sublist-subscription-list/id6757860829?platform=mac) - リマインダー、分析、iCloud同期でサブスクリプション、更新、支出を1か所で追跡。
 * [StockDock](https://github.com/simonsruggi/StockDock) - メニューバーで株・ETF・暗号資産のリアルタイム相場を表示するツール。ポートフォリオ損益と多通貨に対応し、プライバシー重視でアカウント不要。 [![Open-Source Software][OSS Icon]](https://github.com/simonsruggi/StockDock) ![Freeware][Freeware Icon]
-* [TickerNotch](https://bitvibelabs.com/tickernotch/) - MacBookのノッチ横の黒い領域に株・暗号資産の相場、ニュース、天気、SNSフォロワー数を表示。メニューバーにピン留めも可能。ローソク足チャートと価格アラート付き。 ![Native App][Native Icon]
+* [TickerNotch](https://bitvibelabs.com/tickernotch/) - MacBookのノッチ横に株・暗号資産の相場、ニュース、天気、SNSフォロワー数を表示。メニューバーにピン留めも可能。ローソク足チャートと価格アラート付き。 ![Native App][Native Icon]
 
 ## 暗号化
 

--- a/README-ja.md
+++ b/README-ja.md
@@ -1098,6 +1098,7 @@ Awesome Mac
 * [SubManager](https://submanager.app) - 更新通知に対応したサブスクリプション管理ツール。 [![App Store][app-store Icon]](https://apps.apple.com/app/submanager-subscription-list/id1632853914?platform=mac)
 * [SubList](https://apps.apple.com/app/sublist-subscription-list/id6757860829?platform=mac) - リマインダー、分析、iCloud同期でサブスクリプション、更新、支出を1か所で追跡。
 * [StockDock](https://github.com/simonsruggi/StockDock) - メニューバーで株・ETF・暗号資産のリアルタイム相場を表示するツール。ポートフォリオ損益と多通貨に対応し、プライバシー重視でアカウント不要。 [![Open-Source Software][OSS Icon]](https://github.com/simonsruggi/StockDock) ![Freeware][Freeware Icon]
+* [TickerNotch](https://bitvibelabs.com/tickernotch/) - MacBookのノッチ横の黒い領域に株・暗号資産のリアルタイム相場、RSSニュース、価格アラート、ポジション損益を表示。クリックでローソク足チャート、アカウント不要。 ![Native App][Native Icon]
 
 ## 暗号化
 

--- a/README-ja.md
+++ b/README-ja.md
@@ -1098,7 +1098,7 @@ Awesome Mac
 * [SubManager](https://submanager.app) - 更新通知に対応したサブスクリプション管理ツール。 [![App Store][app-store Icon]](https://apps.apple.com/app/submanager-subscription-list/id1632853914?platform=mac)
 * [SubList](https://apps.apple.com/app/sublist-subscription-list/id6757860829?platform=mac) - リマインダー、分析、iCloud同期でサブスクリプション、更新、支出を1か所で追跡。
 * [StockDock](https://github.com/simonsruggi/StockDock) - メニューバーで株・ETF・暗号資産のリアルタイム相場を表示するツール。ポートフォリオ損益と多通貨に対応し、プライバシー重視でアカウント不要。 [![Open-Source Software][OSS Icon]](https://github.com/simonsruggi/StockDock) ![Freeware][Freeware Icon]
-* [TickerNotch](https://bitvibelabs.com/tickernotch/) - MacBookのノッチ横の黒い領域に株・暗号資産のリアルタイム相場、RSSニュース、価格アラート、ポジション損益を表示。クリックでローソク足チャート、アカウント不要。 ![Native App][Native Icon]
+* [TickerNotch](https://bitvibelabs.com/tickernotch/) - MacBookのノッチ横の黒い領域に株・暗号資産の相場、ニュース、天気、SNSフォロワー数を表示。ローソク足チャートと価格アラート付き。 ![Native App][Native Icon]
 
 ## 暗号化
 

--- a/README-ko.md
+++ b/README-ko.md
@@ -830,7 +830,7 @@ Awesome Mac
 * [SubManager](https://submanager.app/) - 갱신 알림을 제공하는 구독 관리 도구. [![App Store][app-store Icon]](https://apps.apple.com/app/submanager-subscription-list/id1632853914?platform=mac)
 * [SubList](https://apps.apple.com/app/sublist-subscription-list/id6757860829?platform=mac) - 알림, 분석 및 iCloud 동기화를 통해 한 곳에서 구독, 갱신 및 지출을 추적.
 * [StockDock](https://github.com/simonsruggi/StockDock) - 메뉴 바에서 주식, ETF, 암호화폐 실시간 시세를 보여주는 도구. 포트폴리오 손익과 다중 통화를 지원하며, 개인정보 보호에 중점을 둔 계정 불필요. [![Open-Source Software][OSS Icon]](https://github.com/simonsruggi/StockDock) ![Freeware][Freeware Icon]
-* [TickerNotch](https://bitvibelabs.com/tickernotch/) - MacBook 노치 양옆의 검은 영역에 주식·암호화폐 실시간 시세, RSS 뉴스, 가격 알림, 포지션 손익을 표시. 클릭하면 캔들 차트 창 열림, 계정 불필요. ![Native App][Native Icon]
+* [TickerNotch](https://bitvibelabs.com/tickernotch/) - MacBook 노치 양옆의 검은 영역에 주식·암호화폐 시세, 뉴스, 날씨, 소셜 팔로워 수를 표시. 캔들 차트와 가격 알림 지원. ![Native App][Native Icon]
 
 ## 암호화
 

--- a/README-ko.md
+++ b/README-ko.md
@@ -830,7 +830,7 @@ Awesome Mac
 * [SubManager](https://submanager.app/) - 갱신 알림을 제공하는 구독 관리 도구. [![App Store][app-store Icon]](https://apps.apple.com/app/submanager-subscription-list/id1632853914?platform=mac)
 * [SubList](https://apps.apple.com/app/sublist-subscription-list/id6757860829?platform=mac) - 알림, 분석 및 iCloud 동기화를 통해 한 곳에서 구독, 갱신 및 지출을 추적.
 * [StockDock](https://github.com/simonsruggi/StockDock) - 메뉴 바에서 주식, ETF, 암호화폐 실시간 시세를 보여주는 도구. 포트폴리오 손익과 다중 통화를 지원하며, 개인정보 보호에 중점을 둔 계정 불필요. [![Open-Source Software][OSS Icon]](https://github.com/simonsruggi/StockDock) ![Freeware][Freeware Icon]
-* [TickerNotch](https://bitvibelabs.com/tickernotch/) - MacBook 노치 양옆의 검은 영역에 주식·암호화폐 시세, 뉴스, 날씨, 소셜 팔로워 수를 표시하고 메뉴 막대에 고정할 수도 있음. 캔들 차트와 가격 알림 지원. ![Native App][Native Icon]
+* [TickerNotch](https://bitvibelabs.com/tickernotch/) - MacBook 노치 양옆에 주식·암호화폐 시세, 뉴스, 날씨, 소셜 팔로워 수를 표시하고 메뉴 막대에 고정할 수도 있음. 캔들 차트와 가격 알림 지원. ![Native App][Native Icon]
 
 ## 암호화
 

--- a/README-ko.md
+++ b/README-ko.md
@@ -830,7 +830,7 @@ Awesome Mac
 * [SubManager](https://submanager.app/) - 갱신 알림을 제공하는 구독 관리 도구. [![App Store][app-store Icon]](https://apps.apple.com/app/submanager-subscription-list/id1632853914?platform=mac)
 * [SubList](https://apps.apple.com/app/sublist-subscription-list/id6757860829?platform=mac) - 알림, 분석 및 iCloud 동기화를 통해 한 곳에서 구독, 갱신 및 지출을 추적.
 * [StockDock](https://github.com/simonsruggi/StockDock) - 메뉴 바에서 주식, ETF, 암호화폐 실시간 시세를 보여주는 도구. 포트폴리오 손익과 다중 통화를 지원하며, 개인정보 보호에 중점을 둔 계정 불필요. [![Open-Source Software][OSS Icon]](https://github.com/simonsruggi/StockDock) ![Freeware][Freeware Icon]
-* [TickerNotch](https://bitvibelabs.com/tickernotch/) - MacBook 노치 양옆의 검은 영역에 주식·암호화폐 시세, 뉴스, 날씨, 소셜 팔로워 수를 표시. 캔들 차트와 가격 알림 지원. ![Native App][Native Icon]
+* [TickerNotch](https://bitvibelabs.com/tickernotch/) - MacBook 노치 양옆의 검은 영역에 주식·암호화폐 시세, 뉴스, 날씨, 소셜 팔로워 수를 표시하고 메뉴 막대에 고정할 수도 있음. 캔들 차트와 가격 알림 지원. ![Native App][Native Icon]
 
 ## 암호화
 

--- a/README-ko.md
+++ b/README-ko.md
@@ -830,6 +830,7 @@ Awesome Mac
 * [SubManager](https://submanager.app/) - 갱신 알림을 제공하는 구독 관리 도구. [![App Store][app-store Icon]](https://apps.apple.com/app/submanager-subscription-list/id1632853914?platform=mac)
 * [SubList](https://apps.apple.com/app/sublist-subscription-list/id6757860829?platform=mac) - 알림, 분석 및 iCloud 동기화를 통해 한 곳에서 구독, 갱신 및 지출을 추적.
 * [StockDock](https://github.com/simonsruggi/StockDock) - 메뉴 바에서 주식, ETF, 암호화폐 실시간 시세를 보여주는 도구. 포트폴리오 손익과 다중 통화를 지원하며, 개인정보 보호에 중점을 둔 계정 불필요. [![Open-Source Software][OSS Icon]](https://github.com/simonsruggi/StockDock) ![Freeware][Freeware Icon]
+* [TickerNotch](https://bitvibelabs.com/tickernotch/) - MacBook 노치 양옆의 검은 영역에 주식·암호화폐 실시간 시세, RSS 뉴스, 가격 알림, 포지션 손익을 표시. 클릭하면 캔들 차트 창 열림, 계정 불필요. ![Native App][Native Icon]
 
 ## 암호화
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -1045,6 +1045,7 @@ Awesome Mac
 
 * [SubList](https://apps.apple.com/app/sublist-subscription-list/id6757860829?platform=mac) - 在一个地方跟踪订阅、续费和支出，提供提醒、分析和 iCloud 同步。
 * [StockDock](https://github.com/simonsruggi/StockDock) - 菜单栏股票/ETF/加密货币实时行情工具，支持投资组合盈亏、多币种，注重隐私无需账户。 [![Open-Source Software][OSS Icon]](https://github.com/simonsruggi/StockDock) ![Freeware][Freeware Icon]
+* [TickerNotch](https://bitvibelabs.com/tickernotch/) - 在 MacBook 刘海两侧的黑色区域显示股票/加密货币实时行情、滚动 RSS 新闻、价格提醒和持仓盈亏，点击可打开K线图窗口，无需账户。 ![Native App][Native Icon]
 
 ## 安全工具
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -1045,7 +1045,7 @@ Awesome Mac
 
 * [SubList](https://apps.apple.com/app/sublist-subscription-list/id6757860829?platform=mac) - 在一个地方跟踪订阅、续费和支出，提供提醒、分析和 iCloud 同步。
 * [StockDock](https://github.com/simonsruggi/StockDock) - 菜单栏股票/ETF/加密货币实时行情工具，支持投资组合盈亏、多币种，注重隐私无需账户。 [![Open-Source Software][OSS Icon]](https://github.com/simonsruggi/StockDock) ![Freeware][Freeware Icon]
-* [TickerNotch](https://bitvibelabs.com/tickernotch/) - 在 MacBook 刘海两侧的黑色区域显示股票/加密货币实时行情、滚动 RSS 新闻、价格提醒和持仓盈亏，点击可打开K线图窗口，无需账户。 ![Native App][Native Icon]
+* [TickerNotch](https://bitvibelabs.com/tickernotch/) - 在 MacBook 刘海两侧的黑色区域显示股票/加密货币行情、新闻、天气和社交关注数，支持K线图窗口和价格提醒。 ![Native App][Native Icon]
 
 ## 安全工具
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -1045,7 +1045,7 @@ Awesome Mac
 
 * [SubList](https://apps.apple.com/app/sublist-subscription-list/id6757860829?platform=mac) - 在一个地方跟踪订阅、续费和支出，提供提醒、分析和 iCloud 同步。
 * [StockDock](https://github.com/simonsruggi/StockDock) - 菜单栏股票/ETF/加密货币实时行情工具，支持投资组合盈亏、多币种，注重隐私无需账户。 [![Open-Source Software][OSS Icon]](https://github.com/simonsruggi/StockDock) ![Freeware][Freeware Icon]
-* [TickerNotch](https://bitvibelabs.com/tickernotch/) - 在 MacBook 刘海两侧的黑色区域显示股票/加密货币行情、新闻、天气和社交关注数，支持K线图窗口和价格提醒。 ![Native App][Native Icon]
+* [TickerNotch](https://bitvibelabs.com/tickernotch/) - 在 MacBook 刘海两侧的黑色区域显示股票/加密货币行情、新闻、天气和社交关注数，也可固定到菜单栏。支持K线图窗口和价格提醒。 ![Native App][Native Icon]
 
 ## 安全工具
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -1045,7 +1045,7 @@ Awesome Mac
 
 * [SubList](https://apps.apple.com/app/sublist-subscription-list/id6757860829?platform=mac) - 在一个地方跟踪订阅、续费和支出，提供提醒、分析和 iCloud 同步。
 * [StockDock](https://github.com/simonsruggi/StockDock) - 菜单栏股票/ETF/加密货币实时行情工具，支持投资组合盈亏、多币种，注重隐私无需账户。 [![Open-Source Software][OSS Icon]](https://github.com/simonsruggi/StockDock) ![Freeware][Freeware Icon]
-* [TickerNotch](https://bitvibelabs.com/tickernotch/) - 在 MacBook 刘海两侧的黑色区域显示股票/加密货币行情、新闻、天气和社交关注数，也可固定到菜单栏。支持K线图窗口和价格提醒。 ![Native App][Native Icon]
+* [TickerNotch](https://bitvibelabs.com/tickernotch/) - 在 MacBook 刘海两侧显示股票/加密货币行情、新闻、天气和社交关注数，也可固定到菜单栏。支持K线图窗口和价格提醒。 ![Native App][Native Icon]
 
 ## 安全工具
 

--- a/README.md
+++ b/README.md
@@ -1101,7 +1101,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [SubManager](https://submanager.app) - Subscription tracker with renewal reminders. [![App Store][app-store Icon]](https://apps.apple.com/app/submanager-subscription-list/id1632853914?platform=mac)
 * [SubList](https://apps.apple.com/app/sublist-subscription-list/id6757860829?platform=mac) - Track subscriptions, renewals, and spending in one place with reminders, analytics, and iCloud sync.
 * [StockDock](https://github.com/simonsruggi/StockDock) - Menu bar app for real-time stocks, ETFs, crypto and portfolio P&L. Privacy-first, no account, multi-currency. [![Open-Source Software][OSS Icon]](https://github.com/simonsruggi/StockDock) ![Freeware][Freeware Icon]
-* [TickerNotch](https://bitvibelabs.com/tickernotch/) - Live stock and crypto tickers, news, weather and social counters in the black bars beside the MacBook notch, or pinned to the menu bar. Candlestick charts and price alerts included. ![Native App][Native Icon]
+* [TickerNotch](https://bitvibelabs.com/tickernotch/) - Live stock and crypto tickers, news, weather and social counters beside the MacBook notch, or pinned to the menu bar. Candlestick charts and price alerts included. ![Native App][Native Icon]
 
 ## Encryption
 

--- a/README.md
+++ b/README.md
@@ -1101,7 +1101,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [SubManager](https://submanager.app) - Subscription tracker with renewal reminders. [![App Store][app-store Icon]](https://apps.apple.com/app/submanager-subscription-list/id1632853914?platform=mac)
 * [SubList](https://apps.apple.com/app/sublist-subscription-list/id6757860829?platform=mac) - Track subscriptions, renewals, and spending in one place with reminders, analytics, and iCloud sync.
 * [StockDock](https://github.com/simonsruggi/StockDock) - Menu bar app for real-time stocks, ETFs, crypto and portfolio P&L. Privacy-first, no account, multi-currency. [![Open-Source Software][OSS Icon]](https://github.com/simonsruggi/StockDock) ![Freeware][Freeware Icon]
-* [TickerNotch](https://bitvibelabs.com/tickernotch/) - Live stock and crypto tickers, scrolling RSS news, price alerts, and position P&L in the black bars beside the MacBook notch, with candlestick chart windows. No account required. ![Native App][Native Icon]
+* [TickerNotch](https://bitvibelabs.com/tickernotch/) - Live stock and crypto tickers, news, weather and social counters in the black bars beside the MacBook notch, with candlestick charts and price alerts. ![Native App][Native Icon]
 
 ## Encryption
 

--- a/README.md
+++ b/README.md
@@ -1101,6 +1101,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [SubManager](https://submanager.app) - Subscription tracker with renewal reminders. [![App Store][app-store Icon]](https://apps.apple.com/app/submanager-subscription-list/id1632853914?platform=mac)
 * [SubList](https://apps.apple.com/app/sublist-subscription-list/id6757860829?platform=mac) - Track subscriptions, renewals, and spending in one place with reminders, analytics, and iCloud sync.
 * [StockDock](https://github.com/simonsruggi/StockDock) - Menu bar app for real-time stocks, ETFs, crypto and portfolio P&L. Privacy-first, no account, multi-currency. [![Open-Source Software][OSS Icon]](https://github.com/simonsruggi/StockDock) ![Freeware][Freeware Icon]
+* [TickerNotch](https://bitvibelabs.com/tickernotch/) - Live stock and crypto tickers, scrolling RSS news, price alerts, and position P&L in the black bars beside the MacBook notch, with candlestick chart windows. No account required. ![Native App][Native Icon]
 
 ## Encryption
 

--- a/README.md
+++ b/README.md
@@ -1101,7 +1101,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [SubManager](https://submanager.app) - Subscription tracker with renewal reminders. [![App Store][app-store Icon]](https://apps.apple.com/app/submanager-subscription-list/id1632853914?platform=mac)
 * [SubList](https://apps.apple.com/app/sublist-subscription-list/id6757860829?platform=mac) - Track subscriptions, renewals, and spending in one place with reminders, analytics, and iCloud sync.
 * [StockDock](https://github.com/simonsruggi/StockDock) - Menu bar app for real-time stocks, ETFs, crypto and portfolio P&L. Privacy-first, no account, multi-currency. [![Open-Source Software][OSS Icon]](https://github.com/simonsruggi/StockDock) ![Freeware][Freeware Icon]
-* [TickerNotch](https://bitvibelabs.com/tickernotch/) - Live stock and crypto tickers, news, weather and social counters in the black bars beside the MacBook notch, with candlestick charts and price alerts. ![Native App][Native Icon]
+* [TickerNotch](https://bitvibelabs.com/tickernotch/) - Live stock and crypto tickers, news, weather and social counters in the black bars beside the MacBook notch, or pinned to the menu bar. Candlestick charts and price alerts included. ![Native App][Native Icon]
 
 ## Encryption
 


### PR DESCRIPTION
NOTE: Searched existing PRs/issues for "TickerNotch". No prior suggestion found.

### Types of Changes

- [x] New addition to list
- [ ] Fixing bug in existing item in list
- [ ] Removing item from list
- [ ] Changing structure (organization) of list

### Proposed Changes

1. Adds **[TickerNotch](https://bitvibelabs.com/tickernotch/)** to the **Finance** section (alphabetical position, after StockDock), synced across `README.md`, `README-zh.md`, `README-ja.md`, and `README-ko.md`.
2. Why it should be added: it fills a spot no current entry covers. It renders live stock/crypto tickers, scrolling RSS news, and position P&L in the black bars beside the MacBook notch (simulated island on external and non-notch displays). Clicking a ticker opens candlestick chart windows; %-move and price-cross alerts fire native notifications. Native Swift/SwiftUI (not Electron), 6.5 MB DMG, signed + notarized (Developer ID), Sparkle auto-update, macOS 14+. Market data flows in-process (Hyperliquid WebSocket for crypto, Yahoo polling for stocks, user RSS feeds), with no account and no vendor server in the data path. Freemium: 7-day full trial, then free forever with 1 ticker + 1 news channel + 1 alert (no card); Pro unlocks more. Placed in Finance following the StockDock precedent (menu-bar real-time stocks/crypto/P&L); Native App icon only, per the freemium convention (no Freeware icon).

### PR Checklist

- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important
- [x] I have added necessary documentation (if appropriate)

### Further Comments

Disclosure: I'm the developer (BitVibe Labs, independent solo studio). Screenshots and a demo are on the landing page: https://bitvibelabs.com/tickernotch/
