### PR TITLE
Add BillHawk to Productivity

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1370,6 +1370,7 @@ Awesome Mac
 * [Better Launchpad](https://github.com/rewhex/better-launchpad) - 高速検索に対応したカスタマイズ可能なランチャー。
 * [BetterMouse](https://better-mouse.com) - サードパーティ製マウスのスクロール、加速、ボタン、ジェスチャーを調整できるツール。
 * [BetterTouchTool](https://folivora.ai/) - トラックパッド、マウス、キーボードのジェスチャーや操作を細かくカスタマイズできるツール。
+* [BillHawk](https://getbillhawk.com) - アプリごとに作業時間を自動記録し、その時間から PDF 請求書を作成するツール。データはすべてローカルに保存されます。 ![Native App][Native Icon]
 * [Cerebro](https://cerebroapp.com/) - 頭脳を持つオープンソースの生産性向上ツール。 [![Open-Source Software][OSS Icon]](https://github.com/cerebroapp/cerebro) ![Freeware][Freeware Icon]
 * [Choosy](https://www.choosyosx.com) - リンクをどこでどのように開くかのルールを管理するUI、URL API、ブラウザ拡張機能のセット。
 * [CurrentKey](https://currentkey.com) - Spacesに名前とアイコンを付けて、アプリごとの利用時間を追跡するツール。 [![App Store][app-store Icon]](https://apps.apple.com/us/app/currentkey/id1456226992?mt=12)

--- a/README-ko.md
+++ b/README-ko.md
@@ -983,6 +983,7 @@ Awesome Mac
 * [Better Launchpad](https://github.com/rewhex/better-launchpad) - 빠른 검색을 지원하는 맞춤형 앱 런처.
 * [BetterMouse](https://better-mouse.com) - 서드파티 마우스의 스크롤, 가속, 버튼, 제스처를 조정하는 도구.
 * [BetterTouchTool](https://folivora.ai/) - 트랙패드, 마우스, 키보드의 제스처와 동작을 세밀하게 설정하는 도구.
+* [BillHawk](https://getbillhawk.com) - 앱별로 작업 시간을 자동으로 기록하고 그 시간으로 PDF 청구서를 만드는 도구. 모든 데이터는 로컬에 저장됩니다. ![Native App][Native Icon]
 * [CurrentKey](https://currentkey.com) - Spaces에 사용자 지정 이름과 아이콘을 붙이고 앱 사용 시간을 추적하는 도구. [![App Store][app-store Icon]](https://apps.apple.com/us/app/currentkey/id1456226992?mt=12)
 * [FnKeyboard](https://github.com/kotique123/FnKeyboard) - 메뉴 막대에서 기능 키를 빠르게 호출하는 도구. [![Open-Source Software][OSS Icon]](https://github.com/kotique123/FnKeyboard) ![Freeware][Freeware Icon]
 * [Freeter](https://freeter.io/) - 앱, 링크, 파일을 프로젝트별로 정리하는 작업 공간 도구. [![Open-Source Software][OSS Icon]](https://github.com/FreeterApp/Freeter) ![Freeware][Freeware Icon]

--- a/README-zh.md
+++ b/README-zh.md
@@ -1116,6 +1116,7 @@ Awesome Mac
 * [Alfred](https://www.alfredapp.com/) - 效率神器。 [![Awesome List][awesome-list Icon]](https://github.com/learn-anything/alfred-workflows#readme)
 * [AltStore](https://altstore.io/) - 非越狱 iOS 设备的替代应用商店。[![Open-Source Software][OSS Icon]](https://altstore.io/#Downloads) ![Freeware][Freeware Icon]
 * [BetterTouchTool](https://folivora.ai/) - 自定义触控板、鼠标和键盘的手势与快捷操作。
+* [BillHawk](https://getbillhawk.com) - 按应用自动记录工作时间，并将时长直接生成 PDF 发票，所有数据保存在本地。 ![Native App][Native Icon]
 * [BetterZip](https://macitbetter.com/) - 压缩解压缩工具支持格式 ZIP、TAR、TGZ、TBZ、TXZ (new)、7-ZIP、RAR
 * [CheatSheet](https://www.mediaatelier.com/CheatSheet/) - CheatSheet 是一款 Mac 上的非常实用的快捷键快速提醒工具。 ![Freeware][Freeware Icon]
 * [Cadran](https://cadranapp.com) - 在Mac桌面壁纸和屏幕保护程序上显示22种可自定义的时钟表盘。

--- a/README.md
+++ b/README.md
@@ -1372,6 +1372,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Better Launchpad](https://github.com/rewhex/better-launchpad) - Customizable app launcher with fast search.
 * [BetterMouse](https://better-mouse.com) - Customize scrolling, acceleration, buttons, and gestures for third-party mice.
 * [BetterTouchTool](https://folivora.ai/) - Customize gestures, shortcuts, and input actions across trackpads, mice, and keyboards.
+* [BillHawk](https://getbillhawk.com) - Automatic per-application time tracking that turns tracked hours into PDF invoices, storing all data locally. ![Native App][Native Icon]
 * [Cerebro](https://cerebroapp.com/) - Open-source productivity booster with a brain. [![Open-Source Software][OSS Icon]](https://github.com/cerebroapp/cerebro) ![Freeware][Freeware Icon]
 * [Choosy](https://www.choosyosx.com) - UI, URL API and a browser extension set for managing rules where and how to open links.
 * [CurrentKey](https://currentkey.com) - Add custom names and icons to Spaces and track app usage time. [![App Store][app-store Icon]](https://apps.apple.com/us/app/currentkey/id1456226992?mt=12)


### PR DESCRIPTION
### Types of Changes

- [x] New addition to list

### Proposed Changes

Adds **BillHawk** to the *Utilities → Productivity* section, in alphabetical order (between BetterTouchTool and Cerebro), and synced across `README.md`, `README-zh.md`, `README-ja.md` and `README-ko.md` as the contributing guide requires.

**What it is:** a native macOS app (Swift, macOS 14+, universal, notarized by Apple) that tracks work time automatically per application — you designate your work apps once and the timer follows whichever is frontmost, pausing on idle, screen lock and sleep. Tracked sessions carry their client and project, so they can be exported directly as PDF invoices.

**Why it fits this list:** the Productivity section already includes comparable automatic time trackers (Qbserve, Rize, Timing, ActivityWatch). BillHawk sits in that group but adds invoicing from tracked time, and it is strictly local-first: all data lives in a single local file, with no account, no cloud sync and no telemetry. For its optional Apple Mail analysis it uses the macOS Automation permission rather than Full Disk Access.

Icon used: `![Native App][Native Icon]` — it is a paid native app distributed directly by the developer (not on the App Store, not open source, not freeware), which matches how comparable paid entries in this section are annotated.

**Disclosure:** I am the developer of BillHawk. Happy to adjust the wording, category or icons if you would prefer something different.

### PR Checklist

- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important
- [x] I have added necessary documentation (if appropriate)