### PR TITLE
Add Phantom Voice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1041,6 +1041,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [OpenQuack](https://github.com/larryxiao/openquack) - Privacy-first voice dictation tool that transcribes locally with WhisperKit and inserts text at the cursor with a hotkey. [![Open-Source Software][OSS Icon]](https://github.com/larryxiao/openquack) ![Freeware][Freeware Icon]
 * [OpenTypeless](https://github.com/tover0314-w/opentypeless) - Open-source AI voice input that types polished text into any app. [![Open-Source Software][OSS Icon]](https://github.com/tover0314-w/opentypeless) ![Freeware][Freeware Icon]
 * [Ottex](https://ottex.ai) - AI dictation tool that formats text for the app or site you are using.
+* [Phantom Voice](https://leftinverse.com/phantom) - Menu bar push-to-talk dictation with on-device whisper.cpp transcription and animated HUD indicators. [![Open-Source Software][OSS Icon]](https://github.com/WillisLiao/Phantom-Voice)
 * [Presspeech](https://github.com/rcourtman/presspeech) - Native push-to-talk local dictation app for Apple Silicon Macs using Parakeet TDT v3 (CoreML/ANE). [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/rcourtman/presspeech)
 * [Spokenly](https://spokenly.app/) - Voice-to-text with 100+ languages, offline mode, and AI-powered formatting.
 * [Tambourine](https://tambourinevoice.com/) - Open-source, customizable AI voice dictation that works in any app. [![Open-Source Software][OSS Icon]](https://github.com/kstonekuan/tambourine-voice/) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds Phantom Voice to the Voice-to-Text section, in alphabetical order between Ottex and Presspeech.

Local push-to-talk dictation for macOS built on whisper.cpp with Metal. Hold fn, speak, release, and the transcript is inserted into the focused app. Audio and transcription stay on device.

It is a menu bar app (LSUIElement, no Dock icon) and the source is MIT at https://github.com/WillisLiao/Phantom-Voice, so I have included the open-source badge. It is a paid app, so no freeware badge.