### PR TITLE
Add Notchpad

### DIFF
--- a/README.md
+++ b/README.md
@@ -807,6 +807,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Fluent](https://fluentmac.app) - AI assistant that works across apps with model and context integration.
 * [Gemini Collector](https://github.com/FirenzeLor/gemini-collector) - Back up Google Gemini conversations, attachments, and AI-generated media locally as JSON. [![Open-Source Software][OSS Icon]](https://github.com/FirenzeLor/gemini-collector) ![Freeware][Freeware Icon]
 * [GroAsk](https://groask.com) - Menu bar launcher that sends selected text to AI assistants and CLI agents.
+* [Notchpad](https://github.com/BirdyTheDev/notchpad) - Modular panel in the MacBook notch: live Claude Code sessions and token usage, a file shelf, keep-awake while an agent works, system stats, Unity and MCP status. [![Open-Source Software][OSS Icon]](https://github.com/BirdyTheDev/notchpad) ![Freeware][Freeware Icon]
 * [RecurseChat](https://recurse.chat) - Local-first AI chat app with customizable workflows.
 * [Runtime](https://github.com/runtime-org/runtime) - AI taskmate and take control of the web & your office tools
 * [TokenMeter](https://priyans-hu.github.io/tokenmeter/) - Track Claude Code usage, rate limits, costs, and activity heatmaps. [![Open-Source Software][OSS Icon]](https://github.com/Priyans-hu/tokenmeter) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds [Notchpad](https://github.com/BirdyTheDev/notchpad) to **AI Tools**, alphabetically.

Open source (MIT), Swift, no dependencies, macOS 14+ on Apple Silicon.

A modular panel that lives in the MacBook notch — you enable the modules you want and order them yourself: live Claude Code sessions and token usage, an action launcher for slash commands, a file shelf you can drag files in and out of, keep-awake that blocks sleep automatically while an agent is working, system and memory readouts, battery, pomodoro, custom shell commands, Unity Hub projects with compile errors, and MCP server reachability.