### PR TITLE
Add Coluracetam to Markdown Tools

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -216,6 +216,7 @@ Awesome Mac
 ### Markdownツール [![Awesome List][awesome-list Icon]](https://github.com/BubuAnabelas/awesome-markdown#tools)
 
 * [Archimedes](https://furnacecreek.org/archimedes/) - インラインLaTeXをサポートした数学的記述向けのネイティブmacOS Markdownエディタ。
+* [Coluracetam](https://kagerou.glass/coluracetam/) - Quick Look とサムネイル拡張を備えた Markdown リーダー。スペースキーで .md ファイルをレンダリングし、Finder でもそのまま表示されます。 [![Open-Source Software][OSS Icon]](https://github.com/kageroumado/coluracetam) ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/us/app/id6788680916?platform=mac)
 * [Edmund](https://github.com/I7T5/Edmund) - ライブプレビュー付きのミニマルなMarkdownエディタ。既存ファイルをそのまま編集でき、保管庫不要。 [![Open-Source Software][OSS Icon]](https://github.com/I7T5/Edmund) ![Freeware][Freeware Icon]
 * [EME](https://github.com/egoist/eme) - Chromeのようなインターフェースを持つオープンソースMarkdownエディタ。 ![Open-Source Software][OSS Icon]
 * [iA Writer](https://ia.net/writer/) - シンプルさとデザインを重視したライティングアプリ。

--- a/README-ko.md
+++ b/README-ko.md
@@ -191,6 +191,7 @@ Awesome Mac
 ### 마크다운 도구 [![Awesome List][awesome-list Icon]](https://github.com/BubuAnabelas/awesome-markdown#tools)
 
 * [Archimedes](https://furnacecreek.org/archimedes/) - 인라인 LaTeX를 지원하는 수학 쓰기에 최적화된 마크다운 편집기.
+* [Coluracetam](https://kagerou.glass/coluracetam/) - Quick Look 및 썸네일 확장이 포함된 Markdown 리더로, 스페이스 바로 .md 파일을 렌더링하고 Finder에서도 바로 표시됩니다. [![Open-Source Software][OSS Icon]](https://github.com/kageroumado/coluracetam) ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/us/app/id6788680916?platform=mac)
 * [Edmund](https://github.com/I7T5/Edmund) - 실시간 미리보기를 지원하는 미니멀 마크다운 편집기. 기존 파일을 바로 편집하며 별도 보관함 불필요. [![Open-Source Software][OSS Icon]](https://github.com/I7T5/Edmund) ![Freeware][Freeware Icon]
 * [EME](https://github.com/egoist/eme) - Chrome과 같은 인터페이스를 가진 오픈 소스 마크다운 편집기. ![Open-Source Software][OSS Icon]
 * [iA Writer](https://ia.net/writer/) - 단순함과 디자인에 강조를 둔 쓰기 앱.

--- a/README-zh.md
+++ b/README-zh.md
@@ -832,6 +832,7 @@ Awesome Mac
 
 * [Cmd Markdown](https://www.zybuluo.com/) - Cmd Markdown 编辑阅读器，支持实时同步预览，区分写作和阅读模式，支持在线存储，分享文稿网址。 ![Freeware][Freeware Icon]
 * [Effie](https://www.effie.co/) - 轻量级 Markdown 写作软件，支持大纲笔记和思维导图。![Freeware][Freeware Icon]
+* [Coluracetam](https://kagerou.glass/coluracetam/) - Markdown 阅读器，附带 Quick Look 和缩略图扩展，按空格键即可预览 .md 文件，Finder 中也能直接渲染。 [![Open-Source Software][OSS Icon]](https://github.com/kageroumado/coluracetam) ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/us/app/id6788680916?platform=mac)
 * [Edmund](https://github.com/I7T5/Edmund) - 极简 Markdown 编辑器，支持实时预览，直接编辑现有文件，无需建立资料库。 [![Open-Source Software][OSS Icon]](https://github.com/I7T5/Edmund) ![Freeware][Freeware Icon]
 * [EME](https://github.com/egoist/eme) - 一款 Markdown 编辑器，界面很像 Chrome 浏览器的界面，很简约。
 * [iA Writer](https://ia.net/writer/) - Markdown 文本预览编辑，注重语法检查，专门为作家提供的编辑器。

--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 ### Markdown Tools [![Awesome List][awesome-list Icon]](https://github.com/BubuAnabelas/awesome-markdown#tools)
 
 * [Archimedes](https://furnacecreek.org/archimedes/) - Native macOS Markdown editor geared toward mathematical writing with inline LaTeX support.
+* [Coluracetam](https://kagerou.glass/coluracetam/) - Markdown reader with Quick Look and thumbnail extensions, so .md files render on spacebar and in Finder. [![Open-Source Software][OSS Icon]](https://github.com/kageroumado/coluracetam) ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/us/app/id6788680916?platform=mac)
 * [Edmund](https://github.com/I7T5/Edmund) - Minimal, native macOS Markdown editor with live preview; works with your existing files, no vault. [![Open-Source Software][OSS Icon]](https://github.com/I7T5/Edmund) ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [EME](https://github.com/egoist/eme) - Open-source Markdown editor with an interface like Chrome. ![Open-Source Software][OSS Icon]
 * [iA Writer](https://ia.net/writer/) - Writing app with an emphasis on simplicity and design.


### PR DESCRIPTION
Adds **Coluracetam** to Markdown Tools, synced across README.md, README-zh.md, README-ja.md, and README-ko.md with translated descriptions.

Markdown reader with Quick Look and thumbnail extensions, so .md files render on spacebar and in Finder.

Placement is alphabetical where the neighboring entries exist; in README-ko.md (and README-zh.md in one case) some neighboring entries are not yet synced from the English list, so the entry was placed beside the nearest existing entry of the same section.

Disclosure: I'm the developer. The app is MIT-licensed, actively maintained, and requires macOS 26 (Tahoe)+. AI assistance was used to prepare this PR per the repo's AI-assisted contribution guidelines; ordering, category choice, and translations were checked manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012R4qcu8ZgzDsEx4oRDF4RE