### PR TITLE
Add DockGroups to Productivity tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1441,7 +1441,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Wox](https://wox-launcher.github.io/Wox/) - Open-source cross-platform launcher with fast local search and plugin extensibility. [![Open-Source Software][OSS Icon]](https://github.com/Wox-launcher/Wox) ![Freeware][Freeware Icon]
 * [xScope](https://xscopeapp.com/) - Toolset for measuring, inspecting, and testing on-screen layouts and graphics.
 * [Z](https://github.com/rupa/z) - Jump to frequently used directories by typing part of the path.
-
+* [DockGroups](https://dockgroups.com) - Group Dock apps into named workflows and launch or quit them all with one click, without replacing the Dock.
 
 ### Window Management
 


### PR DESCRIPTION
Adds DockGroups, a native macOS utility (SwiftUI + AppKit) that organizes Dock apps into named groups and launches/quits each group as a unit. Free tier (2 groups), one-time Pro. Supports macOS 14–26, Apple Silicon + Intel, signed updates, no tracking. Follows the list's entry format and alphabetical order.