### PR TITLE
Add Marko to Markdown Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [LightPaper](https://getlightpaper.com/) - Simple, beautiful, yet powerful text editor for your Mac.
 * [MacDown](https://macdown.uranusjr.com/) - Open source Markdown editor for macOS with live preview and HTML/PDF export. [![Open-Source Software][OSS Icon]](https://github.com/MacDownApp/macdown) ![Freeware][Freeware Icon]
 * [Marked 2](https://marked2app.com/) - This is the Markdown preview with an elegant and powerful set of tools for all writers.
+* [Marko](https://yashbanka.com/marko) - Fast, native Markdown viewer that renders GFM, Mermaid, and KaTeX offline, with an outline and document info. ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [MarkText](https://github.com/marktext/marktext) - Next generation markdown editor, running on platforms of MacOS Windows and Linux. [![Open-Source Software][OSS Icon]](https://github.com/marktext/marktext) ![Freeware][Freeware Icon]
 * [MarkViewer](https://markviewer.com) - Markdown viewer and editor for macOS with AI-assisted editing. ![Freeware][Freeware Icon]
 * [Marp](https://marp.app) - Markdown presentation writer with cross-platform support. [![Open-Source Software][OSS Icon]](https://github.com/marp-team/marp) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds **Marko** to the Markdown Tools section (alphabetically, after Marked 2).

- **Homepage:** https://yashbanka.com/marko
- **What it is:** a fast, native macOS Markdown viewer. Renders GFM, Mermaid, and KaTeX fully offline, with a document outline and an info panel. Free and universal (Apple Silicon + Intel).
- **Badges:** Freeware + Native App. Not open source and not on the App Store, so no OSS/App Store icon.

Entry follows the section's format and alphabetical order.