### PR TITLE
Add HugoKit to Developer Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Gemini](https://macpaw.com/gemini) - Intelligent duplicate file finder.
 * [Hex Fiend](https://ridiculousfish.com/hexfiend/) - Fast and clever open source hex editor. [![Open-Source Software][OSS Icon]](https://github.com/ridiculousfish/HexFiend/) ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/hex-fiend/id1342896380?platform=mac)
 * [Hosts.prefpane](https://github.com/specialunderwear/Hosts.prefpane) - System preference pane to manage your hosts file. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/specialunderwear/Hosts.prefpane)
+* [HugoKit](https://hugokit.com) - Native macOS app for running, previewing and publishing Hugo static sites without the terminal. ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [Icon Preview](https://sindresorhus.com/icon-preview) - Preview your app icon and menu bar icon. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id6480373509?platform=mac)
 * [iHosts](https://en.toolinbox.net/iHosts/) - The only `/etc/hosts` editor on Mac App Store. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id1102004240?platform=mac)
 * [Itsyconnect](https://github.com/nickustinov/itsyconnect-macos) - App Store Connect client for metadata, TestFlight, reviews, analytics, and localization. [![Open-Source Software][OSS Icon]](https://github.com/nickustinov/itsyconnect-macos)


### PR DESCRIPTION
### Types of Changes

**What types of changes does your PR introduce?**

- [x] New addition to list
- [ ] Fixing bug in existing item in list
- [ ] Removing item from list
- [ ] Changing structure (organization) of list

### Proposed Changes

Adds **HugoKit** to the Developer Utilities section (under Developer Tools), in alphabetical order after `Hosts.prefpane`.

HugoKit is a free, native macOS app for Hugo. It runs the dev server, previews pages and templates, edits front matter and `hugo.toml`, runs a preflight check before publishing, and deploys to GitHub Pages or over SFTP – all without the terminal. It works on the Hugo sites you already have and leaves your files as it found them.

Badges: Freeware + Native App (free to use, native SwiftUI). It's closed-source and macOS 26+. The description is kept to one sentence per the contributing guide.

Full disclosure: I'm the author, and it's a free personal project.

### PR Checklist

- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important
- [ ] I have added necessary documentation (if appropriate)

### Further Comments

Single-line addition, placed in Developer Utilities alongside comparable web tooling (CodeKit, Koala, MJML). Happy to move it or adjust the wording if you'd prefer a different spot.