### PR TITLE
Add AgentBar to Menu Bar Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1200,6 +1200,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 ### Menu Bar Tools
 
 * [Agent Island](https://github.com/tristan666666/agent-island) - MacBook notch companion for Claude Code and Codex sessions, showing live status and auto-resuming selected long-running tasks. [![Open-Source Software][OSS Icon]](https://github.com/tristan666666/agent-island) ![Freeware][Freeware Icon]
+* [AgentBar](https://github.com/michalstrnadel/AgentBar) - Menu bar status for AI coding agents (Claude Code, Codex, Copilot) with one-click Allow/Deny of Claude Code permission prompts. [![Open-Source Software][OSS Icon]](https://github.com/michalstrnadel/AgentBar) ![Freeware][Freeware Icon]
 * [Anvil](https://anvilformac.com/) - Tool for serving local static sites and Rack apps with simple URLs. ![Freeware][Freeware Icon]
 * [Atoll](https://github.com/Ebullioscopic/Atoll) - Turns the notch into a Dynamic Island-style hub for media controls, live activities, and quick utilities. [![Open-Source Software][OSS Icon]](https://github.com/Ebullioscopic/Atoll)
 * [Bartender](https://www.macbartender.com) - Organize or hide menu bar icons on your Mac.


### PR DESCRIPTION
## What is AgentBar?

[AgentBar](https://github.com/michalstrnadel/AgentBar) is a free, open-source (MIT) native macOS menu bar app that shows the live status of AI coding agent sessions — Claude Code, Codex, GitHub Copilot, Antigravity — and lets you answer Claude Code permission prompts (Allow / Always allow / Deny) directly from the menu bar, without switching to the terminal.

- Native Swift/AppKit, no dependencies, menu bar only (no dock icon, no windows)
- Universal binary (Apple Silicon + Intel), macOS 12+
- MIT licensed, CI, releases with prebuilt app

Entry added alphabetically to *Menu Bar Tools* following the existing format.