### PR TITLE
Add Tameo to Clipboard Tools

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1184,6 +1184,7 @@ Awesome Mac
 * [Pure Paste](https://sindresorhus.com/pure-paste) - デフォルトでプレーンテキストとして貼り付け。 ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id1611378436?platform=mac)
 * [SaneClip](https://saneclip.com) - 履歴、Touch ID保護、機密データ検出を備えたクリップボードマネージャー。 [![Open-Source Software][OSS Icon]](https://github.com/sane-apps/SaneClip) ![Freeware][Freeware Icon]
 * [SnippetCraft](https://getsnippetcraft.com) - macOS向けのシステム全体で使えるテキスト展開、スニペット管理、クリップボード履歴ツール。
+* [Tameo](https://tameo.ati-mirai.co.jp) - 履歴検索・オンデバイス画像OCR・スニペット対応のプライバシー重視クリップボードマネージャー。 [![Open-Source Software][OSS Icon]](https://github.com/supergodak/tameo) ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [Flycut](https://github.com/TermiT/Flycut) - 開発者向けのクリーンでシンプルなクリップボードマネージャー。 [![Open-Source Software][OSS Icon]](https://github.com/TermiT/Flycut) ![Freeware][Freeware Icon]
 * [Maccy](https://maccy.app/) - macOS用の軽量クリップボードマネージャー。 [![Open-Source Software][OSS Icon]](https://github.com/p0deje/Maccy) ![Freeware][Freeware Icon]
 * [Mask This](https://apps.apple.com/us/app/mask-this/id6759096128) - クリップボード内の機密情報をマスクするメニューバーツール。 [![Open-Source Software][OSS Icon]](https://github.com/tseylerd/MaskThis) ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/us/app/mask-this/id6759096128)

--- a/README-ko.md
+++ b/README-ko.md
@@ -886,6 +886,7 @@ Awesome Mac
 * [Pesty](https://github.com/momenbasel/pesty) - 색상 구분된 슬라이딩 스트립으로 클립보드 기록을 보여주는 무료 오픈소스 클립보드 관리자. [![Open-Source Software][OSS Icon]](https://github.com/momenbasel/pesty) ![Freeware][Freeware Icon]
 * [SaneClip](https://saneclip.com) - 기록, Touch ID 보호, 민감 정보 감지를 갖춘 클립보드 관리자. [![Open-Source Software][OSS Icon]](https://github.com/sane-apps/SaneClip) ![Freeware][Freeware Icon]
 * [SnippetCraft](https://getsnippetcraft.com) - macOS용 시스템 전체 텍스트 확장, 스니펫 관리, 클립보드 기록 도구.
+* [Tameo](https://tameo.ati-mirai.co.jp) - 히스토리 검색, 온디바이스 이미지 OCR, 스니펫을 지원하는 프라이버시 우선 클립보드 관리자. [![Open-Source Software][OSS Icon]](https://github.com/supergodak/tameo) ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [uPaste](https://okaapps.com/product/1503649026) - 클립보드 기록과 스니펫을 정리해 재사용하기 쉽게 해주는 관리자. [![App Store][app-store Icon]](https://apps.apple.com/app/id1503649026?pt=119209922&ct=github)
 
 ### 메뉴 바 도구

--- a/README-zh.md
+++ b/README-zh.md
@@ -1226,6 +1226,7 @@ Awesome Mac
 * [PopClip](https://www.popclip.app/) - 当您在任何应用中选择文本时，PopClip 会出现，为您提供即时访问有用操作的功能。
 * [SaneClip](https://saneclip.com) - 带历史记录、隐私保护和敏感信息检测的剪贴板管理器。 [![Open-Source Software][OSS Icon]](https://github.com/sane-apps/SaneClip) ![Freeware][Freeware Icon]
 * [SnippetCraft](https://getsnippetcraft.com) - 适用于 macOS 的全系统文本扩展、片段管理和剪贴板历史工具。
+* [Tameo](https://tameo.ati-mirai.co.jp) - 支持历史搜索、端侧图片 OCR 和文本片段的隐私优先剪贴板管理器。 [![Open-Source Software][OSS Icon]](https://github.com/supergodak/tameo) ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [uPaste](https://okaapps.com/product/1503649026) - 自动整理剪贴板历史和常用片段的管理器。 [![App Store][app-store Icon]](https://apps.apple.com/app/id1503649026?pt=119209922&ct=github)
 * [Yippy](https://github.com/mattDavo/Yippy) - 具有用户友好界面的剪贴板管理器。 [![Open-Source Software][OSS Icon]](https://github.com/mattDavo/Yippy) ![Freeware][Freeware Icon]
 

--- a/README.md
+++ b/README.md
@@ -1187,6 +1187,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Pure Paste](https://sindresorhus.com/pure-paste) - Paste as plain text by default. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id1611378436?platform=mac)
 * [SaneClip](https://saneclip.com) - Clipboard manager with history, privacy protections, and sensitive data detection. [![Open-Source Software][OSS Icon]](https://github.com/sane-apps/SaneClip) ![Freeware][Freeware Icon]
 * [SnippetCraft](https://getsnippetcraft.com) - System-wide text expansion, snippet management, and clipboard history for macOS.
+* [Tameo](https://tameo.ati-mirai.co.jp) - Privacy-first clipboard manager with history search, on-device image OCR, and snippets. [![Open-Source Software][OSS Icon]](https://github.com/supergodak/tameo) ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [Flycut](https://github.com/TermiT/Flycut) - Clean and simple clipboard manager for developers. [![Open-Source Software][OSS Icon]](https://github.com/TermiT/Flycut) ![Freeware][Freeware Icon]
 * [Maccy](https://maccy.app/) - Lightweight clipboard manager for macOS. [![Open-Source Software][OSS Icon]](https://github.com/p0deje/Maccy) ![Freeware][Freeware Icon]
 * [Nimclip](https://hukdoesn.github.io/Nimclip/) - Local-first clipboard history manager with search, tags, and image support. [![Open-Source Software][OSS Icon]](https://github.com/hukdoesn/Nimclip) ![Freeware][Freeware Icon] ![Native App][Native Icon]


### PR DESCRIPTION
## Add Tameo to Clipboard Tools

- **Name**: [Tameo](https://tameo.ati-mirai.co.jp) — [source (MIT)](https://github.com/supergodak/tameo)
- **What it is**: Privacy-first clipboard manager for macOS. History search (with kana/width folding for Japanese), on-device image OCR so you can search and paste the text inside copied screenshots, snippets with Clipy import. Native SwiftUI app, Apple-Silicon-native, Developer-ID signed and notarized, no telemetry/analytics — fully local.
- Checked: no duplicate in the list, one suggestion per PR, entry synced across README.md / README-ja.md / README-zh.md / README-ko.md as per CONTRIBUTING, inserted alphabetically (after SnippetCraft), one-sentence description, Title Case, no trailing whitespace.
