### PR TITLE
Add Scribe to Voice-to-Text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1038,6 +1038,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [OpenTypeless](https://github.com/tover0314-w/opentypeless) - Open-source AI voice input that types polished text into any app. [![Open-Source Software][OSS Icon]](https://github.com/tover0314-w/opentypeless) ![Freeware][Freeware Icon]
 * [Ottex](https://ottex.ai) - AI dictation tool that formats text for the app or site you are using.
 * [Presspeech](https://github.com/rcourtman/presspeech) - Native push-to-talk local dictation app for Apple Silicon Macs using Parakeet TDT v3 (CoreML/ANE). [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/rcourtman/presspeech)
+* [Scribe](https://github.com/AgentC-Consulting/scribe-app) - Free-for-life on-device dictation (Parakeet on the Neural Engine): hotkey typing into any app, meeting transcription with speaker labels, no cloud or account. ![Freeware][Freeware Icon]
 * [Spokenly](https://spokenly.app/) - Voice-to-text with 100+ languages, offline mode, and AI-powered formatting.
 * [Tambourine](https://tambourinevoice.com/) - Open-source, customizable AI voice dictation that works in any app. [![Open-Source Software][OSS Icon]](https://github.com/kstonekuan/tambourine-voice/) ![Freeware][Freeware Icon]
 * [TypeWhisper](https://www.typewhisper.com) - Local Whisper-based speech-to-text with a global hotkey. [![Open-Source Software][OSS Icon]](https://github.com/TypeWhisper/typewhisper-mac) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds [Scribe](https://github.com/AgentC-Consulting/scribe-app) — free-for-life, fully on-device macOS dictation (NVIDIA Parakeet v3 on the Apple Neural Engine). Hotkey dictation typed at the cursor in any app, meeting transcription with speaker labels from system audio, transcribe audio files. No cloud, no account. Signed and notarized (Developer ID), distributed via GitHub Releases and a Homebrew cask. Placed alphabetically in Voice-to-Text.