### PR TITLE
Add RevelRaw

### DIFF
--- a/README.md
+++ b/README.md
@@ -660,6 +660,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Principle](https://principleformac.com/) -  Application for designing animated and interactive user interfaces.
 * [Pika](https://superhighfives.com/pika) - An open-source color picker app. [![Open-Source Software][OSS Icon]](https://github.com/superhighfives/pika) [![App Store][app-store Icon]](https://apps.apple.com/app/pika/id6739170421?platform=mac)
 * [RawTherapee](https://rawtherapee.com/) - A powerful cross-platform raw photo processing program! ![Freeware][Freeware Icon] [![Open-Source Software][OSS Icon]](https://github.com/Beep6581/RawTherapee)
+* [RevelRaw](https://revelraw.com) - Native RAW photo editor for every major camera brand; AI scene detection ranks 40+ presets per photo, all processing on-device. [![App Store][app-store Icon]](https://apps.apple.com/app/revelraw/id6773942240?platform=mac)
 * [ScreenToLayers](https://github.com/duyquoc/ScreenToLayers) - Easily export your screen into a layered PSD file. [![Open-Source Software][OSS Icon]](https://github.com/duyquoc/ScreenToLayers) ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/screentolayers/id1077317077?platform=mac)
 * [Sketch](https://www.sketchapp.com/) - Professional digital design for mac.
     * [Sketch Cache Cleaner](https://yo-op.github.io/sketchcachecleaner/) - Deletes hidden Sketch history files. [![OSS][OSS Icon]](https://github.com/yo-op/sketchcachecleaner) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds **RevelRaw** to Design Tools — a native macOS RAW photo editor. Opens RAW from every major camera brand (Sony ARW, Canon CR3, Nikon NEF, Fujifilm RAF, and more — 24 formats), with AI scene detection that ranks its 40+ curated presets per photo. All processing on-device; no account or cloud. Free download on the Mac App Store with paid Pro tier.

- Website: https://revelraw.com
- App Store: https://apps.apple.com/app/revelraw/id6773942240
- Placed alphabetically after RawTherapee, matching the existing entry and icon format.

I'm the developer.