### PR TITLE
Add condui to Terminal Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,6 +614,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [alacritty](https://github.com/jwilm/alacritty) - A cross-platform, GPU-accelerated terminal emulator. [![Open-Source Software][OSS Icon]](https://github.com/jwilm/alacritty) ![Freeware][Freeware Icon]
 * [Awal Terminal](https://github.com/AwalTerminal/Awal-terminal) - AI-native terminal emulator with multi-provider profiles and voice input. [![Open-Source Software][OSS Icon]](https://github.com/AwalTerminal/Awal-terminal) ![Freeware][Freeware Icon]
 * [Command Book](https://commandbookapp.com) - A terminal companion for long-running terminal commands (freemium)
+* [condui](https://condui.codeffeine.io/) - Cross-platform desktop workspace for remote infrastructure: SSH terminal, SFTP, tunnels, Docker and database exploration, and VirtualBox controls. [![Open-Source Software][OSS Icon]](https://github.com/mgueregath/condui) ![Freeware][Freeware Icon]
 * [electerm](https://electerm.github.io/electerm/) - Terminal, SSH, and SFTP client. [![Open-Source Software][OSS Icon]](https://github.com/electerm/electerm) ![Freeware][Freeware Icon]
 * [Ghostty](https://github.com/ghostty-org/ghostty) - Fast GPU-accelerated terminal emulator. [![Open-Source Software][OSS Icon]](https://github.com/ghostty-org/ghostty) ![Freeware][Freeware Icon]
 * [hyper](https://hyper.is) - A terminal built on web technologies. [![Open-Source Software][OSS Icon]](https://github.com/zeit/hyper) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds [condui](https://github.com/mgueregath/condui) to Terminal Apps,
alongside electerm/Termius: a cross-platform (macOS/Windows/Linux) SSH
terminal and SFTP client, with tunnels, Docker container management,
database exploration over SSH, and VirtualBox controls in one app.

Open source (AGPL-3.0), free to use.