### PR TITLE
Add Deckle to Menu Bar Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1207,6 +1207,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [DayBar](https://wangchujiang.com/daybar/) - An application that can display the local date and reminder events in the menu bar. [![App Store][app-store Icon]](https://apps.apple.com/app/daybar/6739052447?platform=mac)
 * [Droppy](https://iordv.github.io/Droppy/) - Turns your screen's notch (or Dynamic Island) into a multifunctional tool. [![Open-Source Software][OSS Icon]](https://github.com/iordv/Droppy) ![Freeware][Freeware Icon]
 * [Dato](https://sindresorhus.com/dato) - A better menu bar clock with calendar, events, and time zones. [![App Store][app-store Icon]](https://apps.apple.com/us/app/dato/id1470584107?platform=mac)
+* [Deckle](https://github.com/YellowFoxH4XOR/deckle) - Lays a subtle procedural paper-grain texture over the whole screen to make the display feel less like backlit glass. Click-through, menu bar only. [![Open-Source Software][OSS Icon]](https://github.com/YellowFoxH4XOR/deckle) ![Freeware][Freeware Icon]
 * [Dozer](https://github.com/Mortennn/Dozer) - Hide MacOS menubar items. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/Mortennn/Dozer)
 * [DynamicHorizon](https://dynamichorizon.app) - Adds media controls, notifications, and system indicators to the notch area.
 * [Eye Timer](https://adelmaer.com/eyetimer) - Take Breaks to prevent Eye Strain timer for Mac. [![App Store][app-store Icon]](https://apps.apple.com/us/app/eye-timer/id1485856873?platform=mac)


### PR DESCRIPTION
Adds [Deckle](https://github.com/YellowFoxH4XOR/deckle), a free and open-source (MIT) macOS menu-bar app that lays a subtle procedural paper-grain texture over the whole screen so it feels less like backlit glass. Click-through, signed & notarized.

Added under **Menu Bar Tools**, in alphabetical order, with the Open-Source and Freeware badges per the list format.