### PR TITLE
Add DevProjex to Developer Utilities

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -398,6 +398,7 @@ Awesome Mac
 * [CubicBezier](https://github.com/isaced/CubicBezier) - macOS用CubicBezierジェネレーター。 [![Open-Source Software][OSS Icon]](https://github.com/isaced/CubicBezier) ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/us/app/cubicbezier/id1228492117?platform=mac)
 * [Cutter](https://cutter.re/) - 強力なマルチプラットフォームリバースエンジニアリングツール。 ![Open-Source Software][OSS Icon]
 * [DevHub](https://wangchujiang.com/DevHub/) - 開発者向けの多機能オフラインアプリ。 ![OSS][OSS Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/devhub/id6476452351?platform=mac)
+* [DevProjex](https://github.com/Avazbek22/DevProjex) - フォルダツリー、ファイル内容、トークン数の計測、Smart Ignore、プレビュー、複数形式へのエクスポートに対応した、構造化されたプロジェクトコンテキストを作成するクロスプラットフォームGUI／CLI。 [![Open-Source Software][OSS Icon]](https://github.com/Avazbek22/DevProjex) ![Freeware][Freeware Icon]
 * [Dash](https://kapeli.com/dash) - 素晴らしいAPIドキュメントブラウザ兼コードスニペット管理ツール。 ![Freeware][Freeware Icon]
 * [Deeplink Buddy](https://deeplinkbuddy.com) - 開発者による開発者のためのディープリンク管理ツール。
 * [DiffMerge](http://sourcegear.com/diffmerge/) - ファイルの視覚的な比較とマージを行うアプリケーション。 ![Freeware][Freeware Icon]

--- a/README-ja.md
+++ b/README-ja.md
@@ -419,7 +419,7 @@ Awesome Mac
 * [CubicBezier](https://github.com/isaced/CubicBezier) - macOS用CubicBezierジェネレーター。 [![Open-Source Software][OSS Icon]](https://github.com/isaced/CubicBezier) ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/us/app/cubicbezier/id1228492117?platform=mac)
 * [Cutter](https://cutter.re/) - 強力なマルチプラットフォームリバースエンジニアリングツール。 ![Open-Source Software][OSS Icon]
 * [DevHub](https://wangchujiang.com/DevHub/) - 開発者向けの多機能オフラインアプリ。 ![OSS][OSS Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/devhub/id6476452351?platform=mac)
-* [DevProjex](https://github.com/Avazbek22/DevProjex) - フォルダツリー、ファイル内容、トークン数の計測、Smart Ignore、プレビュー、複数形式へのエクスポートに対応した、構造化されたプロジェクトコンテキストを作成するクロスプラットフォームGUI／CLI。 [![Open-Source Software][OSS Icon]](https://github.com/Avazbek22/DevProjex) ![Freeware][Freeware Icon]
+* [DevProjex](https://github.com/Avazbek22/DevProjex) - macOS Intel と Apple Silicon 向けのクロスプラットフォームなコードベースコンテキストアプリで、GUI、TUI、CLI、ライブプレビュー、マスキング、圧縮、組み込みの読み取り専用 MCP サーバーを備えています。 [![Open-Source Software][OSS Icon]](https://github.com/Avazbek22/DevProjex) ![Freeware][Freeware Icon]
 * [Dash](https://kapeli.com/dash) - 素晴らしいAPIドキュメントブラウザ兼コードスニペット管理ツール。 ![Freeware][Freeware Icon]
 * [Deeplink Buddy](https://deeplinkbuddy.com) - 開発者による開発者のためのディープリンク管理ツール。
 * [DiffMerge](http://sourcegear.com/diffmerge/) - ファイルの視覚的な比較とマージを行うアプリケーション。 ![Freeware][Freeware Icon]

--- a/README-ja.md
+++ b/README-ja.md
@@ -419,6 +419,7 @@ Awesome Mac
 * [CubicBezier](https://github.com/isaced/CubicBezier) - macOS用CubicBezierジェネレーター。 [![Open-Source Software][OSS Icon]](https://github.com/isaced/CubicBezier) ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/us/app/cubicbezier/id1228492117?platform=mac)
 * [Cutter](https://cutter.re/) - 強力なマルチプラットフォームリバースエンジニアリングツール。 ![Open-Source Software][OSS Icon]
 * [DevHub](https://wangchujiang.com/DevHub/) - 開発者向けの多機能オフラインアプリ。 ![OSS][OSS Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/devhub/id6476452351?platform=mac)
+* [DevProjex](https://github.com/Avazbek22/DevProjex) - フォルダツリー、ファイル内容、トークン数の計測、Smart Ignore、プレビュー、複数形式へのエクスポートに対応した、構造化されたプロジェクトコンテキストを作成するクロスプラットフォームGUI／CLI。 [![Open-Source Software][OSS Icon]](https://github.com/Avazbek22/DevProjex) ![Freeware][Freeware Icon]
 * [Dash](https://kapeli.com/dash) - 素晴らしいAPIドキュメントブラウザ兼コードスニペット管理ツール。 ![Freeware][Freeware Icon]
 * [Deeplink Buddy](https://deeplinkbuddy.com) - 開発者による開発者のためのディープリンク管理ツール。
 * [DiffMerge](http://sourcegear.com/diffmerge/) - ファイルの視覚的な比較とマージを行うアプリケーション。 ![Freeware][Freeware Icon]

--- a/README-ko.md
+++ b/README-ko.md
@@ -376,6 +376,7 @@ Awesome Mac
 * [Deeplink Buddy](https://deeplinkbuddy.com) - 딥링크 관리자.
 * [DiffMerge](http://sourcegear.com/diffmerge/) - 파일 비교 및 병합 도구. ![Freeware][Freeware Icon]
 * [DevHub](https://wangchujiang.com/DevHub/) - 개발자를 위한 기능 풍부한 오프라인 앱. ![OSS][OSS Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/devhub/id6476452351?platform=mac)
+* [DevProjex](https://github.com/Avazbek22/DevProjex) - 폴더 트리, 파일 내용, 토큰 계산, Smart Ignore, 미리보기 및 다중 형식 내보내기로 구조화된 프로젝트 컨텍스트를 만드는 크로스 플랫폼 GUI 및 CLI. [![Open-Source Software][OSS Icon]](https://github.com/Avazbek22/DevProjex) ![Freeware][Freeware Icon]
 * [EnvPane](https://github.com/hschmidt/EnvPane) - 환경 변수 설정 창. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/hschmidt/EnvPane)
 * [FinderGo](https://github.com/onmyway133/FinderGo) - Finder에서 터미널 열기. [![Freeware][Freeware Icon] ![Open-Source Software][OSS Icon]](https://github.com/onmyway133/FinderGo)
 * [Tintpad](https://github.com/sorkila/tintpad) - Menu bar launcher that opens your terminal at the right repo with a coding agent (Claude Code, Codex) already running. [![Open-Source Software][OSS Icon]](https://github.com/sorkila/tintpad) ![Freeware][Freeware Icon]

--- a/README-ko.md
+++ b/README-ko.md
@@ -396,7 +396,7 @@ Awesome Mac
 * [Deeplink Buddy](https://deeplinkbuddy.com) - 딥링크 관리자.
 * [DiffMerge](http://sourcegear.com/diffmerge/) - 파일 비교 및 병합 도구. ![Freeware][Freeware Icon]
 * [DevHub](https://wangchujiang.com/DevHub/) - 개발자를 위한 기능 풍부한 오프라인 앱. ![OSS][OSS Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/devhub/id6476452351?platform=mac)
-* [DevProjex](https://github.com/Avazbek22/DevProjex) - 폴더 트리, 파일 내용, 토큰 계산, Smart Ignore, 미리보기 및 다중 형식 내보내기로 구조화된 프로젝트 컨텍스트를 만드는 크로스 플랫폼 GUI 및 CLI. [![Open-Source Software][OSS Icon]](https://github.com/Avazbek22/DevProjex) ![Freeware][Freeware Icon]
+* [DevProjex](https://github.com/Avazbek22/DevProjex) - macOS Intel 및 Apple Silicon용 크로스 플랫폼 코드베이스 컨텍스트 앱으로, GUI, TUI, CLI, 라이브 미리보기, 마스킹, 압축, 내장 읽기 전용 MCP 서버를 제공합니다. [![Open-Source Software][OSS Icon]](https://github.com/Avazbek22/DevProjex) ![Freeware][Freeware Icon]
 * [EnvPane](https://github.com/hschmidt/EnvPane) - 환경 변수 설정 창. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/hschmidt/EnvPane)
 * [FinderGo](https://github.com/onmyway133/FinderGo) - Finder에서 터미널 열기. [![Freeware][Freeware Icon] ![Open-Source Software][OSS Icon]](https://github.com/onmyway133/FinderGo)
 * [Tintpad](https://github.com/sorkila/tintpad) - Menu bar launcher that opens your terminal at the right repo with a coding agent (Claude Code, Codex) already running. [![Open-Source Software][OSS Icon]](https://github.com/sorkila/tintpad) ![Freeware][Freeware Icon]

--- a/README-ko.md
+++ b/README-ko.md
@@ -396,6 +396,7 @@ Awesome Mac
 * [Deeplink Buddy](https://deeplinkbuddy.com) - 딥링크 관리자.
 * [DiffMerge](http://sourcegear.com/diffmerge/) - 파일 비교 및 병합 도구. ![Freeware][Freeware Icon]
 * [DevHub](https://wangchujiang.com/DevHub/) - 개발자를 위한 기능 풍부한 오프라인 앱. ![OSS][OSS Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/devhub/id6476452351?platform=mac)
+* [DevProjex](https://github.com/Avazbek22/DevProjex) - 폴더 트리, 파일 내용, 토큰 계산, Smart Ignore, 미리보기 및 다중 형식 내보내기로 구조화된 프로젝트 컨텍스트를 만드는 크로스 플랫폼 GUI 및 CLI. [![Open-Source Software][OSS Icon]](https://github.com/Avazbek22/DevProjex) ![Freeware][Freeware Icon]
 * [EnvPane](https://github.com/hschmidt/EnvPane) - 환경 변수 설정 창. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/hschmidt/EnvPane)
 * [FinderGo](https://github.com/onmyway133/FinderGo) - Finder에서 터미널 열기. [![Freeware][Freeware Icon] ![Open-Source Software][OSS Icon]](https://github.com/onmyway133/FinderGo)
 * [Tintpad](https://github.com/sorkila/tintpad) - Menu bar launcher that opens your terminal at the right repo with a coding agent (Claude Code, Codex) already running. [![Open-Source Software][OSS Icon]](https://github.com/sorkila/tintpad) ![Freeware][Freeware Icon]

--- a/README-zh.md
+++ b/README-zh.md
@@ -251,7 +251,7 @@ Awesome Mac
 * [Configs](https://github.com/iHongRen/configEditor) - 配置文件管理器，用于快速查看、编辑和管理配置文件。 [![Open-Source Software][OSS Icon]](https://github.com/iHongRen/configEditor) ![Freeware][Freeware Icon]
 * [CubicBezier](https://github.com/isaced/CubicBezier) - 一个适用于 macOS 的贝塞尔曲线生成器。 [![Open-Source Software][OSS Icon]](https://github.com/isaced/CubicBezier) ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/us/app/cubicbezier/id1228492117?platform=mac)
 * [DevHub](https://wangchujiang.com/DevHub/) - 一个功能丰富的离线应用程序，精心制作，以支持开发人员在他们的日常任务。![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/devhub/id6476452351?platform=mac)
-* [DevProjex](https://github.com/Avazbek22/DevProjex) - 用于构建结构化项目上下文的跨平台 GUI 和 CLI，支持目录树、文件内容、Token 统计、Smart Ignore、预览和多格式导出。 [![Open-Source Software][OSS Icon]](https://github.com/Avazbek22/DevProjex) ![Freeware][Freeware Icon]
+* [DevProjex](https://github.com/Avazbek22/DevProjex) - 面向 macOS Intel 和 Apple Silicon 的跨平台代码库上下文应用，提供 GUI、TUI、CLI、实时预览、脱敏、压缩和内置只读 MCP 服务。 [![Open-Source Software][OSS Icon]](https://github.com/Avazbek22/DevProjex) ![Freeware][Freeware Icon]
 * [DevToys](https://github.com/DevToys-app/DevToys) - 开发者的瑞士军刀——一款帮助开发者处理日常任务的桌面应用。[![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/DevToys-app/DevToys)
 * [DevUtils.app](https://devutils.com/) - 用于格式化、转换和调试常见数据的开发者工具箱。 [![Open-Source Software][OSS Icon]](https://github.com/DevUtilsApp/DevUtils-app) ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/us/app/devutils-app/id1533756032?platform=mac)
 * [Dash](https://kapeli.com/dash) - 强大到你无法想象的 API 离线文档软件。![Freeware][Freeware Icon]

--- a/README-zh.md
+++ b/README-zh.md
@@ -251,6 +251,7 @@ Awesome Mac
 * [Configs](https://github.com/iHongRen/configEditor) - 配置文件管理器，用于快速查看、编辑和管理配置文件。 [![Open-Source Software][OSS Icon]](https://github.com/iHongRen/configEditor) ![Freeware][Freeware Icon]
 * [CubicBezier](https://github.com/isaced/CubicBezier) - 一个适用于 macOS 的贝塞尔曲线生成器。 [![Open-Source Software][OSS Icon]](https://github.com/isaced/CubicBezier) ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/us/app/cubicbezier/id1228492117?platform=mac)
 * [DevHub](https://wangchujiang.com/DevHub/) - 一个功能丰富的离线应用程序，精心制作，以支持开发人员在他们的日常任务。![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/devhub/id6476452351?platform=mac)
+* [DevProjex](https://github.com/Avazbek22/DevProjex) - 用于构建结构化项目上下文的跨平台 GUI 和 CLI，支持目录树、文件内容、Token 统计、Smart Ignore、预览和多格式导出。 [![Open-Source Software][OSS Icon]](https://github.com/Avazbek22/DevProjex) ![Freeware][Freeware Icon]
 * [DevToys](https://github.com/DevToys-app/DevToys) - 开发者的瑞士军刀——一款帮助开发者处理日常任务的桌面应用。[![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/DevToys-app/DevToys)
 * [DevUtils.app](https://devutils.com/) - 用于格式化、转换和调试常见数据的开发者工具箱。 [![Open-Source Software][OSS Icon]](https://github.com/DevUtilsApp/DevUtils-app) ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/us/app/devutils-app/id1533756032?platform=mac)
 * [Dash](https://kapeli.com/dash) - 强大到你无法想象的 API 离线文档软件。![Freeware][Freeware Icon]

--- a/README-zh.md
+++ b/README-zh.md
@@ -236,6 +236,7 @@ Awesome Mac
 * [Configs](https://github.com/iHongRen/configEditor) - 配置文件管理器，用于快速查看、编辑和管理配置文件。 [![Open-Source Software][OSS Icon]](https://github.com/iHongRen/configEditor) ![Freeware][Freeware Icon]
 * [CubicBezier](https://github.com/isaced/CubicBezier) - 一个适用于 macOS 的贝塞尔曲线生成器。 [![Open-Source Software][OSS Icon]](https://github.com/isaced/CubicBezier) ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/us/app/cubicbezier/id1228492117?platform=mac)
 * [DevHub](https://wangchujiang.com/DevHub/) - 一个功能丰富的离线应用程序，精心制作，以支持开发人员在他们的日常任务。![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/devhub/id6476452351?platform=mac)
+* [DevProjex](https://github.com/Avazbek22/DevProjex) - 用于构建结构化项目上下文的跨平台 GUI 和 CLI，支持目录树、文件内容、Token 统计、Smart Ignore、预览和多格式导出。 [![Open-Source Software][OSS Icon]](https://github.com/Avazbek22/DevProjex) ![Freeware][Freeware Icon]
 * [DevToys](https://github.com/DevToys-app/DevToys) - 开发者的瑞士军刀——一款帮助开发者处理日常任务的桌面应用。[![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/DevToys-app/DevToys)
 * [DevUtils.app](https://devutils.com/) - 用于格式化、转换和调试常见数据的开发者工具箱。 [![Open-Source Software][OSS Icon]](https://github.com/DevUtilsApp/DevUtils-app) ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/us/app/devutils-app/id1533756032?platform=mac)
 * [Dash](https://kapeli.com/dash) - 强大到你无法想象的 API 离线文档软件。![Freeware][Freeware Icon]

--- a/README.md
+++ b/README.md
@@ -418,6 +418,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [CubicBezier](https://github.com/isaced/CubicBezier) - CubicBezier Generator for macOS. [![Open-Source Software][OSS Icon]](https://github.com/isaced/CubicBezier) ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/us/app/cubicbezier/id1228492117?platform=mac)
 * [Cutter](https://cutter.re/) - Powerful multi-platform reverse engineering tool. ![Open-Source Software][OSS Icon]
 * [DevHub](https://wangchujiang.com/DevHub/) - Feature-rich offline app for developers. ![OSS][OSS Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/devhub/id6476452351?platform=mac)
+* [DevProjex](https://github.com/Avazbek22/DevProjex) - Cross-platform GUI and CLI for building structured project context with folder trees, file contents, token counting, Smart Ignore, preview, and multi-format export. [![Open-Source Software][OSS Icon]](https://github.com/Avazbek22/DevProjex) ![Freeware][Freeware Icon]
 * [Dash](https://kapeli.com/dash) - Awesome API documentation browser and code snippet manager. ![Freeware][Freeware Icon]
 * [Deeplink Buddy](https://deeplinkbuddy.com) - Deeplink managers, made by developer for developers.
 * [DiffMerge](https://sourcegear.com/diffmerge/) - Application to visually compare and merge files. ![Freeware][Freeware Icon]

--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [CubicBezier](https://github.com/isaced/CubicBezier) - CubicBezier Generator for macOS. [![Open-Source Software][OSS Icon]](https://github.com/isaced/CubicBezier) ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/us/app/cubicbezier/id1228492117?platform=mac)
 * [Cutter](https://cutter.re/) - Powerful multi-platform reverse engineering tool. ![Open-Source Software][OSS Icon]
 * [DevHub](https://wangchujiang.com/DevHub/) - Feature-rich offline app for developers. ![OSS][OSS Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/devhub/id6476452351?platform=mac)
-* [DevProjex](https://github.com/Avazbek22/DevProjex) - Cross-platform GUI and CLI for building structured project context with folder trees, file contents, token counting, Smart Ignore, preview, and multi-format export. [![Open-Source Software][OSS Icon]](https://github.com/Avazbek22/DevProjex) ![Freeware][Freeware Icon]
+* [DevProjex](https://github.com/Avazbek22/DevProjex) - Cross-platform codebase-context app for macOS Intel and Apple Silicon with GUI, TUI, CLI, live preview, redaction, compression, and a built-in read-only MCP server. [![Open-Source Software][OSS Icon]](https://github.com/Avazbek22/DevProjex) ![Freeware][Freeware Icon]
 * [Dash](https://kapeli.com/dash) - Awesome API documentation browser and code snippet manager. ![Freeware][Freeware Icon]
 * [Deeplink Buddy](https://deeplinkbuddy.com) - Deeplink managers, made by developer for developers.
 * [DiffMerge](https://sourcegear.com/diffmerge/) - Application to visually compare and merge files. ![Freeware][Freeware Icon]

--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [CubicBezier](https://github.com/isaced/CubicBezier) - CubicBezier Generator for macOS. [![Open-Source Software][OSS Icon]](https://github.com/isaced/CubicBezier) ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/us/app/cubicbezier/id1228492117?platform=mac)
 * [Cutter](https://cutter.re/) - Powerful multi-platform reverse engineering tool. ![Open-Source Software][OSS Icon]
 * [DevHub](https://wangchujiang.com/DevHub/) - Feature-rich offline app for developers. ![OSS][OSS Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/devhub/id6476452351?platform=mac)
+* [DevProjex](https://github.com/Avazbek22/DevProjex) - Cross-platform GUI and CLI for building structured project context with folder trees, file contents, token counting, Smart Ignore, preview, and multi-format export. [![Open-Source Software][OSS Icon]](https://github.com/Avazbek22/DevProjex) ![Freeware][Freeware Icon]
 * [Dash](https://kapeli.com/dash) - Awesome API documentation browser and code snippet manager. ![Freeware][Freeware Icon]
 * [Deeplink Buddy](https://deeplinkbuddy.com) - Deeplink managers, made by developer for developers.
 * [DiffMerge](https://sourcegear.com/diffmerge/) - Application to visually compare and merge files. ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds DevProjex to Developer Utilities across the English, Chinese, Japanese, and Korean lists. It is a cross-platform macOS codebase-context app for Intel and Apple Silicon with GUI, TUI, CLI, live preview, redaction, compression, and a built-in read-only MCP server.