### PR TITLE
Add Logue to Note-taking

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Joplin](https://joplinapp.org/) - Cross-platform open-source notepad with markdown support and to-do list management. [![Open-Source Software][OSS Icon]](https://github.com/laurent22/joplin) ![Freeware][Freeware Icon]
 * [Knopo](https://github.com/alkalim/Knopo) - Native macOS outliner for local-first notes stored as plain Markdown files. [![Open-Source Software][OSS Icon]](https://github.com/alkalim/Knopo) ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [Logseq](https://logseq.com/) - Privacy-first, open-source knowledge base. [![OSS][OSS Icon]](https://github.com/logseq/logseq) ![Freeware][Freeware Icon]
+* [Logue](https://github.com/bitwize-ai/Logue) - Privacy-first AI meeting notes & writing assistant; on-device transcription, speaker diarization, and Smart Minutes summaries, all local on Apple Silicon. [![Open-Source Software][OSS Icon]](https://github.com/bitwize-ai/Logue) ![Freeware][Freeware Icon]
 * [MarginNote 4](https://marginnote.com/) - In-depth PDF and EPUB reading, learning, managing and note taking app.
 * [massCode](https://masscode.io/) - Cross-platform open-source code snippets manager with markdown and mermaid support. [![Open-Source Software][OSS Icon]](https://github.com/massCodeIO/massCode) ![Freeware][Freeware Icon]
 * [MiaoYan](https://miaoyan.app/) - Lightweight Markdown app to help you write great sentences.


### PR DESCRIPTION
Adds **[Logue](https://github.com/bitwize-ai/Logue)** to **Note-taking** (placed alphabetically, with the Open-Source + Freeware badges).

Logue is a free, open-source, privacy-first AI meeting-notes & writing assistant for macOS. Transcription, speaker diarization, Smart Minutes summaries, and AI writing all run **on-device** on Apple Silicon — nothing leaves the Mac. Only README.md edited (translations are maintainer-synced).