### PR TITLE
Add Waindow to Window Management

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1476,6 +1476,7 @@ Awesome Mac
 * [Tiles](https://freemacsoft.net/tiles/) - 画面端、ショートカット、メニューバーでウィンドウを整列できるツール。 ![Freeware][Freeware Icon]
 * [Topit](https://github.com/lihaoyun6/Topit) - 任意のウィンドウを画面の最前面に固定。 [![Open-Source Software][OSS Icon]](https://github.com/lihaoyun6/Topit) ![Freeware][Freeware Icon]
 * [Total Spaces](http://totalspaces.binaryage.com/) - ワークスペースの切り替えや把握をしやすくする管理ツール。
+* [Waindow](https://www.waindow.app/) - ウィンドウ管理、ウィンドウ連携のローカルメモ、長いページのキャプチャ、Keep Awakeセッションを統合した無料のネイティブワークスペースユーティリティ。 ![Freeware][Freeware Icon]
 * [yabai](https://github.com/koekeishiya/yabai) - キーボード操作中心のタイル型ウィンドウマネージャー。 [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/koekeishiya/yabai/wiki)
 
 ### パスワード管理

--- a/README-ko.md
+++ b/README-ko.md
@@ -1039,6 +1039,7 @@ Awesome Mac
 * [Swift Shift](https://swiftshift.app) - 단축키와 마우스로 창을 빠르게 이동하고 크기를 조절하는 도구. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/pablopunk/swiftshift)
 * [Tiles](https://freemacsoft.net/tiles/) - 화면 가장자리, 단축키, 메뉴 막대로 창을 정렬하는 도구. ![Freeware][Freeware Icon]
 * [Total Spaces](http://totalspaces.binaryage.com/) - 작업 공간 전환과 배치를 위한 단축키를 제공하는 도구.
+* [Waindow](https://www.waindow.app/) - 창 관리, 창별 로컬 메모, 긴 페이지 캡처, Keep Awake 세션을 하나로 묶은 무료 네이티브 작업 공간 유틸리티. ![Freeware][Freeware Icon]
 * [yabai](https://github.com/koekeishiya/yabai) - 키보드 중심의 타일링 창 관리자. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/koekeishiya/yabai/wiki)
 
 ### 비밀번호 관리

--- a/README-zh.md
+++ b/README-zh.md
@@ -1407,6 +1407,7 @@ Awesome Mac
 * [SizeUp](http://www.irradiatedsoftware.com/sizeup/) - 强大的，以键盘为中心的窗口管理。
 * [Topit](https://github.com/lihaoyun6/Topit) - 在Mac上将你的任何窗口强制置顶 [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/lihaoyun6/Topit)
 * [Total Spaces](http://totalspaces.binaryage.com/) - 为工作区提供快捷键和空间总览的管理工具。
+* [Waindow](https://www.waindow.app/) - 免费的原生工作区工具，将窗口管理、窗口关联本地备忘录、长页面截图和防休眠会话整合于一体。 ![Freeware][Freeware Icon]
 * [yabai](https://github.com/koekeishiya/yabai) - 键盘驱动的平铺式窗口管理器。 [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/koekeishiya/yabai/wiki)
 
 ### 密码管理

--- a/README.md
+++ b/README.md
@@ -1480,6 +1480,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Tiles](https://freemacsoft.net/tiles/) - Snap and rearrange windows with screen edges, shortcuts, or the menu bar. ![Freeware][Freeware Icon]
 * [Topit](https://github.com/lihaoyun6/Topit) - Pin any window to the top of your screen [![Open-Source Software][OSS Icon]](https://github.com/lihaoyun6/Topit) ![Freeware][Freeware Icon]
 * [Total Spaces](https://totalspaces.binaryage.com/) - Workspace manager with hotkeys and spatial overview.
+* [Waindow](https://www.waindow.app/) - Free native workspace utility combining window management with local window-linked notes, long-page capture, and Keep Awake sessions. ![Freeware][Freeware Icon]
 * [yabai](https://github.com/koekeishiya/yabai) - Keyboard-driven tiling window manager. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/koekeishiya/yabai/wiki)
 
 ### Password Management


### PR DESCRIPTION
## Summary

- add Waindow to the Window Management section
- keep the entry synchronized across English, Chinese, Japanese, and Korean lists
- mark the app as freeware without linking the private source repository

## Validation

- confirmed the product page is public at https://www.waindow.app/
- confirmed exactly one Waindow entry in each of the four README files
- ran `git diff --check`

Waindow is a free native workspace utility that combines window management with local window-linked notes, long-page capture, and Keep Awake sessions.