### PR TITLE
Add Nextline

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -285,6 +285,7 @@ Awesome Mac
 
 ### ライティング
 
+* [Nextline](https://www.thenextline.app/) - ローカルLLMで動作する、あらゆるアプリで使えるシステム全体のインライン自動補完ツール。 ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [Retrotype](https://retrotype.ink/) - 本物のタイプライターのような感覚の楽しくミニマルなライティングアプリ。 ![Freeware][Freeware Icon]
 * [novelWriter](https://github.com/vkbo/novelWriter) - 最小限のMarkdown風構文で小説を書くためのオープンソースプレーンテキストエディタ。 [![OSS][OSS Icon]](https://github.com/vkbo/novelWriter) ![Freeware][Freeware Icon]
 * [Scrivener](https://www.literatureandlatte.com/scrivener/overview/) - ライターのための定番ワードプロセッサ。

--- a/README-ko.md
+++ b/README-ko.md
@@ -259,6 +259,7 @@ Awesome Mac
 
 ### 쓰기
 
+* [Nextline](https://www.thenextline.app/) - 로컬 LLM으로 구동되는 시스템 전역 인라인 자동완성 도구. ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [Retrotype](https://retrotype.ink/) - 실제 타자기 느낌을 주는 미니멀한 쓰기 앱. ![Freeware][Freeware Icon]
 * [novelWriter](https://github.com/vkbo/novelWriter) - 소설 작성을 위한 오픈 소스 일반 텍스트 편집기. [![OSS][OSS Icon]](https://github.com/vkbo/novelWriter) ![Freeware][Freeware Icon]
 * [Scrivener](https://www.literatureandlatte.com/scrivener/overview/) - 작가를 위한 전형적인 워드 프로세서.

--- a/README-zh.md
+++ b/README-zh.md
@@ -878,6 +878,7 @@ Awesome Mac
 
 ### 写作
 
+* [Nextline](https://www.thenextline.app/) - 由本地大语言模型驱动的系统级行内自动补全工具，适用于任意应用。 ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [Retrotype](https://retrotype.ink/) - 有趣且极简的写作应用，带来真实打字机的手感。 ![Freeware][Freeware Icon]
 * [novelWriter](https://github.com/vkbo/novelWriter) - 一个开源的纯文本编辑器，专为写小说设计。它支持类似 Markdown 的最小语法来格式化文本。 [![Open-Source Software][OSS Icon]](https://github.com/vkbo/novelWriter) ![Freeware][Freeware Icon]
 * [THORN](https://thorn.red) - 一站式个人写作与建站平台

--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 
 ### Writing
 
+* [Nextline](https://www.thenextline.app/) - System-wide inline autocomplete powered by a local LLM. ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [Retrotype](https://retrotype.ink/) - A fun and minimalist writing app that feels like a real typewriter. ![Freeware][Freeware Icon]
 * [novelWriter](https://github.com/vkbo/novelWriter) - Open-source plain text editor for writing novels with minimal markdown-like syntax. [![OSS][OSS Icon]](https://github.com/vkbo/novelWriter) ![Freeware][Freeware Icon]
 * [Scrivener](https://www.literatureandlatte.com/scrivener/overview/) - The quintessential word processor for writers.


### PR DESCRIPTION
Adds [Nextline](https://www.thenextline.app/) to the **Writing** category.

Nextline is a system-wide inline autocomplete app for macOS: it suggests the rest of your sentence as you type in any app, generated by a local LLM on-device (no cloud). Free download, Developer ID-signed and notarized.

Per the contributing guidelines:

- Placed in alphabetical order (first entry in Writing, before Retrotype).
- Entry synced across `README.md`, `README-zh.md`, `README-ja.md`, and `README-ko.md`, with a one-sentence description in each language.
- Searched all four files first — no duplicate listing.
- Icons: Freeware (currently a free download) and Native App (native Swift app).

This is an AI-assisted contribution (prepared with Claude, reviewed by me), following the repository's AI-assisted contribution guidelines.
