### PR TITLE
Add Codex Skins under Developer Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Cacher](https://www.cacher.io/) - Cloud-based code snippet manager with Gist sync and multi-platform support.
 * [CodeKit](https://codekitapp.com/) - Web development tool for compiling and auto-refreshing.
 * [CodeMenu](https://extiri.com/codemenu.html) - Advanced snippets manager with IDE integration, natural language search, and more.
+* [Codex Skins](https://codexskins.org) - One-click wallpaper themes for the OpenAI Codex desktop app; reversible CDP theming, macOS & Windows. ![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]
 * [CoilPad](https://coilpad.com) - Native macOS Python scratchpad designed for instant prototyping and interactive learning. ![Freeware][Freeware Icon]
 * [Conduktor](https://www.conduktor.io) - Kafka desktop client.  ![Freeware][Freeware Icon]
 * [Swifka](https://github.com/Ender-Wang/Swifka) - Read-only Kafka monitor for safely inspecting topics, messages, and consumer state. [![Open-Source Software][OSS Icon]](https://github.com/Ender-Wang/Swifka) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds [Codex Skins](https://codexskins.org) — one-click wallpaper themes for the OpenAI Codex desktop app (reversible CDP theming, macOS & Windows, open-source MIT engine). Inserted alphabetically under Developer Tools → Developer Utilities with Open-Source + Freeware markers per contributing guidelines.