### PR TITLE
Add WorkBuddy Dream Theme and Fengge Pet

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -1376,6 +1376,8 @@ Awesome Mac
 * [SwiftMTP](https://github.com/Neighbor-Z/SwiftMTP) - 用于在 Mac 与 Android 设备之间浏览和传输文件的开源 MTP 管理工具。 [![Open-Source Software][OSS Icon]](https://github.com/Neighbor-Z/SwiftMTP) ![Freeware][Freeware Icon]
 * [TG Pro](https://www.tunabellysoftware.com/tgpro/) - 温度监控，风扇控制和硬件诊断，帮助您保持 Mac的 凉爽和健康。
 * [Tuxera NTFS](http://www.tuxera.com/products/tuxera-ntfs-for-mac/) - Mac 上的 NTFS 文件系统驱动。
+* [WorkBuddy Dream Theme](https://github.com/shaozhengmao/workbuddy-dream-theme) - macOS 版 WorkBuddy 换肤工具，支持自定义壁纸与页面内主题菜单，零侵入、不修改官方安装包。 [![Open-Source Software][OSS Icon]](https://github.com/shaozhengmao/workbuddy-dream-theme) ![Freeware][Freeware Icon]
+* [Fengge Pet（峰哥桌面宠物）](https://github.com/shaozhengmao/fengge-pet) - 像素风 macOS 桌面宠物「二次元峰哥」，9 种动画、点击冒经典语录、开机自启、台词可自定义。 [![Open-Source Software][OSS Icon]](https://github.com/shaozhengmao/fengge-pet) ![Freeware][Freeware Icon]
 
 ### 窗口管理
 

--- a/README.md
+++ b/README.md
@@ -1531,6 +1531,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Snap](https://indragie.com/snap) - Launch an app in a snap. Ridiculously easy shortcut management. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id418073146?platform=mac)
 * [Shareful](https://sindresorhus.com/shareful) - Supercharge the system share menu with copy, save, and open actions. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id1522267256?platform=mac)
 * [Mouse Jiggler for Mac](https://mousejigglermac.com) - Prevent Mac from sleep with Mac Mouse Mover. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id6740313656?platform=mac)
+* [Fengge Pet](https://github.com/shaozhengmao/fengge-pet) - A pixel-art macOS desktop pet "Fengge" with 9 animations, click-to-quote, auto-start on boot, and customizable lines. [![Open-Source Software][OSS Icon]](https://github.com/shaozhengmao/fengge-pet) ![Freeware][Freeware Icon]
 
 ### System Related Tools
 
@@ -1576,6 +1577,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Time Machine Inspector](https://github.com/probablykasper/time-machine-inspector) - Find out what's hogging up your Time Machine backups. [![Open-Source Software][OSS Icon]](https://github.com/probablykasper/time-machine-inspector) ![Freeware][Freeware Icon]
 * [Tuxera NTFS](https://www.tuxera.com/products/tuxera-ntfs-for-mac/) - Full read-write compatibility with NTFS-formatted drives on a Mac.
 * [Overkill](https://github.com/KrauseFx/overkill-for-mac) - Stop iTunes from opening when you connect your iPhone.
+* [WorkBuddy Dream Theme](https://github.com/shaozhengmao/workbuddy-dream-theme) - A macOS skin/theme tool for WorkBuddy with custom wallpaper and an in-app theme menu; zero-intrusion, no changes to the official app. [![Open-Source Software][OSS Icon]](https://github.com/shaozhengmao/workbuddy-dream-theme) ![Freeware][Freeware Icon]
 
 ## Gaming Software
 


### PR DESCRIPTION
Add macOS WorkBuddy skin tool and Fengge desktop pet to README and README-zh

NOTE: A similar PR may already be submitted! Please search among the Pull request before creating one.

### Types of Changes

**What types of changes does your PR introduce?** Put an x in all boxes that apply

- [x] New addition to list
- [ ] Fixing bug in existing item in list
- [ ] Removing item from list
- [ ] Changing structure (organization) of list

### Proposed Changes

1. **WorkBuddy Dream Theme** — a zero-intrusion skin/theme tool for WorkBuddy on macOS with custom wallpaper and an in-app theme menu.
2. **Fengge Pet** — a pixel-art desktop pet for macOS with animations, clickable quotes, and auto-start on boot.

Both are open-source (MIT), free, and fit the existing category structure (`System Related Tools` / `Quality of Life Improvements`).


### PR Checklist

Put an x in the boxes once you've completed each step. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important
- [x] I have added necessary documentation (if appropriate)

### Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
