### PR TITLE
Add Quant Keyboard to Input Methods

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1021,6 +1021,7 @@ Awesome Mac
 
 * [Kawa](https://github.com/utatti/kawa) - OS X用のより良い入力ソース切り替え。 [![Open-Source Software][OSS Icon]](https://github.com/utatti/kawa) ![Freeware][Freeware Icon]
 * [LangSwitcher](https://github.com/reg2005/langSwitcher) - 間違ったキーボード配列で入力した文字を変換するツール。 [![Open-Source Software][OSS Icon]](https://github.com/reg2005/langSwitcher) ![Freeware][Freeware Icon]
+* [Quant Keyboard](https://github.com/avklyuev79-hash/quant-keyboard) - 誤ったキーボードレイアウトで入力したテキストを統計的トライグラムエンジンで自動修正。[![Open-Source Software][OSS Icon]](https://github.com/avklyuev79-hash/quant-keyboard) ![Freeware][Freeware Icon]
 * [Rocket](http://matthewpalmer.net/rocket/) - Slackスタイルのショートカットを使用して絵文字入力をより速く簡単にする。 ![Freeware][Freeware Icon]
 * [Touch Emoji](https://github.com/lessmess-dev/touch-emoji) - MacBook Pro Touch Bar用の絵文字ピッカー。 [![Open-Source Software][OSS Icon]](https://github.com/lessmess-dev/touch-emoji)
 * [Type2Phone](https://www.houdah.com/type2Phone/) - MacをiPhone、iPad、Apple TVのキーボードとして使用。

--- a/README-ko.md
+++ b/README-ko.md
@@ -783,6 +783,7 @@ Awesome Mac
 
 * [Kawa](https://github.com/utatti/kawa) - OS X용 단축키 기반 입력 소스 전환기. [![Open-Source Software][OSS Icon]](https://github.com/utatti/kawa) ![Freeware][Freeware Icon]
 * [LangSwitcher](https://github.com/reg2005/langSwitcher) - 잘못된 키보드 레이아웃으로 입력한 텍스트를 고쳐주는 변환 도구. [![Open-Source Software][OSS Icon]](https://github.com/reg2005/langSwitcher) ![Freeware][Freeware Icon]
+* [Quant Keyboard](https://github.com/avklyuev79-hash/quant-keyboard) - 잘못된 키보드 레이아웃으로 입력한 텍스트를 통계 트라이그램 엔진으로 자동 수정합니다. [![Open-Source Software][OSS Icon]](https://github.com/avklyuev79-hash/quant-keyboard) ![Freeware][Freeware Icon]
 * [Rocket](https://matthewpalmer.net/rocket/) - Slack 스타일의 단축키를 사용하여 이모지를 더 빠르게 입력. ![Freeware][Freeware Icon]
 * [InputSourcePro](https://inputsource.pro/) - 앱이나 웹사이트별로 입력 소스를 자동 전환하는 도구. [![Open-Source Software][OSS Icon]](https://github.com/runjuu/InputSourcePro) ![Freeware][Freeware Icon]
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -983,6 +983,7 @@ Awesome Mac
 * [fcitx5-macos](https://github.com/fcitx-contrib/fcitx5-macos) - 小企鹅输入法 macOS版本 [![Open-Source Software][OSS Icon]](https://github.com/fcitx-contrib/fcitx5-macos) ![Freeware][Freeware Icon]
 * [LangSwitcher](https://github.com/reg2005/langSwitcher) - 用于纠正错误键盘布局输入文本的转换工具。 [![Open-Source Software][OSS Icon]](https://github.com/reg2005/langSwitcher) ![Freeware][Freeware Icon]
 * [RIME](http://rime.im/) - 中州韻輸入法引擎。[![Open-Source Software][OSS Icon]](https://github.com/rime) ![Freeware][Freeware Icon]
+* [Quant Keyboard](https://github.com/avklyuev79-hash/quant-keyboard) - 使用统计三元组引擎自动修正在错误键盘布局下输入的文本。[![Open-Source Software][OSS Icon]](https://github.com/avklyuev79-hash/quant-keyboard) ![Freeware][Freeware Icon]
 * [Rocket](http://matthewpalmer.net/rocket/) - 使用冒号快捷键可以更快捷地输入表情符号。![Freeware][Freeware Icon]
 * [Type2Phone](https://www.houdah.com/support/) - 把 Macbook 键盘变为 iPhone 的蓝牙键盘。 [![App Store][app-store Icon]](https://apps.apple.com/cn/app/type2phone-bluetooth-keyboard/id472717129?platform=mac)
 * [WBIM](http://www.glamtime.com.cn/wbim) - 五笔输入法。[![App Store][app-store Icon]](https://apps.apple.com/cn/app/wbim-%E5%86%99%E5%AD%97%E6%9D%BF/id929844708?platform=mac)

--- a/README.md
+++ b/README.md
@@ -1024,6 +1024,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 
 * [Kawa](https://github.com/utatti/kawa) - Better input source switcher for OS X. [![Open-Source Software][OSS Icon]](https://github.com/utatti/kawa) ![Freeware][Freeware Icon]
 * [LangSwitcher](https://github.com/reg2005/langSwitcher) - Keyboard layout converter for mistyped text. [![Open-Source Software][OSS Icon]](https://github.com/reg2005/langSwitcher) ![Freeware][Freeware Icon]
+* [Quant Keyboard](https://github.com/avklyuev79-hash/quant-keyboard) - Automatically fixes text typed in the wrong keyboard layout using a statistical trigram engine. [![Open-Source Software][OSS Icon]](https://github.com/avklyuev79-hash/quant-keyboard) ![Freeware][Freeware Icon]
 * [Rocket](https://matthewpalmer.net/rocket/) - Makes typing emoji faster and easier using Slack-style shortcuts. ![Freeware][Freeware Icon]
 * [Touch Emoji](https://github.com/lessmess-dev/touch-emoji) - Emoji picker for MacBook Pro Touch Bar. [![Open-Source Software][OSS Icon]](https://github.com/lessmess-dev/touch-emoji)
 * [Type2Phone](https://www.houdah.com/type2Phone/) - Use Your Mac as Keyboard for iPhone, iPad & Apple TV.


### PR DESCRIPTION
### Types of Changes

Add a new app.

### Description

Quant Keyboard is a free, MIT-licensed macOS menu-bar app that automatically fixes text typed in the wrong keyboard layout. Unlike dictionary-based switchers it uses a statistical character-trigram engine plus `UCKeyTranslate`, so it is layout-invariant. Russian and English, source on GitHub, no App Store, no subscription, no telemetry.

Added to **Input Methods** next to LangSwitcher, in alphabetical order, and synced across `README.md`, `README-zh.md`, `README-ja.md` and `README-ko.md` as the contributing guidelines require.

Disclosure: I am the author of the app.

### Checklist

- [x] Not a duplicate of an existing entry
- [x] Alphabetical order inside the category
- [x] One sentence description, existing icon style preserved
- [x] All four language files updated