### PR TITLE
Add CleanMyMac CLI

### DIFF
--- a/command-line-apps.md
+++ b/command-line-apps.md
@@ -123,6 +123,7 @@ A curated list of useful command line apps
 * [Clipport](https://github.com/arihantsethia/clipport) - Paste Mac clipboard text and screenshots into remote iTerm SSH sessions. [![Open-Source Software][OSS Icon]](https://github.com/arihantsethia/clipport) ![Freeware][Freeware Icon]
 * [ccat](https://github.com/jingweno/ccat) - The colorizing cat which works similar to cat but displays content with syntax highlighting. [![Open-Source Software][OSS Icon]](https://github.com/jingweno/ccat) ![Freeware][Freeware Icon]
 * [ClamAV](https://www.clamav.net/) - Cross-platform, open-source antivirus engine. [![OSS][OSS Icon]](https://github.com/Cisco-Talos/clamav/) ![Freeware][Freeware Icon]
+* [CleanMyMac CLI](https://github.com/MacPaw/cleanmymac-cli) - Clean Xcode, Docker, Homebrew, and developer caches; analyze storage and reclaim disk space from the Terminal.
 * [cmatrix](https://github.com/abishekvashok/cmatrix/) - Terminal screensaver inspired by "The Matrix" movie. [![OSS][OSS Icon]](https://github.com/abishekvashok/cmatrix/) ![Freeware][Freeware Icon]
 * [cool-retro-term](https://github.com/Swordfish90/cool-retro-term) - Good looking terminal emulator which mimics the old cathode display. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/Swordfish90/cool-retro-term)
 * [CSV2Notion Neo](https://github.com/TheAcharya/csv2notion-neo) - Upload & Merge CSV or JSON Data with Images to Notion Database. [![Open-Source Software][OSS Icon]](https://github.com/TheAcharya/csv2notion-neo) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds CleanMyMac CLI, a terminal-first cleanup tool for developers on macOS.

### Types of Changes

- [x] New addition to list
- [ ] Fixing bug in existing item in list
- [ ] Removing item from list
- [ ] Changing structure (organization) of list

### Proposed Changes

Adding CleanMyMac CLI, a terminal-first cleanup tool for developers on macOS. It cleans Xcode, Docker, Homebrew, and other developer caches, removes project and build artifacts, and helps analyze and reclaim disk space — all from the command line, without needing a GUI. 

### PR Checklist

- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important
- [x] I have added necessary documentation