### PR TITLE
Add Dictami to Voice-to-Text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 <div align="center" markdown="1">
+  - [Dictami](https://dictami.com) - Private offline voice dictation for Mac with live transcription, automatic punctuation, and no account required.
   <sup>Special thanks to:</sup>
   <br>
   <br>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 <div align="center" markdown="1">
-    <sup>Special thanks to:</sup>
+  <sup>Special thanks to:</sup>
   <br>
   <br>
+
   <a href="https://screensage.pro/">
     <img alt="ScreenSage Pro" width="400" src="https://jaywcjlove.github.io/sponsor/screensage.png">
   </a>

--- a/README.md
+++ b/README.md
@@ -1033,7 +1033,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Aiko](https://sindresorhus.com/aiko) - High-quality on-device transcription. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id1666327168?platform=mac)
 * [Azex Speech](https://github.com/azex-ai/speech) - Voice input tuned for mixed Chinese-English dictation in AI and crypto work. [![Open-Source Software][OSS Icon]](https://github.com/azex-ai/speech) ![Freeware][Freeware Icon]
 * [buzz](https://github.com/chidiwilliams/buzz) - Transcribes and translates audio offline on your personal computer. Powered by OpenAI's Whisper. [![Open-Source Software][OSS Icon]](https://github.com/chidiwilliams/buzz)
-* [Dictami](https://dictami.com/) - Press a hotkey and speak; punctuated text appears in whatever app your cursor is in, transcribed entirely on-device in 28 languages.
+* [Dictami](https://dictami.com/) - Press a hotkey and speak; punctuated text appears in whatever app your cursor is in, transcribed entirely on-device in 30 languages.
 * [EnviousWispr](https://enviouswispr.com) - Sub-second dictation running Whisper/Parakeet locally with privacy-first AI text polish. ![Freeware][Freeware Icon]
 * [FnKey](https://github.com/evoleinik/fnkey) - Push-to-talk voice input tool that pastes transcribed text instantly. [![Open-Source Software][OSS Icon]](https://github.com/evoleinik/fnkey) ![Freeware][Freeware Icon]
 * [OpenDictation](https://github.com/kdcokenny/OpenDictation) - Open-source dictation utility with local and cloud speech-to-text. [![Open-Source Software][OSS Icon]](https://github.com/kdcokenny/OpenDictation) ![Freeware][Freeware Icon]

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 <div align="center" markdown="1">
-  - [Dictami](https://dictami.com) - Private offline voice dictation for Mac with live transcription, automatic punctuation, and no account required.
-  <sup>Special thanks to:</sup>
+    <sup>Special thanks to:</sup>
   <br>
   <br>
-
   <a href="https://screensage.pro/">
     <img alt="ScreenSage Pro" width="400" src="https://jaywcjlove.github.io/sponsor/screensage.png">
   </a>
@@ -1034,6 +1032,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Aiko](https://sindresorhus.com/aiko) - High-quality on-device transcription. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id1666327168?platform=mac)
 * [Azex Speech](https://github.com/azex-ai/speech) - Voice input tuned for mixed Chinese-English dictation in AI and crypto work. [![Open-Source Software][OSS Icon]](https://github.com/azex-ai/speech) ![Freeware][Freeware Icon]
 * [buzz](https://github.com/chidiwilliams/buzz) - Transcribes and translates audio offline on your personal computer. Powered by OpenAI's Whisper. [![Open-Source Software][OSS Icon]](https://github.com/chidiwilliams/buzz)
+* [Dictami](https://dictami.com/) - Press a hotkey and speak; punctuated text appears in whatever app your cursor is in, transcribed entirely on-device in 28 languages.
 * [EnviousWispr](https://enviouswispr.com) - Sub-second dictation running Whisper/Parakeet locally with privacy-first AI text polish. ![Freeware][Freeware Icon]
 * [FnKey](https://github.com/evoleinik/fnkey) - Push-to-talk voice input tool that pastes transcribed text instantly. [![Open-Source Software][OSS Icon]](https://github.com/evoleinik/fnkey) ![Freeware][Freeware Icon]
 * [OpenDictation](https://github.com/kdcokenny/OpenDictation) - Open-source dictation utility with local and cloud speech-to-text. [![Open-Source Software][OSS Icon]](https://github.com/kdcokenny/OpenDictation) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds Dictami to the Voice-to-Text section.

Dictami is a private offline voice dictation app for Mac with live transcription and automatic punctuation.

- [x] New addition to list
- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important