### PR TITLE
Add SADFinder to Finder tools

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1507,6 +1507,7 @@ Awesome Mac
 * [Path Finder](http://www.cocoatech.com/pathfinder/) - ファイル管理アプリ。
 * [QSpace](https://qspace.awehunt.com) - クリーンで効率的なマルチビューファイルマネージャー。 [![App Store][app-store Icon]](https://apps.apple.com/us/app/id1469774098?platform=mac)
 * [RClick](https://github.com/wflixu/RClick) - macOS Finderのコンテキストメニューに新しい機能を追加。 [![Open-Source Software][OSS Icon]](https://github.com/wflixu/RClick) ![Freeware][Freeware Icon]
+* [SADFinder](https://sadfinder.com/?utm_source=awesome_mac&utm_medium=product_directory&utm_campaign=product_launch_2026&utm_content=listing) - Windows風ショートカット、タブ、編集可能なパスバー、デスクトップ管理を備えたネイティブmacOS Finder代替。 ![Native App][Native Icon]
 * [SwiftyMenu](https://apps.apple.com/us/app/swiftymenu/id1567748223?platform=mac) - 選択したファイルやフォルダを指定アプリですばやく開く Finder 拡張。
 * [TotalFinder](http://totalfinder.binaryage.com/) - Chrome風のFinder代替。
 * [XtraFinder](https://www.trankynam.com/xtrafinder/) - Mac Finderにタブ機能と切り取り機能を追加。 ![Freeware][Freeware Icon]

--- a/README-ko.md
+++ b/README-ko.md
@@ -949,6 +949,7 @@ Awesome Mac
 * [cmd+x](https://apps.apple.com/app/cmd-x/id6754665762?platform=mac) - Ctrl+Opt+Delete로 활동 모니터를 실행하고 Finder에서 Cmd+X로 파일을 잘라 이동.
 * [Oka Unarchiver](https://okaapps.com/product/1441507725) - RAR와 암호 보호 압축 파일까지 다루는 압축 해제 도구. [![App Store][app-store Icon]](https://apps.apple.com/app/id1441507725?pt=119209922&ct=github)
 * [SaneClick](https://saneclick.com) - Finder 우클릭 메뉴에 파일 작업, 변환, 개발자 액션을 추가하는 확장. [![Open-Source Software][OSS Icon]](https://github.com/sane-apps/SaneClick) ![Freeware][Freeware Icon]
+* [SADFinder](https://sadfinder.com/?utm_source=awesome_mac&utm_medium=product_directory&utm_campaign=product_launch_2026&utm_content=listing) - Windows 스타일 단축키, 탭, 편집 가능한 경로 표시줄, 데스크톱 제어를 제공하는 네이티브 macOS Finder 대안. ![Native App][Native Icon]
 * [Shuffle](https://shuffleapp.co) - Rust로 개발된 GPU 렌더링 고속 파일 관리자이자 Finder 대안. [![Open-Source Software][OSS Icon]](https://github.com/WizenPainter/shuffle) ![Freeware][Freeware Icon]
 * [SwiftyMenu](https://apps.apple.com/us/app/swiftymenu/id1567748223?platform=mac) - 선택한 파일이나 폴더를 지정 앱으로 빠르게 여는 Finder 확장.
 * [Keka](https://www.keka.io/) - 다양한 포맷을 지원하는 오픈 소스 압축/해제 도구. [![Open-Source Software][OSS Icon]](https://github.com/aonez/Keka) ![Freeware][Freeware Icon]

--- a/README-zh.md
+++ b/README-zh.md
@@ -1437,6 +1437,7 @@ Awesome Mac
 * [Quicklook-Plugins](https://github.com/sindresorhus/quick-look-plugins) - Finder 快速预览文件插件。
 * [QSpace](https://qspace.awehunt.com) - 一款简洁高效的多视图文件管理器。 [![App Store][app-store Icon]](https://apps.apple.com/cn/app/id1469774098?platform=mac)
 * [RClick](https://github.com/wflixu/RClick) - 一款简洁实用的 Finder 右键菜单增强工具 [![Open-Source Software][OSS Icon]](https://github.com/wflixu/RClick) ![Freeware][Freeware Icon]
+* [SADFinder](https://sadfinder.com/?utm_source=awesome_mac&utm_medium=product_directory&utm_campaign=product_launch_2026&utm_content=listing) - 原生 macOS Finder 替代工具，提供 Windows 风格快捷键、标签页、可编辑路径栏和桌面管理。 ![Native App][Native Icon]
 * [SaneClick](https://saneclick.com) - 为 Finder 右键菜单增加文件处理、转换和开发者操作。 [![Open-Source Software][OSS Icon]](https://github.com/sane-apps/SaneClick) ![Freeware][Freeware Icon]
 * [Shuffle](https://shuffleapp.co) - 使用 Rust 构建的 GPU 渲染高速文件管理器，Finder 的替代品。 [![Open-Source Software][OSS Icon]](https://github.com/WizenPainter/shuffle) ![Freeware][Freeware Icon]
 * [SwiftyMenu](https://apps.apple.com/us/app/swiftymenu/id1567748223?platform=mac) - 用常用应用快速打开所选文件或文件夹的 Finder 扩展。

--- a/README.md
+++ b/README.md
@@ -1510,6 +1510,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Path Finder](https://www.cocoatech.com/pathfinder/) - File management app.
 * [QSpace](https://qspace.awehunt.com) - A clean and efficient Multi-view File Manager. [![App Store][app-store Icon]](https://apps.apple.com/us/app/id1469774098?platform=mac)
 * [RClick](https://github.com/wflixu/RClick) - Add new functionality to the macOS Finder context menu.  [![Open-Source Software][OSS Icon]](https://github.com/wflixu/RClick) ![Freeware][Freeware Icon]
+* [SADFinder](https://sadfinder.com/?utm_source=awesome_mac&utm_medium=product_directory&utm_campaign=product_launch_2026&utm_content=listing) - Native macOS Finder alternative with Windows-style shortcuts, tabs, an editable path bar, and Desktop control. ![Native App][Native Icon]
 * [SwiftyMenu](https://apps.apple.com/us/app/swiftymenu/id1567748223?platform=mac) - Finder extension for opening selected files or folders with custom app shortcuts.
 * [TotalFinder](https://totalfinder.binaryage.com/) - Chrome-styled Finder substitute.
 * [XtraFinder](https://www.trankynam.com/xtrafinder/) - Adds tabs and cut to Mac Finder. ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds SADFinder, a native macOS Finder alternative, to the relevant Finder/file-organization section in the English, Chinese, Japanese, and Korean READMEs.

The entry identifies its Windows-style shortcuts, tabs, editable path bar, Desktop control, and native macOS implementation without marking the paid app as freeware.

Checks:
- git diff --check
- tracked product URL returns HTTP 200
- all four localized lists contain the same product URL and Native App marker