### PR TITLE
Add LidRun to System Related Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1547,6 +1547,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [iStats](https://github.com/Chris911/iStats) - Command-line system information tool. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/Chris911/iStats)
 * [Juice](https://github.com/brianmichel/Juice) - Enhanced battery information display. [![Open-Source Software][OSS Icon]](https://github.com/brianmichel/Juice) ![Freeware][Freeware Icon]
 * [KeepingYouAwake](https://github.com/newmarcel/KeepingYouAwake) - Caffeine alternative with dark mode support. [![Open-Source Software][OSS Icon]](https://github.com/newmarcel/KeepingYouAwake)
+* [LidRun](https://lidrun.com) - Keep your Mac awake with the lid closed for long AI/dev runs, with timers and battery/thermal safety. ![Freeware][Freeware Icon]
 * [macUSB](https://github.com/Kruszoneq/macUSB) - A bootable macOS / OS X installer creator for Apple Silicon Macs. [![Open-Source Software][OSS Icon]](https://github.com/Kruszoneq/macUSB) ![Freeware][Freeware Icon]
 * [MagicQuit](https://magicquit.com/) - Automatically quit inactive apps to reduce clutter and free resources. [![Open-Source Software][OSS Icon]](https://github.com/BigBerny/magicquit) ![Freeware][Freeware Icon]
 * [MiddleDrag](https://github.com/NullPointerDepressiveDisorder/MiddleDrag) - Three-finger trackpad gestures for middle-click and middle-drag on macOS. [![Open-Source Software][OSS Icon]](https://github.com/NullPointerDepressiveDisorder/MiddleDrag) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds **LidRun** to *Utilities → System Related Tools*, alongside Amphetamine and KeepingYouAwake.

**LidRun** is a menu-bar app that keeps a Mac awake — including with the lid closed — for long AI/dev workloads (Claude Code, Cursor, Docker, Ollama). It only holds the Mac awake while work is actually running and auto-releases with battery/thermal guardrails, timers and charging-only mode. Signed and notarized by Apple; macOS 13+.

- Homepage: https://lidrun.com
- Free forever for basic keep-awake sessions; Pro is a one-time purchase. Marked `Freeware` for the free tier, the same way Amphetamine is listed.
- Placed near the other keep-awake apps, description ends with a period per the format.