### PR TITLE
Add Mojito to Input Methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -1020,6 +1020,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 
 * [Kawa](https://github.com/utatti/kawa) - Better input source switcher for OS X. [![Open-Source Software][OSS Icon]](https://github.com/utatti/kawa) ![Freeware][Freeware Icon]
 * [LangSwitcher](https://github.com/reg2005/langSwitcher) - Keyboard layout converter for mistyped text. [![Open-Source Software][OSS Icon]](https://github.com/reg2005/langSwitcher) ![Freeware][Freeware Icon]
+* [Mojito](https://mojito.wells.ee/) - Type `:emoji:`, `::symbol::`, and `:::gif:::` shortcodes in any app. [![Open-Source Software][OSS Icon]](https://github.com/wr/mojito) ![Freeware][Freeware Icon]
 * [Rocket](https://matthewpalmer.net/rocket/) - Makes typing emoji faster and easier using Slack-style shortcuts. ![Freeware][Freeware Icon]
 * [Touch Emoji](https://github.com/lessmess-dev/touch-emoji) - Emoji picker for MacBook Pro Touch Bar. [![Open-Source Software][OSS Icon]](https://github.com/lessmess-dev/touch-emoji)
 * [Type2Phone](https://www.houdah.com/type2Phone/) - Use Your Mac as Keyboard for iPhone, iPad & Apple TV.


### PR DESCRIPTION
Adds [Mojito](https://mojito.wells.ee/) — free, open-source menu-bar utility that expands `:emoji:` shortcodes into real emoji in any macOS text field, plus `::symbol::` and `:::gif:::` variants. Signed + notarized, open source (AGPL-3.0) at github.com/wr/mojito. Placed alphabetically in Input Methods.