### PR TITLE
Add Yap to Voice-to-Text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1049,6 +1049,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Voxt](https://github.com/hehehai/voxt) - Hold-to-talk voice input tool with AI transcription rules per app and URL, and built-in translation. [![Open-Source Software][OSS Icon]](https://github.com/hehehai/voxt) ![Freeware][Freeware Icon]
 * [Whispering](https://epicenter.md/whispering/) - Multi-provider speech-to-text with AI transformations and keyboard shortcuts. [![Open-Source Software][OSS Icon]](https://github.com/EpicenterHQ/epicenter/tree/main/apps/whispering) ![Freeware][Freeware Icon]
 * [Willow Voice](https://willowvoice.com/) - AI dictation with automatic editing, style-matching, and noise optimization.
+* [Yap](https://github.com/FrigadeHQ/yap) - On-device voice dictation from the menu bar, with a hotkey to talk and no model to download. [![Open-Source Software][OSS Icon]](https://github.com/FrigadeHQ/yap) ![Freeware][Freeware Icon]
 
 ## Browsers
 


### PR DESCRIPTION
Adds Yap to the Voice-to-Text section.

Yap is an open source menu bar app for on-device voice dictation on macOS. You set a hotkey, talk, and the text is pasted into whatever field you were typing in. It uses the built-in speech APIs on macOS 26, so unlike the Whisper and Parakeet tools in this section there is no model to download, and it has no network code at all.

https://github.com/FrigadeHQ/yap

Placed alphabetically at the end of the section, with the open-source and freeware badges.