### PR TITLE
Add Terminal Candy to Terminal Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,6 +619,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [kitty](https://github.com/kovidgoyal/kitty) - A cross-platform, fast, feature full, GPU based terminal emulator. [![Open-Source Software][OSS Icon]](https://github.com/kovidgoyal/kitty) ![Freeware][Freeware Icon]
 * [KubeSwitch](https://www.kubeswitch.com/) - The fastest way to switch between Kubernetes contexts and namespaces on macOS. ![Freeware][Freeware Icon]
 * [Tabby (formerly Terminus)](https://github.com/Eugeny/tabby) - Free terminal tool, built with TypeScript, heavily inspired by Hyper. [![Open-Source Software][OSS Icon]](https://github.com/Eugeny/terminus) ![Freeware][Freeware Icon]
+* [Terminal Candy](https://terminalcandy.com) - Skinnable native terminal that turns any image into a working terminal, with alerts when AI coding agents finish.
 * [Termius](https://www.termius.com/) - A beautiful SSH and SFTP client for Mac. It is also available for mobile. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/us/app/termius-terminal-ssh-client/id549039908?platform=mac)
 * [tty7](https://github.com/l0ng-ai/tty7) - A GPU-rendered, daemon-backed terminal in pure Rust with sessions that stay alive without tmux. [![Open-Source Software][OSS Icon]](https://github.com/l0ng-ai/tty7) ![Freeware][Freeware Icon]
 * [Vesta](https://github.com/vestaterm/Vesta) - Native macOS terminal built on libghostty for running coding agents in parallel. [![Open-Source Software][OSS Icon]](https://github.com/vestaterm/Vesta) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds **[Terminal Candy](https://terminalcandy.com)** to Terminal Apps (alphabetical, between Tabby and Termius).

Terminal Candy is a native macOS (Apple Silicon) terminal built around visual skins: any image becomes a working terminal via the built-in Skin Builder, skins swap live with no restart, and it can alert you (Dock bounce / sound / bring-to-front) when AI coding agents like Claude Code or Codex CLI finish or need input. Real PTY underneath (SwiftTerm): full VT, true color, scrollback, multi-session.

- Commercial app (free 14-day trial, $10 one-time license) — entry follows the paid-app convention with no icons, like SecureCRT / ZOC Terminal in this section.
- Disclosure: I'm the developer.