### PR TITLE
Add EyeBreak to Menu Bar Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1216,6 +1216,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Dozer](https://github.com/Mortennn/Dozer) - Hide MacOS menubar items. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/Mortennn/Dozer)
 * [DynamicHorizon](https://dynamichorizon.app) - Adds media controls, notifications, and system indicators to the notch area.
 * [Eye Timer](https://adelmaer.com/eyetimer) - Take Breaks to prevent Eye Strain timer for Mac. [![App Store][app-store Icon]](https://apps.apple.com/us/app/eye-timer/id1485856873?platform=mac)
+* [EyeBreak](https://github.com/sviatil0/eyebreak) - Menu bar 20-20-20 break reminders to reduce digital eye strain. No camera, no network. [![Open-Source Software][OSS Icon]](https://github.com/sviatil0/eyebreak) ![Freeware][Freeware Icon]
 * [Repose](https://github.com/fikrikarim/repose) - Menu bar break timer that dims your screen and pauses during calls. [![Open-Source Software][OSS Icon]](https://github.com/fikrikarim/repose) ![Freeware][Freeware Icon]
 * [Fishing Funds](https://ff.1zilc.top) - Display real-time trends of Chinese funds in the menubar. [![Open-Source Software][OSS Icon]](https://github.com/1zilc/fishing-funds) ![Freeware][Freeware Icon]
 * [GoogleDriveSync](https://github.com/saihgupr/GoogleDriveSync) - A menu bar app for seamless Google Drive syncing. [![Open-Source Software][OSS Icon]](https://github.com/saihgupr/GoogleDriveSync)


### PR DESCRIPTION
Adds [EyeBreak](https://github.com/sviatil0/eyebreak) to **Utilities → Menu Bar Tools**.

EyeBreak is a free, open-source (MIT) macOS menu-bar app that reminds you to take 20-20-20 screen breaks to reduce digital eye strain. Native Swift, zero third-party dependencies, no camera, and no network access (no analytics or telemetry).

- Single entry added in alphabetical order, right after "Eye Timer" in the same section.
- Marked with the Open-Source Software and Freeware icons, matching neighbouring entries.
- No `Contents` change needed (no new category).

🤖 Generated with [Claude Code](https://claude.com/claude-code)