### PR TITLE
Add McAwake to System Related Tools

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1549,10 +1549,10 @@ Awesome Mac
 * [KeepingYouAwake](https://github.com/newmarcel/KeepingYouAwake) - ダークモード対応のCaffeine代替。 [![Open-Source Software][OSS Icon]](https://github.com/newmarcel/KeepingYouAwake)
 * [macUSB](https://github.com/Kruszoneq/macUSB) - Apple Silicon Mac用の起動可能なmacOS/OS Xインストーラー作成ツール。 [![Open-Source Software][OSS Icon]](https://github.com/Kruszoneq/macUSB) ![Freeware][Freeware Icon]
 * [MagicQuit](https://magicquit.com/) - 非アクティブなアプリを自動終了してリソースを整理するツール。 [![Open-Source Software][OSS Icon]](https://github.com/BigBerny/magicquit) ![Freeware][Freeware Icon]
+* [McAwake](https://github.com/taufiqxr/McAwake) - 外部ディスプレイなしでふたを閉じたままでもMacのスリープを防ぎ、バッテリー低下時の保護、ローカルサーバー監視、Claude Codeセッション切り替えを備えるツール。 [![Open-Source Software][OSS Icon]](https://github.com/taufiqxr/McAwake) ![Freeware][Freeware Icon]
 * [MiddleDrag](https://github.com/NullPointerDepressiveDisorder/MiddleDrag) - macOSでの中クリックと中ドラッグのための3本指トラックパッドジェスチャー。 [![Open-Source Software][OSS Icon]](https://github.com/NullPointerDepressiveDisorder/MiddleDrag) ![Freeware][Freeware Icon]
 * [Monity](http://www.monityapp.com/) - OS X用のシステム監視ウィジェット。
 * [Mounty](http://enjoygineering.com/mounty/) - Mac OS X 10.9以降で書き込み保護されたNTFSボリュームを読み書きモードで再マウントする小さなツール。 ![Freeware][Freeware Icon]
-* [NightOwl](https://github.com/taufiqxr/NightOwl) - 外部ディスプレイなしでふたを閉じたままでもMacのスリープを防ぎ、バッテリー低下時の保護、ローカルサーバー監視、Claude Codeセッション切り替えを備えるツール。 [![Open-Source Software][OSS Icon]](https://github.com/taufiqxr/NightOwl) ![Freeware][Freeware Icon]
 * [NitroShare](https://nitroshare.net/) - クロスプラットフォームのネットワークファイル転送ユーティリティ。 [![Open-Source Software][OSS Icon]](https://github.com/nitroshare/nitroshare-desktop) ![Freeware][Freeware Icon]
 * [OnyX](https://www.titanium-software.fr/en/onyx.html) - クリーニング、検証、隠し設定変更をまとめたシステム保守ツール。 ![Freeware][Freeware Icon]
 * [Paragon NTFS](https://www.paragon-software.com/home/ntfs-mac/) - macOS SierraでNTFSへの読み書きアクセス。

--- a/README-ja.md
+++ b/README-ja.md
@@ -1552,6 +1552,7 @@ Awesome Mac
 * [MiddleDrag](https://github.com/NullPointerDepressiveDisorder/MiddleDrag) - macOSでの中クリックと中ドラッグのための3本指トラックパッドジェスチャー。 [![Open-Source Software][OSS Icon]](https://github.com/NullPointerDepressiveDisorder/MiddleDrag) ![Freeware][Freeware Icon]
 * [Monity](http://www.monityapp.com/) - OS X用のシステム監視ウィジェット。
 * [Mounty](http://enjoygineering.com/mounty/) - Mac OS X 10.9以降で書き込み保護されたNTFSボリュームを読み書きモードで再マウントする小さなツール。 ![Freeware][Freeware Icon]
+* [NightOwl](https://github.com/taufiqxr/NightOwl) - 外部ディスプレイなしでふたを閉じたままでもMacのスリープを防ぎ、バッテリー低下時の保護、ローカルサーバー監視、Claude Codeセッション切り替えを備えるツール。 [![Open-Source Software][OSS Icon]](https://github.com/taufiqxr/NightOwl) ![Freeware][Freeware Icon]
 * [NitroShare](https://nitroshare.net/) - クロスプラットフォームのネットワークファイル転送ユーティリティ。 [![Open-Source Software][OSS Icon]](https://github.com/nitroshare/nitroshare-desktop) ![Freeware][Freeware Icon]
 * [OnyX](https://www.titanium-software.fr/en/onyx.html) - クリーニング、検証、隠し設定変更をまとめたシステム保守ツール。 ![Freeware][Freeware Icon]
 * [Paragon NTFS](https://www.paragon-software.com/home/ntfs-mac/) - macOS SierraでNTFSへの読み書きアクセス。

--- a/README-ko.md
+++ b/README-ko.md
@@ -960,7 +960,7 @@ Awesome Mac
 * [Grayscale Mode](https://github.com/rkbhochalya/grayscale-mode) - 메뉴 막대나 단축키로 흑백 화면을 켜고 끄는 도구. [![Open-Source Software][OSS Icon]](https://github.com/rkbhochalya/grayscale-mode) ![Freeware][Freeware Icon]
 * [MaCursor](https://github.com/writronic/MaCursor) - macOS용 커스텀 커서 테마 도구. [![Open-Source Software][OSS Icon]](https://github.com/writronic/MaCursor) ![Freeware][Freeware Icon]
 * [MagicQuit](https://magicquit.com/) - 비활성 앱을 자동 종료해 리소스와 화면을 정리하는 도구. [![Open-Source Software][OSS Icon]](https://github.com/BigBerny/magicquit) ![Freeware][Freeware Icon]
-* [NightOwl](https://github.com/taufiqxr/NightOwl) - 외부 디스플레이 없이 덮개를 닫아도 Mac을 깨어 있게 유지하고, 배터리 부족 보호, 로컬 서버 모니터링, Claude Code 세션 전환을 제공하는 도구. [![Open-Source Software][OSS Icon]](https://github.com/taufiqxr/NightOwl) ![Freeware][Freeware Icon]
+* [McAwake](https://github.com/taufiqxr/McAwake) - 외부 디스플레이 없이 덮개를 닫아도 Mac을 깨어 있게 유지하고, 배터리 부족 보호, 로컬 서버 모니터링, Claude Code 세션 전환을 제공하는 도구. [![Open-Source Software][OSS Icon]](https://github.com/taufiqxr/McAwake) ![Freeware][Freeware Icon]
 * [OnyX](https://www.titanium-software.fr/en/onyx.html) - 정리, 점검, 숨은 설정 변경을 묶은 시스템 유지보수 도구. ![Freeware][Freeware Icon]
 * [Sensei](https://sensei.app/) - 모니터링, 정리, 하드웨어 진단을 제공하는 성능 관리 도구.
 * [SiliconScope](https://siliconscope.calidalab.ai) - 免授权的 Apple Silicon 系统监控工具（菜单栏 + 仪表盘），支持 ANE、媒体引擎、内存带宽追踪以及 E/P 核性能分解。 [![Open-Source Software][OSS Icon]](https://github.com/kennss/SiliconScope) ![Freeware][Freeware Icon]

--- a/README-ko.md
+++ b/README-ko.md
@@ -960,6 +960,7 @@ Awesome Mac
 * [Grayscale Mode](https://github.com/rkbhochalya/grayscale-mode) - 메뉴 막대나 단축키로 흑백 화면을 켜고 끄는 도구. [![Open-Source Software][OSS Icon]](https://github.com/rkbhochalya/grayscale-mode) ![Freeware][Freeware Icon]
 * [MaCursor](https://github.com/writronic/MaCursor) - macOS용 커스텀 커서 테마 도구. [![Open-Source Software][OSS Icon]](https://github.com/writronic/MaCursor) ![Freeware][Freeware Icon]
 * [MagicQuit](https://magicquit.com/) - 비활성 앱을 자동 종료해 리소스와 화면을 정리하는 도구. [![Open-Source Software][OSS Icon]](https://github.com/BigBerny/magicquit) ![Freeware][Freeware Icon]
+* [NightOwl](https://github.com/taufiqxr/NightOwl) - 외부 디스플레이 없이 덮개를 닫아도 Mac을 깨어 있게 유지하고, 배터리 부족 보호, 로컬 서버 모니터링, Claude Code 세션 전환을 제공하는 도구. [![Open-Source Software][OSS Icon]](https://github.com/taufiqxr/NightOwl) ![Freeware][Freeware Icon]
 * [OnyX](https://www.titanium-software.fr/en/onyx.html) - 정리, 점검, 숨은 설정 변경을 묶은 시스템 유지보수 도구. ![Freeware][Freeware Icon]
 * [Sensei](https://sensei.app/) - 모니터링, 정리, 하드웨어 진단을 제공하는 성능 관리 도구.
 * [SiliconScope](https://siliconscope.calidalab.ai) - 免授权的 Apple Silicon 系统监控工具（菜单栏 + 仪表盘），支持 ANE、媒体引擎、内存带宽追踪以及 E/P 核性能分解。 [![Open-Source Software][OSS Icon]](https://github.com/kennss/SiliconScope) ![Freeware][Freeware Icon]

--- a/README-zh.md
+++ b/README-zh.md
@@ -1357,9 +1357,9 @@ Awesome Mac
 * [Latest](https://github.com/mangerlahn/Latest) - 一个小型实用程序应用程序，可确保您了解所使用应用程序的所有最新更新。 [![Open-Source Software][OSS Icon]](https://github.com/mangerlahn/Latest) ![Freeware][Freeware Icon]
 * [MaCursor](https://github.com/writronic/MaCursor) - macOS自定义光标主题工具。 [![Open-Source Software][OSS Icon]](https://github.com/writronic/MaCursor) ![Freeware][Freeware Icon]
 * [MagicQuit](https://magicquit.com/) - 自动退出不活跃应用以减少占用和桌面杂乱。 [![Open-Source Software][OSS Icon]](https://github.com/BigBerny/magicquit) ![Freeware][Freeware Icon]
+* [McAwake](https://github.com/taufiqxr/McAwake) - 合盖且无外接显示器时也能保持 Mac 唤醒，内置低电量保护、本地服务器监控和 Claude Code 会话切换。 [![Open-Source Software][OSS Icon]](https://github.com/taufiqxr/McAwake) ![Freeware][Freeware Icon]
 * [Monity](http://www.monityapp.com/) - 帮助用户实时监控系统的一款非常漂亮的软件。
 * [Mounty](http://enjoygineering.com/mounty/) - NTFS 分区读写组件。![Freeware][Freeware Icon]
-* [NightOwl](https://github.com/taufiqxr/NightOwl) - 合盖且无外接显示器时也能保持 Mac 唤醒，内置低电量保护、本地服务器监控和 Claude Code 会话切换。 [![Open-Source Software][OSS Icon]](https://github.com/taufiqxr/NightOwl) ![Freeware][Freeware Icon]
 * [NitroShare](https://nitroshare.net/) - 跨平台网络文件传输应用程序。 [![Open-Source Software][OSS Icon]](https://github.com/nitroshare/nitroshare-desktop) ![Freeware][Freeware Icon]
 * [OnyX](http://www.titanium.free.fr/) - 集清理、校验和隐藏设置于一体的系统维护工具。![Freeware][Freeware Icon]
 * [Sensei](https://sensei.app/) - 提供监控、清理和硬件诊断的性能管理工具。

--- a/README-zh.md
+++ b/README-zh.md
@@ -1359,6 +1359,7 @@ Awesome Mac
 * [MagicQuit](https://magicquit.com/) - 自动退出不活跃应用以减少占用和桌面杂乱。 [![Open-Source Software][OSS Icon]](https://github.com/BigBerny/magicquit) ![Freeware][Freeware Icon]
 * [Monity](http://www.monityapp.com/) - 帮助用户实时监控系统的一款非常漂亮的软件。
 * [Mounty](http://enjoygineering.com/mounty/) - NTFS 分区读写组件。![Freeware][Freeware Icon]
+* [NightOwl](https://github.com/taufiqxr/NightOwl) - 合盖且无外接显示器时也能保持 Mac 唤醒，内置低电量保护、本地服务器监控和 Claude Code 会话切换。 [![Open-Source Software][OSS Icon]](https://github.com/taufiqxr/NightOwl) ![Freeware][Freeware Icon]
 * [NitroShare](https://nitroshare.net/) - 跨平台网络文件传输应用程序。 [![Open-Source Software][OSS Icon]](https://github.com/nitroshare/nitroshare-desktop) ![Freeware][Freeware Icon]
 * [OnyX](http://www.titanium.free.fr/) - 集清理、校验和隐藏设置于一体的系统维护工具。![Freeware][Freeware Icon]
 * [Sensei](https://sensei.app/) - 提供监控、清理和硬件诊断的性能管理工具。

--- a/README.md
+++ b/README.md
@@ -1552,10 +1552,10 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [KeepingYouAwake](https://github.com/newmarcel/KeepingYouAwake) - Caffeine alternative with dark mode support. [![Open-Source Software][OSS Icon]](https://github.com/newmarcel/KeepingYouAwake)
 * [macUSB](https://github.com/Kruszoneq/macUSB) - A bootable macOS / OS X installer creator for Apple Silicon Macs. [![Open-Source Software][OSS Icon]](https://github.com/Kruszoneq/macUSB) ![Freeware][Freeware Icon]
 * [MagicQuit](https://magicquit.com/) - Automatically quit inactive apps to reduce clutter and free resources. [![Open-Source Software][OSS Icon]](https://github.com/BigBerny/magicquit) ![Freeware][Freeware Icon]
+* [McAwake](https://github.com/taufiqxr/McAwake) - Keeps your Mac awake even with the lid closed and no external display, with a low-battery guard, local server monitoring, and a Claude Code session switcher. [![Open-Source Software][OSS Icon]](https://github.com/taufiqxr/McAwake) ![Freeware][Freeware Icon]
 * [MiddleDrag](https://github.com/NullPointerDepressiveDisorder/MiddleDrag) - Three-finger trackpad gestures for middle-click and middle-drag on macOS. [![Open-Source Software][OSS Icon]](https://github.com/NullPointerDepressiveDisorder/MiddleDrag) ![Freeware][Freeware Icon]
 * [Monity](https://www.monityapp.com/) - System monitoring widget for OS X.
 * [Mounty](https://enjoygineering.com/mounty/) - Tiny tool to re-mount write-protected NTFS volumes under Mac OS X 10.9+ in read-write mode. ![Freeware][Freeware Icon]
-* [NightOwl](https://github.com/taufiqxr/NightOwl) - Keeps your Mac awake even with the lid closed and no external display, with a low-battery guard, local server monitoring, and a Claude Code session switcher. [![Open-Source Software][OSS Icon]](https://github.com/taufiqxr/NightOwl) ![Freeware][Freeware Icon]
 * [NitroShare](https://nitroshare.net/) - Cross-platform network file transfer utility. [![Open-Source Software][OSS Icon]](https://github.com/nitroshare/nitroshare-desktop) ![Freeware][Freeware Icon]
 * [OnyX](https://www.titanium-software.fr/en/onyx.html) - System maintenance utility for cleanup, verification, and hidden settings. ![Freeware][Freeware Icon]
 * [Paragon NTFS](https://www.paragon-software.com/home/ntfs-mac/) - Read/write access to NTFS in macOS Sierra.

--- a/README.md
+++ b/README.md
@@ -1555,6 +1555,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [MiddleDrag](https://github.com/NullPointerDepressiveDisorder/MiddleDrag) - Three-finger trackpad gestures for middle-click and middle-drag on macOS. [![Open-Source Software][OSS Icon]](https://github.com/NullPointerDepressiveDisorder/MiddleDrag) ![Freeware][Freeware Icon]
 * [Monity](https://www.monityapp.com/) - System monitoring widget for OS X.
 * [Mounty](https://enjoygineering.com/mounty/) - Tiny tool to re-mount write-protected NTFS volumes under Mac OS X 10.9+ in read-write mode. ![Freeware][Freeware Icon]
+* [NightOwl](https://github.com/taufiqxr/NightOwl) - Keeps your Mac awake even with the lid closed and no external display, with a low-battery guard, local server monitoring, and a Claude Code session switcher. [![Open-Source Software][OSS Icon]](https://github.com/taufiqxr/NightOwl) ![Freeware][Freeware Icon]
 * [NitroShare](https://nitroshare.net/) - Cross-platform network file transfer utility. [![Open-Source Software][OSS Icon]](https://github.com/nitroshare/nitroshare-desktop) ![Freeware][Freeware Icon]
 * [OnyX](https://www.titanium-software.fr/en/onyx.html) - System maintenance utility for cleanup, verification, and hidden settings. ![Freeware][Freeware Icon]
 * [Paragon NTFS](https://www.paragon-software.com/home/ntfs-mac/) - Read/write access to NTFS in macOS Sierra.


### PR DESCRIPTION
### Types of Changes

- [x] New addition to list
- [ ] Fixing bug in existing item in list
- [ ] Removing item from list
- [ ] Changing structure (organization) of list

### Proposed Changes

Adds **[McAwake](https://github.com/taufiqxr/McAwake)** to **System Related Tools**, in alphabetical order, synced across `README.md`, `README-zh.md`, `README-ja.md`, and `README-ko.md`.

Why it should be added: McAwake is a free, MIT-licensed, open-source menu bar app (Swift/AppKit, macOS 13+) that keeps a Mac awake **even with the lid closed and no external display attached** — it uses `pmset disablesleep`, which covers a case that idle-sleep assertion tools listed here (Amphetamine, KeepingYouAwake) cannot. It also has a Smart Auto mode (awake on AC, sleep on battery), a low-battery guard that restores normal sleep below 15% battery, live monitoring of local servers/tunnels with down/up notifications, and a Claude Code session switcher. Distributed via GitHub Releases and a Homebrew tap (`brew install --cask taufiqxr/tap/mcawake`).

Full disclosure:

- I'm the developer of the app.
- The app is ad-hoc signed, not notarized (disclosed in its README with install instructions).
- **This PR was opened when the app was named NightOwl.** It has since been renamed to McAwake (v2.0.0) specifically to avoid confusion with the discontinued dark-mode switcher of the same name. The entry text and links are updated, and the entry has been moved to its correct alphabetical position — `McAwake` sorts after `MagicQuit`, so it moves in three of the four files (`README-ko.md`'s slot is unchanged). The branch name still reads `add-nightowl` because renaming it would close this PR.

### PR Checklist

- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important
- [ ] I have added necessary documentation (if appropriate) — N/A, single list entry

### Further Comments

None — single entry, one PR.
