### PR TITLE
Add MailMerge for Gmail to Email Clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -869,6 +869,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [CanaryMail](https://canarymail.io/) - Secure email app for Mac and iPhone with built-in PGP Support and AI assistance. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/us/app/canary-mail-email-meet-ai/id1236045954?platform=mac)
 * [ElectronMail](https://github.com/vladimiry/ElectronMail) - An Electron-based unofficial desktop client for ProtonMail. [![Open-Source Software][OSS Icon]](https://github.com/vladimiry/ElectronMail) ![Freeware][Freeware Icon]
 * [Foxmail](https://www.foxmail.com/mac/en) - Fast email client. ![Freeware][Freeware Icon]
+* [MailMerge for Gmail](https://asishvault.gumroad.com/l/tjykl) - Mail merge app that sends personalized, one at a time emails through your own Gmail. Recipient lists stay in local files on your Mac.
 * [MailTags](https://smallcubed.com/) - Use tags to organize email and schedule.
 * [Mailspring](https://getmailspring.com/) - A beautiful, fast, and fully open source mail client. [![Open-Source Software][OSS Icon]](https://github.com/Foundry376/Mailspring) ![Freeware][Freeware Icon]
 * [N1](https://www.nylas.com/) - Extensible, open-source mail app, free for developers and $7/month for Pro. ![Open-Source Software][OSS Icon]


### PR DESCRIPTION
### Types of Changes

**What types of changes does your PR introduce?**

- [x] New addition to list
- [ ] Fixing bug in existing item in list
- [ ] Removing item from the list

### Description

Adds **MailMerge for Gmail** to Email Clients, in alphabetical order.

It is a paid Mac app (no freeware icon, matching MailTags and Postbox) for sending personalized, one at a time mail merges through the user's own Gmail via an App Password. Recipients load from CSV or Excel files, every column becomes a personalization tag, and each email can be previewed before sending. Recipient lists stay in local files on the user's machine.

Product page with screenshots: https://asishvault.gumroad.com/l/tjykl