### PR TITLE
Add QuelPad to Databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,6 +594,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Postgres.app](https://postgresapp.com/) - The easiest way to get started with PostgreSQL on the Mac. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/PostgresApp/PostgresApp)
 * [Postico](https://eggerapps.at/postico/) - Modern PostgreSQL client for Mac.
 * [PSequel](https://www.psequel.com/) - PostgreSQL GUI tool for Mac OS X. ![Freeware][Freeware Icon]
+* [QuelPad](https://quelpad.com) - TypeScript scratchpad and database client for PostgreSQL, MySQL, SQLite, MSSQL and cloud variants; query, transform and chart with typed scripts, or ask in plain English. ![Freeware][Freeware Icon]
 * [Redis Insight](https://redis.io/insight/) - Official Redis tool for browsing, debugging, and visualizing data. ![Freeware][Freeware Icon]
 * [RedisClient](https://github.com/UUGU/redis-client-app) - Redis client application on mac, windows and linux. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/UUGU/redis-client-app)
 * [RedisDesktopManager](https://redisdesktop.com) - Cross-platform GUI management tool for Redis. [![Open-Source Software][OSS Icon]](https://github.com/uglide/RedisDesktopManager) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds [QuelPad](https://quelpad.com) to the **Databases** section (alphabetically between PSequel and Redis Insight).

QuelPad is a native macOS (and Windows) app: a TypeScript-first scratchpad + database client for PostgreSQL, MySQL, SQLite, MSSQL and their cloud/serverless variants (Neon, PlanetScale, TiDB, CockroachDB, ClickHouse, libSQL, DuckDB, …). Query, transform and chart your data with typed TypeScript scripts, or ask in plain English. Has a free tier, hence the Freeware marker (freemium).