### PR TITLE
Add mac-ssd-toolkit to Developer Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 
 ### Developer Utilities
 
+* [mac-ssd-toolkit](https://github.com/sxrxvxnn/mac-ssd-toolkit) - Use an external SSD as your Mac's primary storage — terminal menus (`ssd` + `mac`), 27 automation scripts, 18 LaunchAgents, and a one-command installer. [![Open-Source Software][OSS Icon]](https://github.com/sxrxvxnn/mac-ssd-toolkit) ![Freeware][Freeware Icon]
 * [AXe](https://github.com/cameroncooke/AXe) - CLI tool for controlling iOS Simulators through Accessibility APIs and HID automation. [![Open-Source Software][OSS Icon]](https://github.com/cameroncooke/AXe) ![Freeware][Freeware Icon]
 * [BetterRename](https://www.publicspace.net/BetterRename/) - The most powerful and complete Mac file renaming application on the market. [![App Store][app-store Icon]](https://apps.apple.com/us/app/better-rename-11/id1501308038?platform=mac)
 * [Beyond Compare](https://www.scootersoftware.com/) - Compare files and folders with powerful commands. ![Freeware][Freeware Icon]


### PR DESCRIPTION
## mac-ssd-toolkit

**Link:** https://github.com/sxrxvxnn/mac-ssd-toolkit

A shell toolkit for using an external SSD as Mac primary storage, with automation and terminal menus.

**What it does:**
- Moves Dev projects, toolchains, and user folders to SSD via symlinks
- `ssd` menu: 27 scripts covering storage, dev workflow, system monitoring, productivity
- `mac` menu: 19 tools for system stats, app management, security, power
- 18 launchd LaunchAgents for nightly backups, cache cleanup, disk alerts, git reports
- Interactive installer — one command, configures everything for any username/SSD

**Why it belongs here:**
Fills a gap for Mac developers with limited internal storage (128–256GB) who need a practical, automated workflow around external SSDs. Pure shell — no dependencies beyond Homebrew.

**Checklist:**
- [x] Open source (MIT)
- [x] Free
- [x] macOS native (zsh + launchd)
- [x] Actively maintained