### PR TITLE
Add Mainspring to System Related Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1552,6 +1552,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [KeepingYouAwake](https://github.com/newmarcel/KeepingYouAwake) - Caffeine alternative with dark mode support. [![Open-Source Software][OSS Icon]](https://github.com/newmarcel/KeepingYouAwake)
 * [macUSB](https://github.com/Kruszoneq/macUSB) - A bootable macOS / OS X installer creator for Apple Silicon Macs. [![Open-Source Software][OSS Icon]](https://github.com/Kruszoneq/macUSB) ![Freeware][Freeware Icon]
 * [MagicQuit](https://magicquit.com/) - Automatically quit inactive apps to reduce clutter and free resources. [![Open-Source Software][OSS Icon]](https://github.com/BigBerny/magicquit) ![Freeware][Freeware Icon]
+* [Mainspring](https://trymainspring.com/) - Turn 90+ hidden macOS settings into one-click, reversible toggles, each with an undo button.
 * [MiddleDrag](https://github.com/NullPointerDepressiveDisorder/MiddleDrag) - Three-finger trackpad gestures for middle-click and middle-drag on macOS. [![Open-Source Software][OSS Icon]](https://github.com/NullPointerDepressiveDisorder/MiddleDrag) ![Freeware][Freeware Icon]
 * [Monity](https://www.monityapp.com/) - System monitoring widget for OS X.
 * [Mounty](https://enjoygineering.com/mounty/) - Tiny tool to re-mount write-protected NTFS volumes under Mac OS X 10.9+ in read-write mode. ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds Mainspring, a native macOS utility that turns 90+ hidden system settings into one-click, reversible toggles (each with an undo button), covering the Dock, Finder, keyboard, trackpad, privacy, performance, screenshots, and the menu bar.

- Placed alphabetically in **System Related Tools** (between MagicQuit and MiddleDrag).
- Format matches existing entries. No badge, consistent with other commercial, non App Store apps (e.g. iStat Menus).
- Signed and notarized by Apple. Website: https://trymainspring.com