### PR TITLE
Add Caxton (large-file text editor)

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -178,6 +178,7 @@ Awesome Mac
 * [Aurora Editor](https://auroraeditor.com/) - macOS用の軽量コードエディタ（IDE）。 [![Open-Source Software][OSS Icon]](https://github.com/AuroraEditor/AuroraEditor)
 * [Bootstrap Studio](https://bootstrapstudio.io/) - Bootstrapフレームワークを使用してレスポンシブWebサイトを作成するための強力なデスクトップアプリ。
 * [Brackets](http://brackets.io) - Webデザインを理解する、モダンなオープンソーステキストエディタ。 [![Open-Source Software][OSS Icon]](https://github.com/brackets-cont/brackets/) ![Freeware][Freeware Icon]
+* [Caxton](https://caxton.app) - 巨大ファイル向けのネイティブテキストエディタ — メモリマップ方式で、数GBのログやCSVを瞬時に開けます。
 * [CodeEdit](https://www.codeedit.app/) - 軽量でネイティブ構築のエディタ。オープンソース。永久無料。 [![Open-Source Software][OSS Icon]](https://github.com/CodeEditApp/CodeEdit) ![Freeware][Freeware Icon]
 * [CotEditor](https://coteditor.com) - macOS用の軽量プレーンテキストエディタ。 [![Open-Source Software][OSS Icon]](https://github.com/coteditor/CotEditor/) ![Freeware][Freeware Icon]
 * [Cursor](https://cursor.com/) - オートコンプリート、チャット、エージェント機能を備えたAIコードエディタ。 ![Freeware][Freeware Icon]

--- a/README-ko.md
+++ b/README-ko.md
@@ -331,6 +331,7 @@ Awesome Mac
 * [BBEdit](http://www.barebones.com/products/bbedit/) - 인기 있고 강력한 HTML 및 텍스트 편집기.
 * [Brackets](http://brackets.io/) - 웹 디자인을 고집하는 오픈 소스 텍스트 편집기. [![Open-Source Software][OSS Icon]](https://github.com/adobe/brackets) ![Freeware][Freeware Icon]
 * [Cate](https://cate.cero-ai.com) - 무한 줌 캔버스 기반의 오픈소스 IDE로, 에디터, 터미널, 브라우저, AI 에이전트 패널을 공간형 워크스페이스에 배치할 수 있습니다. [![Open-Source Software][OSS Icon]](https://github.com/0-AI-UG/cate) ![Freeware][Freeware Icon]
+* [Caxton](https://caxton.app) - 초대형 파일을 위한 네이티브 텍스트 편집기 — 메모리 매핑 방식으로 수 GB 로그와 CSV를 즉시 엽니다.
 * [Coda 2](https://panic.com/coda/) - 빠르고 투명하며 강력한 텍스트 편집기.
 * [Cursor](https://www.cursor.com/) - 자동 완성, 채팅, 에이전트 기능을 갖춘 AI 코드 편집기. ![Freeware][Freeware Icon]
 * [Eclipse](http://www.eclipse.org/) - 인기 있는 오픈 소스 IDE, 주로 Java로 작성됨. [![Open-Source Software][OSS Icon]](http://git.eclipse.org/c/) ![Freeware][Freeware Icon]

--- a/README-zh.md
+++ b/README-zh.md
@@ -179,6 +179,7 @@ Awesome Mac
 * [Neovim](https://github.com/neovim/neovim) - 专注于可扩展性和可用性的 Vim 分支。 [![Open-Source Software][OSS Icon]](https://github.com/neovim/neovim) ![Freeware][Freeware Icon]
 * [Nova](https://nova.app/) - 用于编写 Web 应用，长得漂亮的编辑器，Coda2 下一代编辑器。
 * [Cate](https://cate.cero-ai.com) - 基于无限缩放画布的开源 IDE，可将编辑器、终端、浏览器和 AI 代理面板自由分布在空间化工作区中。 [![Open-Source Software][OSS Icon]](https://github.com/0-AI-UG/cate) ![Freeware][Freeware Icon]
+* [Caxton](https://caxton.app) - 面向超大文件的原生文本编辑器 — 内存映射架构，瞬间打开数 GB 的日志和 CSV 文件。
 * [CodeEdit](https://www.codeedit.app/) - 专为Mac编写的原生编辑器，轻量化且利用Mac平台的特性。 [![Open-Source Software][OSS Icon]](https://github.com/CodeEditApp/CodeEdit) ![Freeware][Freeware Icon]
 * [CotEditor](https://coteditor.com) - 轻量级的纯文本编辑器。 [![Open-Source Software][OSS Icon]](https://github.com/coteditor/CotEditor/) ![Freeware][Freeware Icon]
 * [Cursor](https://www.cursor.com/) - 支持自动补全、聊天和智能体能力的 AI 代码编辑器。 ![Freeware][Freeware Icon]

--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Aurora Editor](https://auroraeditor.com/) - Lightweight Code Editor (IDE) for macOS. [![Open-Source Software][OSS Icon]](https://github.com/AuroraEditor/AuroraEditor)
 * [Bootstrap Studio](https://bootstrapstudio.io/) - A powerful desktop app for creating responsive websites using the Bootstrap framework.
 * [Brackets](https://brackets.io) - A modern, open source text editor that understands web design. [![Open-Source Software][OSS Icon]](https://github.com/brackets-cont/brackets/) ![Freeware][Freeware Icon]
+* [Caxton](https://caxton.app) - Native text editor for very large files — memory-mapped, opens multi-GB logs and CSVs instantly.
 * [CodeEdit](https://www.codeedit.app/) - A lightweight, natively-built editor. Open source. Free forever. [![Open-Source Software][OSS Icon]](https://github.com/CodeEditApp/CodeEdit) ![Freeware][Freeware Icon]
 * [CotEditor](https://coteditor.com) - Lightweight plain-text editor for macOS. [![Open-Source Software][OSS Icon]](https://github.com/coteditor/CotEditor/) ![Freeware][Freeware Icon]
 * [Cursor](https://cursor.com/) - AI code editor with autocomplete, chat, and coding agent features. ![Freeware][Freeware Icon]


### PR DESCRIPTION
### Types of Changes

**What types of changes does your PR introduce?** Put an x in all boxes that apply

- [x] New addition to list

### Proposed Changes

Adds Caxton (https://caxton.app) to Developer Tools → Text Editors.

Caxton is a native AppKit text editor built specifically for very large files — multi-GB logs and CSVs past spreadsheet row limits — using memory-mapped I/O rather than loading files into RAM. Notarized, macOS 13+. It fills a gap in the current Text Editors section: none of the listed editors are designed for this workload, and the Windows tool that owns the category (EmEditor) has no Mac version. Benchmarks and methodology are published: https://caxton.app/docs/benchmarks

The entry is added to all four README files (en/zh/ja/ko) in alphabetical position, matching the existing entry format, one sentence, no badges (paid, closed-source).

### PR Checklist

- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important
- [x] I have added necessary documentation (if appropriate)

### Further Comments

None, single-entry addition.