### PR TITLE
Add ASN1 to Developer Utilities

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -384,6 +384,7 @@ Awesome Mac
 
 ### 開発者ユーティリティ
 
+* [ASN1](https://asn1.inyosystems.com/) - ASN.1スキーマの検証、BER・DER・OER・PER・UPER・XERによるエンコードとデコード、およびBER/DER構造の検査に対応するワークベンチ。 [![App Store][app-store Icon]](https://apps.apple.com/us/app/asn1/id6477905565?platform=mac) ![Native App][Native Icon]
 * [AXe](https://github.com/cameroncooke/AXe) - アクセシビリティAPIとHID自動化でiOSシミュレーターを操作できるCLIツール。 [![Open-Source Software][OSS Icon]](https://github.com/cameroncooke/AXe) ![Freeware][Freeware Icon]
 * [BetterRename](http://www.publicspace.net/BetterRename/) - 市場で最も強力で完成度の高いMacファイルリネームアプリケーション。 [![App Store][app-store Icon]](https://apps.apple.com/us/app/better-rename-11/id1501308038?platform=mac)
 * [Beyond Compare](http://www.scootersoftware.com/) - 強力なコマンドでファイルやフォルダを比較。 ![Freeware][Freeware Icon]

--- a/README-ko.md
+++ b/README-ko.md
@@ -360,6 +360,7 @@ Awesome Mac
 
 ### 개발자 유틸리티
 
+* [ASN1](https://asn1.inyosystems.com/) - ASN.1 스키마 검증, BER·DER·OER·PER·UPER·XER 인코딩 및 디코딩, BER/DER 구조 검사를 위한 워크벤치. [![App Store][app-store Icon]](https://apps.apple.com/us/app/asn1/id6477905565?platform=mac) ![Native App][Native Icon]
 * [AXe](https://github.com/cameroncooke/AXe) - 접근성 API와 HID 자동화를 통해 iOS 시뮬레이터를 제어할 수 있는 CLI 도구. [![Open-Source Software][OSS Icon]](https://github.com/cameroncooke/AXe) ![Freeware][Freeware Icon]
 * [BetterRename](http://www.publicspace.net/BetterRename/) - 강력한 파일 이름 변경 앱.
 * [Beyond Compare](http://www.scootersoftware.com/) - 파일 및 폴더 비교 도구.

--- a/README-zh.md
+++ b/README-zh.md
@@ -226,6 +226,7 @@ Awesome Mac
 
 ### 开发者实用工具
 
+* [ASN1](https://asn1.inyosystems.com/) - ASN.1 工作台，用于验证模式，使用 BER、DER、OER、PER、UPER 和 XER 进行编码与解码，并检查 BER/DER 结构。 [![App Store][app-store Icon]](https://apps.apple.com/us/app/asn1/id6477905565?platform=mac) ![Native App][Native Icon]
 * [AXe](https://github.com/cameroncooke/AXe) - 一个通过辅助功能 API 和 HID 自动化与 iOS 模拟器交互的命令行工具。 [![Open-Source Software][OSS Icon]](https://github.com/cameroncooke/AXe) ![Freeware][Freeware Icon]
 * [BetterRename](http://www.publicspace.net/BetterRename/) - 一款强大的批量重命名工具，可以通过搜索功能改名。[![App Store][app-store Icon]](https://apps.apple.com/cn/app/better-rename-11/id1501308038?platform=mac)
 * [Beyond Compare](http://www.scootersoftware.com/download.php) - 对比两个文件夹或者文件，并将差异以颜色标示。

--- a/README.md
+++ b/README.md
@@ -386,6 +386,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 
 ### Developer Utilities
 
+* [ASN1](https://asn1.inyosystems.com/) - ASN.1 workbench for validating schemas, encoding and decoding with BER, DER, OER, PER, UPER, and XER, and inspecting BER/DER structures. [![App Store][app-store Icon]](https://apps.apple.com/us/app/asn1/id6477905565?platform=mac) ![Native App][Native Icon]
 * [AXe](https://github.com/cameroncooke/AXe) - CLI tool for controlling iOS Simulators through Accessibility APIs and HID automation. [![Open-Source Software][OSS Icon]](https://github.com/cameroncooke/AXe) ![Freeware][Freeware Icon]
 * [BetterRename](https://www.publicspace.net/BetterRename/) - The most powerful and complete Mac file renaming application on the market. [![App Store][app-store Icon]](https://apps.apple.com/us/app/better-rename-11/id1501308038?platform=mac)
 * [Beyond Compare](https://www.scootersoftware.com/) - Compare files and folders with powerful commands. ![Freeware][Freeware Icon]


### PR DESCRIPTION
## Summary

Adds ASN1 to the Developer Utilities section and synchronizes the entry across the English, Chinese, Japanese, and Korean README files.

ASN1 is a native macOS workbench for validating ASN.1 schemas, encoding and decoding with BER, DER, OER, PER, UPER, and XER, and inspecting BER/DER structures.

- Website: https://asn1.inyosystems.com/
- Mac App Store: https://apps.apple.com/us/app/asn1/id6477905565?platform=mac
- Requirements: macOS 13 or later
- Compatibility: Intel and Apple silicon

## Validation

- Confirmed the entry appears once in each localized README and is alphabetically placed before AXe.
- Ran `git diff --check`.
- Built the documentation successfully with idoc.
- Verified the website and App Store links return HTTP 200.

## Disclosure

I am the developer of ASN1.
