### PR TITLE
Add TabType (open-source on-device AI autocomplete) to list of Mac applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [SkyFonts](https://skyfonts.com/) - The simplest way to try, install, and manage fonts.
 * [SmoothCSV](https://smoothcsv.com/) - Fast, full-featured CSV editor with SQL queries. ![Freeware][Freeware Icon]
 * [Spillo](https://bananafishsoftware.com/products/spillo/) - Powerful, beautiful and amazingly fast Pinboard client for OS X.
+* [TabType](https://github.com/nilava/TabType) - Free, open-source AI autocomplete for every Mac app — on-device ghost-text suggestions powered by a local LLM (MLX); nothing leaves your Mac. [![Open-Source Software][OSS Icon]](https://github.com/nilava/TabType) ![Freeware][Freeware Icon]
 * [Tad](https://www.tadviewer.com) - Application for viewing and analyzing tabular data such as CSV files. [![Open-Source Software][OSS Icon]](https://github.com/antonycourtney/tad) ![Freeware][Freeware Icon]
 * [texifier](https://www.texifier.com/) - Great LaTeX editor for Mac with auto-update PDF and autocomplete LaTeX commands.
 * [UPDF](https://updf.com/) - Free PDF editor for reading, annotating, and editing PDFs. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id1619925971?platform=mac)


### PR DESCRIPTION
NOTE: A similar PR may already be submitted! Please search among the Pull request before creating one.

### Types of Changes

- [x] New addition to list
- [ ] Fixing bug in existing item in list
- [ ] Removing item from list
- [ ] Changing structure (organization) of list

### Proposed Changes

Adds **[TabType](https://github.com/nilava/TabType)** — a free, open-source (MIT) AI autocomplete for macOS.

Why it should be added:

1. It fills a gap in the list: system-wide inline ghost-text autocomplete (the "Cotypist" category) currently has no open-source entry. TabType works in any Mac app — chat apps, browsers, editors — with Tab-to-accept suggestions.
2. It is fully **on-device**: a local LLM (Qwen3-4B via Apple's MLX Swift) generates the suggestions; no account, no cloud, no telemetry — nothing the user types ever leaves the Mac.
3. Native Swift/AppKit app, actively maintained, with a signed DMG on the [releases page](https://github.com/nilava/TabType/releases) (v0.1.0) and full build-from-source instructions.

The entry follows the existing format and is inserted in alphabetical order within its section.

### PR Checklist

- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important
- [ ] I have added necessary documentation (if appropriate)

### Further Comments

TabType is an early-stage alpha and the README discloses this (plus a full AI-assistance disclosure). Happy to adjust the entry wording, section, or formatting if the maintainers prefer.