### PR TITLE
Add Burst2GIF (Lightroom burst-to-GIF/MP4 plugin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -748,6 +748,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [APNGb](https://github.com/mancunianetz/APNGb) - PNG image assembler/disassembler app. [![Open-Source Software][OSS Icon]](https://github.com/mancunianetz/APNGb) ![Freeware][Freeware Icon]
 * [Aspect](https://aspect.bildhuus.com) - Photo organization app with peer-to-peer sync. ![Freeware][Freeware Icon]
 * [Assetizr](https://assetizr.com) - Resizing images and optimising them for web and mobile applications.  ![Freeware][Freeware Icon]
+* [Burst2GIF](https://www.marektopolar.com/tools/burst2gif) - Lightroom Classic plugin that converts burst photo sequences into MP4 videos or animated GIFs.
 * [Lap](https://github.com/julyx10/lap) - Local photo manager for browsing and organizing personal media libraries offline. [![Open-Source Software][OSS Icon]](https://github.com/julyx10/lap) ![Freeware][Freeware Icon]
 * [Couleurs](http://couleursapp.com) - Simple app for grabbing and tweaking the colors you see on your screen. ![Freeware][Freeware Icon]
 * [CompressO](https://github.com/codeforreal1/compressO) - Open-source tool for compressing videos and images to smaller sizes. [![Open-Source Software][OSS Icon]](https://github.com/codeforreal1/compressO) ![Freeware][Freeware Icon]


### PR DESCRIPTION
## What is Burst2GIF?

Burst2GIF is a plugin for Adobe Lightroom Classic that converts burst photo sequences into MP4 videos or animated GIFs directly inside Lightroom — no Photoshop or separate video editor needed.

- Live preview with FPS control (auto-detected from EXIF SubSecTime)
- Exports MP4 (H.264, up to 6K) or GIF, preserves all develop edits
- Free version available (10 exports); Standard is a one-time $29 license
- macOS, Lightroom Classic 10.0+, notarized by Apple

Added to **Design and Product → Other Tools**, alphabetical order, matching the existing entry format (similar tool already listed: Preset Brewery).

Built by a wedding photographer for photographers. Website: https://www.marektopolar.com/tools/burst2gif

🤖 Generated with [Claude Code](https://claude.com/claude-code)