### PR TITLE
Add yap to Note-taking

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -273,6 +273,7 @@ Awesome Mac
 * [Quick Note](https://quicknoteapp.com) - メニューバーのカラフルな付箋。 [![App Store][app-store Icon]](https://apps.apple.com/in/app/quick-note-in-the-menu/id1472935217?platform=mac)
 * [Quiver](http://happenapps.com/#quiver) - テキスト、コード、Markdown、LaTeXをライブプレビュー付きで1つのノートに統合。
 * [VNote](https://app.vnote.fun/) - 洗練されたエディタを備えたオープンソースのMarkdownノートアプリ。 [![Open-Source Software][OSS Icon]](https://github.com/vnotex/vnote/) ![Freeware][Freeware Icon]
+* [yap](https://useyap.app) - 声に出して考える人のためのボイスファーストノート。ホットキーを押しながら話すだけで、生の思考を保存し、整理された検索可能なノートと決定事項・タスクの抽出を提供。
 * [Zettel](https://github.com/AlexW00/Zettel) - Markdownとハッシュタグ整理に対応した、ミニマルで集中しやすいメモアプリ。 [![Open-Source Software][OSS Icon]](https://github.com/AlexW00/Zettel) [![App Store][app-store Icon]](https://apps.apple.com/app/zettel-quick-notes/id6748525244?platform=mac)
 
 ### ジャーナリング

--- a/README-ko.md
+++ b/README-ko.md
@@ -247,6 +247,7 @@ Awesome Mac
 * [Quick Note](https://quicknoteapp.com) - 메뉴바의 다채로운 스티키 노트. [![App Store][app-store Icon]](https://apps.apple.com/in/app/quick-note-in-the-menu/id1472935217?platform=mac)
 * [Quiver](http://happenapps.com/#quiver) - 텍스트, 코드, 마크다운, LaTeX를 하나의 노트에서 믹스.
 * [VNote](https://app.vnote.fun/) - 완성도 높은 편집 경험을 제공하는 오픈 소스 마크다운 노트 앱. [![Open-Source Software][OSS Icon]](https://github.com/vnotex/vnote/) ![Freeware][Freeware Icon]
+* [yap](https://useyap.app) - 소리 내어 생각하는 사람을 위한 음성 우선 노트. 단축키를 누른 채 말하면 원본 생각을 보존하고, 정리된 검색 가능한 노트와 결정·할 일 추출을 제공.
 * [Zettel](https://github.com/AlexW00/Zettel) - Markdown과 해시태그 정리를 지원하는 미니멀한 무방해 노트 앱. [![Open-Source Software][OSS Icon]](https://github.com/AlexW00/Zettel) [![App Store][app-store Icon]](https://apps.apple.com/app/zettel-quick-notes/id6748525244?platform=mac)
 
 ### 저널링

--- a/README-zh.md
+++ b/README-zh.md
@@ -866,6 +866,7 @@ Awesome Mac
 * [Revu](https://revu.cards/) - 本地优先的间隔重复学习应用，支持 FSRS 排程和 Anki 导入。 [![Open-Source Software][OSS Icon]](https://github.com/JuliusBrussee/revu-swift) ![Native App][Native Icon]
 * [Stik](https://github.com/0xMassi/stik_app) - 支持全局快捷键和 AI 语义搜索的快速 Markdown 笔记应用。 [![Open-Source Software][OSS Icon]](https://github.com/0xMassi/stik_app) ![Freeware][Freeware Icon]
 * [VNote](https://app.vnote.fun/) - 带优秀编辑体验的开源 Markdown 笔记应用。 [![Open-Source Software][OSS Icon]](https://github.com/vnotex/vnote/) ![Freeware][Freeware Icon]
+* [yap](https://useyap.app) - 为爱边说边想的人打造的语音笔记：按住全局快捷键说话，即可保留原始语音内容，并生成可搜索的整洁笔记，自动提取决定和待办。
 * [Zettel](https://github.com/AlexW00/Zettel) - 极简无干扰笔记应用，支持 Markdown 和标签整理。 [![Open-Source Software][OSS Icon]](https://github.com/AlexW00/Zettel) [![App Store][app-store Icon]](https://apps.apple.com/app/zettel-quick-notes/id6748525244?platform=mac)
 * [为知笔记](http://www.wiz.cn/download.html) - 支持 Markdown，搜集整理图片链接导入文档。![Freeware][Freeware Icon]
 * [有道云笔记](http://note.youdao.com/) - 支持多目录，Markdown，iWork/Office 预览。![Freeware][Freeware Icon]

--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Quick Note](https://quicknoteapp.com) - Colorful sticky notes in the Menu bar. [![App Store][app-store Icon]](https://apps.apple.com/in/app/quick-note-in-the-menu/id1472935217?platform=mac)
 * [Quiver](http://happenapps.com/#quiver) - Mix text, code, Markdown, and LaTeX in one note with live preview.
 * [VNote](https://app.vnote.fun/) - Open-source Markdown note-taking app with a polished editor. [![Open-Source Software][OSS Icon]](https://github.com/vnotex/vnote/) ![Freeware][Freeware Icon]
+* [yap](https://useyap.app) - Voice-first notes for people who think out loud: hold a hotkey anywhere, talk, and get the raw thought plus a clean, searchable version with extracted decisions and todos.
 * [Zettel](https://github.com/AlexW00/Zettel) - Minimal, distraction-free note-taking app with Markdown and hashtag-based organization. [![Open-Source Software][OSS Icon]](https://github.com/AlexW00/Zettel) [![App Store][app-store Icon]](https://apps.apple.com/app/zettel-quick-notes/id6748525244?platform=mac)
 
 ### Journaling


### PR DESCRIPTION
Adds [yap](https://useyap.app) to the Note-taking section (all four README translations synced).

yap is a voice-first note-taking app for macOS: hold a global hotkey from any app, talk, release — it keeps the raw transcript, generates a clean readable version, and extracts decisions/todos. Menubar app with a notch overlay showing a live waveform while recording. Signed and notarized.

I'm the developer. Entry placed alphabetically (before Zettel), matching the existing entry format.