### PR TITLE
Add Stir to General Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1338,6 +1338,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Rewind](https://www.rewind.ai/) - Searchable history of your screen and audio activity.
 * [SlowQuitApps](https://github.com/dteoh/SlowQuitApps) - An OS X app that adds a global delay of 1 second to the Cmd-Q shortcut. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/dteoh/SlowQuitApps)
 * [Speediness](https://sindresorhus.com/speediness) - Check your internet speed. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id1596706466?platform=mac)
+* [Stir](https://apps.apple.com/us/app/stir-wake-up-experience/id6761769404) - Plays a short cinematic greeting overlay when your Mac wakes up, with a different message each time. [![App Store][app-store Icon]](https://apps.apple.com/us/app/stir-wake-up-experience/id6761769404)
 * [Ultra TabSaver](https://github.com/Swift-open-source/UltraTabSaver) - The Open Source Tab Manager for Safari [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/Swift-open-source/UltraTabSaver)
 * [Upscayl](https://github.com/upscayl/upscayl) - Free and open-source AI image upscaling tool. [![Open-Source Software][OSS Icon]](https://github.com/upscayl/upscayl) ![Freeware][Freeware Icon]
 * [Vidwall](https://apps.apple.com/app/Vidwall/6747587746?platform=mac) - Easily import MP4/MOV videos as system wallpapers and lock screen animations. [![Open-Source Software][OSS Icon]](https://github.com/jaywcjlove/vidwall) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adding Stir - a small app I built that plays a cinematic greeting overlay when your Mac wakes up, similar spirit to lo-rain or Vidwall in this section, just a screen effect rather than a functional tool. The message is different each time rather than a fixed script.

Placed it alphabetically between Speediness and Ultra TabSaver.