### PR TITLE
Add SFTPro

### DIFF
--- a/README.md
+++ b/README.md
@@ -893,6 +893,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [LocalSend](https://localsend.org/) - An open-source cross-platform alternative to AirDrop. [![Open-Source Software][OSS Icon]](https://github.com/localsend/localsend) ![Freeware][Freeware Icon]
 * [NearDrop](https://github.com/grishka/NearDrop) - An unofficial Google Nearby Share/Quick Share app for macOS. [![Open-Source Software][OSS Icon]](https://github.com/localsend/localsend) ![Freeware][Freeware Icon]
 * [Rclone UI](https://rcloneui.com/) - The GUI for Rclone & S3. [![App Store][app-store Icon]](https://apps.apple.com/app/rclone-ui/id6756127598?platform=mac) [![Open-Source Software][OSS Icon]](https://github.com/rclone-ui/rclone-ui) ![Freeware][Freeware Icon]
+* [SFTPro](https://sftpro.dev) - Native, keyboard-first SFTP client with an in-place editor, transfer queue, and SSH-key auth. ![Native App][Native Icon]
 * [Transmit](https://panic.com/transmit/) - Highly flexible and intuitive FTP client, supports SFTP, S3 and iDisk/WebDAV.
 
 ## Data Recovery Tools


### PR DESCRIPTION
Adds [SFTPro](https://sftpro.dev), a native macOS SFTP client built in SwiftUI — keyboard-first, color-coded file browser with an in-place editor, transfer queue, and SSH-key/password auth.

Placed alphabetically in **File Sharing** alongside Cyberduck, Flow, and Transmit. It's a native, closed-source, non-App-Store app, so I annotated it with the Native App icon only (no Open-Source, App Store, or Freeware badge), matching the legend. One neutral description sentence, single-line diff.