### PR TITLE
Add Chronoid to Productivity section

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1367,6 +1367,7 @@ Awesome Mac
 * [BetterTouchTool](https://folivora.ai/) - トラックパッド、マウス、キーボードのジェスチャーや操作を細かくカスタマイズできるツール。
 * [Cerebro](https://cerebroapp.com/) - 頭脳を持つオープンソースの生産性向上ツール。 [![Open-Source Software][OSS Icon]](https://github.com/cerebroapp/cerebro) ![Freeware][Freeware Icon]
 * [Choosy](https://www.choosyosx.com) - リンクをどこでどのように開くかのルールを管理するUI、URL API、ブラウザ拡張機能のセット。
+* [Chronoid](https://www.chronoid.app/) - アプリやウェブサイトの利用時間を自動記録し、データをローカルに保存する時間追跡ツール。
 * [CurrentKey](https://currentkey.com) - Spacesに名前とアイコンを付けて、アプリごとの利用時間を追跡するツール。 [![App Store][app-store Icon]](https://apps.apple.com/us/app/currentkey/id1456226992?mt=12)
 * [CursorSense](https://www.plentycom.jp/en/cursorsense/index.html) - アクセラレーションカーブなどを調整できるマウス＆トラックパッドドライバー。
 * [Day Progress](https://sindresorhus.com/day-progress) - メニューバーに今日の残り時間を表示。 ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id6450280202?platform=mac)

--- a/README-ko.md
+++ b/README-ko.md
@@ -977,6 +977,7 @@ Awesome Mac
 * [Better Launchpad](https://github.com/rewhex/better-launchpad) - 빠른 검색을 지원하는 맞춤형 앱 런처.
 * [BetterMouse](https://better-mouse.com) - 서드파티 마우스의 스크롤, 가속, 버튼, 제스처를 조정하는 도구.
 * [BetterTouchTool](https://folivora.ai/) - 트랙패드, 마우스, 키보드의 제스처와 동작을 세밀하게 설정하는 도구.
+* [Chronoid](https://www.chronoid.app/) - 앱과 웹사이트 사용 시간을 자동으로 기록하고 데이터를 로컬에만 저장하는 시간 추적 도구.
 * [CurrentKey](https://currentkey.com) - Spaces에 사용자 지정 이름과 아이콘을 붙이고 앱 사용 시간을 추적하는 도구. [![App Store][app-store Icon]](https://apps.apple.com/us/app/currentkey/id1456226992?mt=12)
 * [FnKeyboard](https://github.com/kotique123/FnKeyboard) - 메뉴 막대에서 기능 키를 빠르게 호출하는 도구. [![Open-Source Software][OSS Icon]](https://github.com/kotique123/FnKeyboard) ![Freeware][Freeware Icon]
 * [Freeter](https://freeter.io/) - 앱, 링크, 파일을 프로젝트별로 정리하는 작업 공간 도구. [![Open-Source Software][OSS Icon]](https://github.com/FreeterApp/Freeter) ![Freeware][Freeware Icon]

--- a/README-zh.md
+++ b/README-zh.md
@@ -1303,6 +1303,7 @@ Awesome Mac
 
 * [Table Habit](https://github.com/FriesI23/mhabit) – 带成长曲线和离线优先同步的习惯追踪器。![Open-Source Software][OSS Icon] [![App Store][app-store Icon]](https://apps.apple.com/us/app/table-habit/id6744886469?platform=mac)
 * [Rustcast](https://rustcast.app) - 集模式切换、快速启动、文件搜索和剪贴板历史于一体的工作流工具。 [![Open-Source Software][OSS Icon]](https://github.com/unsecretised/rustcast) ![Freeware][Freeware Icon]
+* [Chronoid](https://www.chronoid.app/) - 自动记录应用、网站和文档的使用时间，数据完全保存在本地，并提供专注工具与效率报告。
 * [CurrentKey](https://currentkey.com) - 为空间添加自定义名称和图标，并统计各应用使用时长。 [![App Store][app-store Icon]](https://apps.apple.com/cn/app/currentkey/id1456226992?mt=12)
 * [Desktop Control](https://desktopctl.com/) - 面向 AI 代理的本地桌面控制 CLI，可通过屏幕、鼠标和键盘操作任意应用。 [![Open-Source Software][OSS Icon]](https://github.com/yaroshevych/desktopctl) ![Freeware][Freeware Icon]
 * [Timing](https://timingapp.com/) - 自动记录时间并提供效率分析与工时统计。

--- a/README.md
+++ b/README.md
@@ -1369,6 +1369,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [BetterTouchTool](https://folivora.ai/) - Customize gestures, shortcuts, and input actions across trackpads, mice, and keyboards.
 * [Cerebro](https://cerebroapp.com/) - Open-source productivity booster with a brain. [![Open-Source Software][OSS Icon]](https://github.com/cerebroapp/cerebro) ![Freeware][Freeware Icon]
 * [Choosy](https://www.choosyosx.com) - UI, URL API and a browser extension set for managing rules where and how to open links.
+* [Chronoid](https://www.chronoid.app/) - Automatic time tracking that keeps all data on your Mac, with focus tools and productivity reports.
 * [CurrentKey](https://currentkey.com) - Add custom names and icons to Spaces and track app usage time. [![App Store][app-store Icon]](https://apps.apple.com/us/app/currentkey/id1456226992?mt=12)
 * [CursorSense](https://www.plentycom.jp/en/cursorsense/index.html) - Mouse & trackpad driver that lets you tweak the acceleration curve and more.
 * [Day Progress](https://sindresorhus.com/day-progress) - Time remaining today in your menu bar. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id6450280202?platform=mac)


### PR DESCRIPTION
Adds [Chronoid](https://www.chronoid.app/) to the Productivity section in all four READMEs (en, zh, ja, ko), in alphabetical order.

Chronoid is an automatic time tracker for macOS. It logs apps, websites, and documents in the background with no manual timers, keeps all data local on the Mac (no cloud), and includes focus tools (website blocker, Pomodoro) and productivity reports. Comparable to existing entries like Timing, Qbserve, and Rize, with local-only storage as the differentiator.

- One entry per language file, one-sentence description, no icons (not open source, not freeware, not on the App Store)
- Placement follows each file's local section structure per the maintainer skill guidelines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QGKp3NXv855WBm4ynSmtkk