### PR TITLE
Add RegexPilot to Regular Expression Editors

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -469,6 +469,7 @@ Awesome Mac
 * [Regex](https://motionobj.com/regex/) - シンプルさを重視した正規表現テストツール。
 * [RegExRX](http://www.mactechnologies.com/index.php?page=downloads#regexrx) - 正規表現用の開発ツール。
 * [RegexMate](https://apps.apple.com/app/6479819388?platform=mac) - クイックリファレンスガイドを内蔵した正規表現テストツール。
+* [RegexPilot](https://regexpilot.com/) - 21 種類の実際の言語エンジンでパターンを実行できるビジュアル正規表現ビルダー。[![App Store][app-store Icon]](https://apps.apple.com/us/app/regexpilot/id6764146125?platform=mac)
 
 ### API開発と分析
 

--- a/README-ko.md
+++ b/README-ko.md
@@ -424,6 +424,7 @@ Awesome Mac
 * [Regex](https://motionobj.com/regex/) - 간단한 정규 표현식 테스트 도구.
 * [RegExRX](http://www.mactechnologies.com/index.php?page=downloads#regexrx) - 정규 표현식 개발 도구.
 * [RegexMate](https://apps.apple.com/app/6479819388?platform=mac) - 참조 가이드가 포함된 테스트 도구.
+* [RegexPilot](https://regexpilot.com/) - 21개 실제 언어 엔진에서 패턴을 실행하는 비주얼 정규식 빌더. [![App Store][app-store Icon]](https://apps.apple.com/us/app/regexpilot/id6764146125?platform=mac)
 
 ### API 개발 및 분석
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -296,6 +296,7 @@ Awesome Mac
 * [Reggy](http://reggyapp.com/) - 正则表达式编辑器。[![Open-Source Software][OSS Icon]](https://github.com/samsouder/reggy) ![Freeware][Freeware Icon]
 * [RegExRX](http://www.mactechnologies.com/index.php?page=downloads#regexrx) - 正则表达式的开发工具。
 * [RegexMate](https://apps.apple.com/app/6479819388?platform=mac) - 带速查手册的正则表达式测试工具。
+* [RegexPilot](https://regexpilot.com/) - 可视化正则表达式构建器，可在 21 种真实语言引擎上测试。[![App Store][app-store Icon]](https://apps.apple.com/us/app/regexpilot/id6764146125?platform=mac)
 
 ### API开发和分析
 

--- a/README.md
+++ b/README.md
@@ -470,6 +470,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Regex](https://motionobj.com/regex/) - Regular expression testing tool with an emphasis on simplicity.
 * [RegExRX](https://www.mactechnologies.com/index.php?page=downloads#regexrx) - Development tool for regular expressions.
 * [RegexMate](https://apps.apple.com/app/6479819388?platform=mac) - A regular expression testing tool with a built-in quick reference guide.
+* [RegexPilot](https://regexpilot.com/) - Visual regex builder that runs patterns against 21 real language engines. [![App Store][app-store Icon]](https://apps.apple.com/us/app/regexpilot/id6764146125?platform=mac)
 
 ### API Development and Analysis
 


### PR DESCRIPTION
Adds RegexPilot to Developer Tools > Regular Expression Editors, in all four READMEs.

RegexPilot is a visual regex builder for macOS. It renders a pattern as an editable railroad diagram and runs it against bundled native engines for 21 language flavors (CPython, MRI Ruby, GraalVM Java, .NET, PCRE and others), so match results reflect the target language rather than approximating with JavaScript.

- Homepage: https://regexpilot.com/
- Mac App Store: https://apps.apple.com/us/app/regexpilot/id6764146125?platform=mac
- macOS 14+, universal binary, signed and notarized

Follows the section conventions: homepage as the primary link with the App Store badge alongside, matching entries like Woodpecker and Nib Unlocker. No Freeware badge, since the app is free to download with paid features via in-app purchase, and the other paid entries in this section carry none.

Localized descriptions included for zh, ja and ko.