### PR TITLE
Add WebVideoHarbor to Download Management Tools

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1001,6 +1001,7 @@ Awesome Mac
 * [Shuttle](https://fiplab.com/apps/download-shuttle-for-mac) - あらゆるリンクに対応する簡単なダウンロードマネージャー。
 * [Swads](https://swads.app/) - Synology Download Stationクライアント。モダンでネイティブ、直感的に再設計。
 * [Transmission](https://www.transmissionbt.com/) - 高速で簡単、無料のBitTorrentクライアント。 [![Open-Source Software][OSS Icon]](https://github.com/transmission/transmission) ![Freeware][Freeware Icon]
+* [WebVideoHarbor](https://phpfrank.github.io/web-video-harbor/) - macOSでWebページが直接提供するMP4/WebMメディアと暗号化されていないHLSストリームを保存するための、オープンソースのChrome拡張機能とローカルヘルパー。 [![Open-Source Software][OSS Icon]](https://github.com/PHPfrank/web-video-harbor) ![Freeware][Freeware Icon]
 * [XGetter](https://xgetter.com/) - 主要サイトから動画や音声を保存できるメディアダウンローダー。 ![Freeware][Freeware Icon]
 * [You-Get](https://you-get.org/) - Webからメディアコンテンツ（ビデオ、オーディオ、画像）をダウンロードするための小さなコマンドラインユーティリティ。 [![Open-Source Software][OSS Icon]](https://github.com/soimort/you-get) ![Freeware][Freeware Icon]
 * [youtube-dl](https://github.com/rg3/youtube-dl/) - YouTube.comおよびその他のビデオサイトからビデオをダウンロードするコマンドラインプログラム [![Open-Source Software][OSS Icon]](https://github.com/rg3/youtube-dl/) ![Freeware][Freeware Icon]

--- a/README-ko.md
+++ b/README-ko.md
@@ -769,6 +769,7 @@ Awesome Mac
 * [Neat Download Manager](https://www.neatdownloadmanager.com/) - 최적화된 전송 엔진을 갖춘 경량 다운로드 관리자. ![Freeware][Freeware Icon]
 * [qBittorrent](https://www.qbittorrent.org/) - 인기 있는 비트토렌트 클라이언트. [![Open-Source Software][OSS Icon]](https://github.com/qbittorrent/qBittorrent) ![Freeware][Freeware Icon]
 * [Transmission](https://www.transmissionbt.com/) - 빠르고 쉽고 무료인 비트토렌트 클라이언트. [![Open-Source Software][OSS Icon]](https://github.com/transmission/transmission) ![Freeware][Freeware Icon]
+* [WebVideoHarbor](https://phpfrank.github.io/web-video-harbor/) - macOS에서 웹페이지가 직접 제공하는 MP4/WebM 미디어와 암호화되지 않은 HLS 스트림을 저장하는 오픈 소스 Chrome 확장 프로그램 및 로컬 도우미. [![Open-Source Software][OSS Icon]](https://github.com/PHPfrank/web-video-harbor) ![Freeware][Freeware Icon]
 * [XGetter](https://xgetter.com/) - 주요 웹사이트에서 동영상과 오디오를 내려받는 미디어 다운로드 도구. ![Freeware][Freeware Icon]
 
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -951,6 +951,7 @@ Awesome Mac
 * [qBittorrent](https://www.qbittorrent.org/) - 一个替代 μTorrent 的开源软件。 [![Open-Source Software][OSS Icon]](https://github.com/qbittorrent/qBittorrent) ![Freeware][Freeware Icon]
 * [Swads](https://swads.app/) - 群晖 Download Station 客户端，现代、原生、凭直觉再设计。
 * [Transmission](https://www.transmissionbt.com/) - 免费的 BitTorrent 客户端 [![Open-Source Software][OSS Icon]](https://github.com/transmission/transmission) ![Freeware][Freeware Icon]
+* [WebVideoHarbor](https://phpfrank.github.io/web-video-harbor/) - 用于在 macOS 上保存网页直接提供的 MP4/WebM 与非加密 HLS 流的开源 Chrome 扩展和本地助手。 [![Open-Source Software][OSS Icon]](https://github.com/PHPfrank/web-video-harbor) ![Freeware][Freeware Icon]
 * [XGetter](https://xgetter.com/) - 用于从主流网站下载音视频的媒体下载器。 ![Freeware][Freeware Icon]
 * [You-Get](https://you-get.org/) - 网络富媒体命令行下载工具。[![Open-Source Software][OSS Icon]](https://github.com/soimort/you-get) ![Freeware][Freeware Icon]
 * [yt-dlp](https://github.com/yt-dlp/yt-dlp) - 一款功能丰富的命令行音视频下载器。 [![Open-Source Software][OSS Icon]](https://github.com/yt-dlp/yt-dlp) ![Freeware][Freeware Icon]

--- a/README.md
+++ b/README.md
@@ -1004,6 +1004,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Shuttle](https://fiplab.com/apps/download-shuttle-for-mac) - Easy Download Manager for any links.
 * [Swads](https://swads.app/) - Synology Download Station Client, modern, native, and intuitively redesign.
 * [Transmission](https://www.transmissionbt.com/) - Fast, easy, free BitTorrent Client. [![Open-Source Software][OSS Icon]](https://github.com/transmission/transmission) ![Freeware][Freeware Icon]
+* [WebVideoHarbor](https://phpfrank.github.io/web-video-harbor/) - Open-source Chrome extension and local helper for saving direct MP4/WebM media and non-encrypted HLS streams on macOS. [![Open-Source Software][OSS Icon]](https://github.com/PHPfrank/web-video-harbor) ![Freeware][Freeware Icon]
 * [XGetter](https://xgetter.com/) - Media downloader for video and audio from major websites. ![Freeware][Freeware Icon]
 * [You-Get](https://you-get.org/) - Tiny command-line utility to download media contents (videos, audios, images) from the web. [![Open-Source Software][OSS Icon]](https://github.com/soimort/you-get) ![Freeware][Freeware Icon]
 * [youtube-dl](https://github.com/rg3/youtube-dl/) - Command-line program to download videos from YouTube.com and other video sites [![Open-Source Software][OSS Icon]](https://github.com/rg3/youtube-dl/) ![Freeware][Freeware Icon]


### PR DESCRIPTION
## Summary

- Add WebVideoHarbor to Download Management Tools.
- Keep the entry synchronized across the English, Chinese, Japanese, and Korean READMEs.

WebVideoHarbor is a free, MIT-licensed project composed of a Chrome extension and a local macOS helper. It saves direct MP4/WebM media and non-encrypted HLS streams without claiming DRM or access-control bypass support.

Project: https://github.com/PHPfrank/web-video-harbor

## Validation

- `git diff --check`
- `npm run build`
- `npm run create:ast`
- `npm run feed`
