### PR TITLE
Add Crisp to Quality of Life Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1515,6 +1515,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 
 * [Actions](https://sindresorhus.com/actions) - Provides many useful actions for the Shortcuts app. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id1586435171?platform=mac)
 * [AI Actions](https://sindresorhus.com/ai-actions) - AI actions for the Shortcuts app. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id6465250302)
+* [Crisp](https://didriksg.github.io/Crisp/) - Manage external displays from the menu bar: HiDPI scaling, DDC brightness, color, and presets. [![Open-Source Software][OSS Icon]](https://github.com/didriksg/Crisp) ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [DisplayBuddy](https://displaybuddy.app) - Control external display brightness, contrast, and input source.
 * [Dimly](https://feuerbacher.me/projects/dimly) - Control brightness across mixed monitor setups from one menu bar app. [![Open-Source Software][OSS Icon]](https://github.com/punshnut/macos-dimly) ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [f.lux](https://justgetflux.com/) - Makes the color of your computer's display adapt to the time of day. ![Freeware][Freeware Icon]


### PR DESCRIPTION
Crisp is a free, open-source, native macOS menu bar app for managing external displays: HiDPI scaling, DDC brightness, color profiles, arrangement, and presets. MIT licensed.

Added to Quality of Life Improvements next to the other display tools (DisplayBuddy, Dimly, Lunar), placed alphabetically and formatted to match with the Open-Source, Freeware, and Native App badges.

Repo: https://github.com/didriksg/Crisp