### PR TITLE
Add HeatPilot (menu-bar fan control for Apple Silicon)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1548,6 +1548,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [GrandPerspective](https://grandperspectiv.sourceforge.net) - Visualize disk usage with tree maps. [![Open-Source Software][OSS Icon]](https://git.code.sf.net/p/grandperspectiv/source) [![Freeware][Freeware Icon]](https://sourceforge.net/projects/grandperspectiv/files/grandperspective/) [![App Store][app-store Icon]](https://apps.apple.com/us/app/grandperspective/id1111570163?platform=mac)
 * [Gray](https://github.com/zenangst/Gray) - Per-app light/dark mode switcher. ![Freeware][Freeware Icon] [![Open-Source Software][OSS Icon]](https://github.com/zenangst/Gray)
 * [HandShaker](https://www.smartisan.com/apps/handshaker) - Manage Android phone content on Mac. ![Freeware][Freeware Icon]
+* [HeatPilot](https://github.com/AgentC-Consulting/heatpilot) - Free menu-bar fan control for Apple Silicon: a cooler custom curve, Full Blast mode, and one click back to Apple's defaults. ![Freeware][Freeware Icon]
 * [iStat Menus](https://bjango.com/mac/istatmenus/) - Advanced system monitor for menubar.
 * [iStats](https://github.com/Chris911/iStats) - Command-line system information tool. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/Chris911/iStats)
 * [Juice](https://github.com/brianmichel/Juice) - Enhanced battery information display. [![Open-Source Software][OSS Icon]](https://github.com/brianmichel/Juice) ![Freeware][Freeware Icon]


### PR DESCRIPTION
## What is HeatPilot?

[HeatPilot](https://github.com/AgentC-Consulting/heatpilot) is a free, native menu-bar fan controller for Apple Silicon Macs (macOS 14+): a cooler custom fan curve, a Full Blast mode, live temperatures in the menu bar, and one click back to Apple's default thermal management.

- **Free** (freeware, free for life — no account, no telemetry, no network calls)
- Signed with Apple Developer ID and notarized; DMG + GPG-signed checksums on the [releases page](https://github.com/AgentC-Consulting/heatpilot/releases)
- Added under **System Tools**, alphabetical order, with the Freeware icon (closed source)

Made by AgentC Consulting — happy to adjust wording or placement if you prefer.