### PR TITLE
Add Actvt to Menu Bar Tools

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1195,6 +1195,7 @@ Awesome Mac
 
 ### メニューバーツール
 
+* [Actvt](https://actvt.io) - システムのリアルタイム指標とClaude Code・Codexのセッション履歴、コストとトークンの分析をまとめ、エージェントが照会できるMCPサーバーを内蔵したメニューバーアプリ。
 * [Agent Island](https://github.com/tristan666666/agent-island) - MacBookのノッチにClaude CodeとCodexのセッション状態を表示し、選択した長時間タスクを自動再開できるツール。 [![Open-Source Software][OSS Icon]](https://github.com/tristan666666/agent-island) ![Freeware][Freeware Icon]
 * [Anvil](https://anvilformac.com/) - ローカルの静的サイトやRackアプリを手軽に公開できるツール。 ![Freeware][Freeware Icon]
 * [Atoll](https://github.com/Ebullioscopic/Atoll) - ノッチを、メディア操作・ライブアクティビティ・クイックユーティリティをまとめたDynamic Island風ハブに変える。 [![Open-Source Software][OSS Icon]](https://github.com/Ebullioscopic/Atoll)

--- a/README-ko.md
+++ b/README-ko.md
@@ -890,6 +890,7 @@ Awesome Mac
 
 ### 메뉴 바 도구
 
+* [Actvt](https://actvt.io) - 실시간 시스템 지표와 Claude Code·Codex 세션 기록, 비용 및 토큰 분석을 한곳에 모으고 에이전트가 조회할 수 있는 MCP 서버를 내장한 메뉴 바 앱.
 * [Agent Island](https://github.com/tristan666666/agent-island) - MacBook 노치에서 Claude Code와 Codex 세션 상태를 보여주고 선택한 장시간 작업을 자동으로 이어서 실행하는 도구. [![Open-Source Software][OSS Icon]](https://github.com/tristan666666/agent-island) ![Freeware][Freeware Icon]
 * [Anvil](https://anvilformac.com/) - 로컬 정적 사이트와 Rack 앱을 손쉽게 띄우는 도구. ![Freeware][Freeware Icon]
 * [Atoll](https://github.com/Ebullioscopic/Atoll) - 노치를 미디어 제어, 라이브 활동, 빠른 유틸리티를 담은 다이내믹 아일랜드형 허브로 바꿔준다. [![Open-Source Software][OSS Icon]](https://github.com/Ebullioscopic/Atoll)

--- a/README-zh.md
+++ b/README-zh.md
@@ -1231,6 +1231,7 @@ Awesome Mac
 
 ### 菜单栏工具
 
+* [Actvt](https://actvt.io) - 菜单栏应用，将实时系统指标与 Claude Code、Codex 的会话历史和成本、token 分析结合，并内置可供智能体查询的 MCP 服务器。
 * [Agent Island](https://github.com/tristan666666/agent-island) - 将 MacBook 刘海变成 Claude Code 与 Codex 会话状态看板，并可自动续跑选定的长任务。 [![Open-Source Software][OSS Icon]](https://github.com/tristan666666/agent-island) ![Freeware][Freeware Icon]
 * [Anvil](https://anvilformac.com/) - 轻松托管本地静态网站和 Rack 应用的工具。 ![Freeware][Freeware Icon]
 * [Atoll](https://github.com/Ebullioscopic/Atoll) - 将刘海区域变成集媒体控制、实时活动和快捷工具于一体的动态面板。 [![Open-Source Software][OSS Icon]](https://github.com/Ebullioscopic/Atoll)

--- a/README.md
+++ b/README.md
@@ -1198,6 +1198,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 
 ### Menu Bar Tools
 
+* [Actvt](https://actvt.io) - Menu bar app combining live system metrics with Claude Code and Codex session history, cost and token analytics, and an embedded MCP server agents can query.
 * [Agent Island](https://github.com/tristan666666/agent-island) - MacBook notch companion for Claude Code and Codex sessions, showing live status and auto-resuming selected long-running tasks. [![Open-Source Software][OSS Icon]](https://github.com/tristan666666/agent-island) ![Freeware][Freeware Icon]
 * [Anvil](https://anvilformac.com/) - Tool for serving local static sites and Rack apps with simple URLs. ![Freeware][Freeware Icon]
 * [Atoll](https://github.com/Ebullioscopic/Atoll) - Turns the notch into a Dynamic Island-style hub for media controls, live activities, and quick utilities. [![Open-Source Software][OSS Icon]](https://github.com/Ebullioscopic/Atoll)


### PR DESCRIPTION
Adds Actvt to Menu Bar Tools, synced across `README.md`, `README-zh.md`, `README-ja.md` and `README-ko.md`.

Actvt is a native macOS menu bar app that monitors the machine and the AI coding agents running on it.

The section already lists several Claude Code / Codex session monitors (Agent Island, cctop, CodexIsland), so the entry leads with what those don't do: live system metrics for the Mac itself, and an embedded MCP server that agents can query.

Closed source with a free tier, so no badge — matching the existing Bartender entry, since `Freeware` would be inaccurate for a paid app.
