### PR TITLE
Add Headless Guard to System Related Tools

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1551,6 +1551,7 @@ Awesome Mac
 * [gfxCardStatus](https://gfx.io/) - グラフィックカードの使用状況とバッテリーへの影響を監視。 ![Freeware][Freeware Icon]
 * [GrandPerspective](https://grandperspectiv.sourceforge.net) - ツリーマップでディスク使用量を視覚化。 [![Open-Source Software][OSS Icon]](https://git.code.sf.net/p/grandperspectiv/source) [![Freeware][Freeware Icon]](https://sourceforge.net/projects/grandperspectiv/files/grandperspective/) [![App Store][app-store Icon]](https://apps.apple.com/us/app/grandperspective/id1111570163?platform=mac)
 * [Gray](https://github.com/zenangst/Gray) - アプリごとのライト/ダークモード切り替え。 ![Freeware][Freeware Icon] [![Open-Source Software][OSS Icon]](https://github.com/zenangst/Gray)
+* [Headless Guard](https://github.com/study8677/HeadlessGuard) - 通常の Chrome セッションを保護しながら、孤立したヘッドレスブラウザを安全に検出・停止するオープンソースのメニューバーツール。 [![Open-Source Software][OSS Icon]](https://github.com/study8677/HeadlessGuard) ![Freeware][Freeware Icon]
 * [HandShaker](http://www.smartisan.com/apps/handshaker) - MacでAndroidスマートフォンのコンテンツを管理。 ![Freeware][Freeware Icon]
 * [iStat Menus](https://bjango.com/mac/istatmenus/) - メニューバー向けの高度なシステムモニター。
 * [iStats](https://github.com/Chris911/iStats) - コマンドライン対応のシステム情報ツール。 [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/Chris911/iStats)

--- a/README-ko.md
+++ b/README-ko.md
@@ -966,6 +966,7 @@ Awesome Mac
 * [Phosphene](https://kagerou.glass/phosphene/) - 어떤 동영상이든 macOS 배경화면으로 사용하세요. 데스크톱과 잠금 화면을 지원하며 시스템 설정에서 직접 선택합니다. [![Open-Source Software][OSS Icon]](https://github.com/kageroumado/phosphene) ![Freeware][Freeware Icon]
 * [WaifuX](https://jipika.github.io/WaifuX) - 배경화면, 동적 배경, 애니메이션 영상을 한곳에서 즐길 수 있는 오픈 소스 ACG 앱입니다. [![Open-Source Software][OSS Icon]](https://github.com/jipika/WaifuX) ![Freeware][Freeware Icon]
 * [Grayscale Mode](https://github.com/rkbhochalya/grayscale-mode) - 메뉴 막대나 단축키로 흑백 화면을 켜고 끄는 도구. [![Open-Source Software][OSS Icon]](https://github.com/rkbhochalya/grayscale-mode) ![Freeware][Freeware Icon]
+* [Headless Guard](https://github.com/study8677/HeadlessGuard) - 일반 Chrome 세션을 보호하면서 고아 상태의 헤드리스 브라우저를 안전하게 감지하고 종료하는 오픈 소스 메뉴 막대 도구. [![Open-Source Software][OSS Icon]](https://github.com/study8677/HeadlessGuard) ![Freeware][Freeware Icon]
 * [MaCursor](https://github.com/writronic/MaCursor) - macOS용 커스텀 커서 테마 도구. [![Open-Source Software][OSS Icon]](https://github.com/writronic/MaCursor) ![Freeware][Freeware Icon]
 * [MagicQuit](https://magicquit.com/) - 비활성 앱을 자동 종료해 리소스와 화면을 정리하는 도구. [![Open-Source Software][OSS Icon]](https://github.com/BigBerny/magicquit) ![Freeware][Freeware Icon]
 * [Adrafinil](https://kagerou.glass/adrafinil/) - AI 에이전트가 작업 중일 때만 Mac을 깨어 있게 하고, 작업이 끝나면 정상적으로 잠자기 상태로 전환합니다. [![Open-Source Software][OSS Icon]](https://github.com/kageroumado/adrafinil) ![Freeware][Freeware Icon]

--- a/README-zh.md
+++ b/README-zh.md
@@ -1357,6 +1357,7 @@ Awesome Mac
 * [everythingByMdfind](https://github.com/appledragon/everythingByMdfind) - 一款高效的 macOS 文件搜索工具，基于原生 Spotlight 引擎，支持极速搜索。[![Open-Source Software][OSS Icon]](https://github.com/appledragon/everythingByMdfind) ![Freeware][Freeware Icon]
 * [FixTim](https://github.com/Lakr233/FixTim) - 无须重启即可修复 macOS 上的所有运行时的 bug。[![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/Lakr233/FixTim)
 * [gfxCardStatus](https://gfx.io/) - 控制Mac独立显卡与集成显卡之间的切换。![Freeware][Freeware Icon]
+* [Headless Guard](https://github.com/study8677/HeadlessGuard) - 安全识别并停止遗留无头浏览器，同时保护正常 Chrome 会话的开源菜单栏工具。 [![Open-Source Software][OSS Icon]](https://github.com/study8677/HeadlessGuard) ![Freeware][Freeware Icon]
 * [HandShaker](http://www.smartisan.com/apps/handshaker) - Mac 电脑上也可以方便自如地管理您在 Android 手机中的内容。 ![Freeware][Freeware Icon]
 * [iStat Menus](https://bjango.com/mac/istatmenus/) - 菜单栏上的高级 Mac 系统监视器。
 * [iStats](https://github.com/Chris911/iStats) - iStats 是一个可以让你快速查看电脑 CPU 温度，磁盘转速和电池等信息的命令行工具。[![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/Chris911/iStats)

--- a/README.md
+++ b/README.md
@@ -1554,6 +1554,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [gfxCardStatus](https://gfx.io/) - Monitor graphics card usage and battery impact. ![Freeware][Freeware Icon]
 * [GrandPerspective](https://grandperspectiv.sourceforge.net) - Visualize disk usage with tree maps. [![Open-Source Software][OSS Icon]](https://git.code.sf.net/p/grandperspectiv/source) [![Freeware][Freeware Icon]](https://sourceforge.net/projects/grandperspectiv/files/grandperspective/) [![App Store][app-store Icon]](https://apps.apple.com/us/app/grandperspective/id1111570163?platform=mac)
 * [Gray](https://github.com/zenangst/Gray) - Per-app light/dark mode switcher. ![Freeware][Freeware Icon] [![Open-Source Software][OSS Icon]](https://github.com/zenangst/Gray)
+* [Headless Guard](https://github.com/study8677/HeadlessGuard) - Open-source menu bar utility that safely detects and stops orphaned headless browsers without touching normal Chrome sessions. [![Open-Source Software][OSS Icon]](https://github.com/study8677/HeadlessGuard) ![Freeware][Freeware Icon]
 * [HandShaker](https://www.smartisan.com/apps/handshaker) - Manage Android phone content on Mac. ![Freeware][Freeware Icon]
 * [iStat Menus](https://bjango.com/mac/istatmenus/) - Advanced system monitor for menubar.
 * [iStats](https://github.com/Chris911/iStats) - Command-line system information tool. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/Chris911/iStats)


### PR DESCRIPTION
Adds [Headless Guard](https://github.com/study8677/HeadlessGuard) to **System Related Tools** in the English, Chinese, Japanese, and Korean READMEs.

Headless Guard is an open-source native macOS menu bar utility that uses multiple process signals to detect and stop orphaned Playwright/Puppeteer headless browsers while protecting normal Chrome sessions.

- MIT licensed and free
- macOS 13+ on Apple Silicon
- One concise sentence per language
- Placed between the neighboring `G` and `H` entries where the local section is alphabetized
- Uses the existing open-source and freeware markers

The current v0.1.0 release is ad-hoc signed and not yet Apple-notarized; this limitation is disclosed in the project's README and release notes.

Disclosure: this is a self-submission. AI assistance was used, and the repository's `awesome-mac-maintainer` guidance was followed for category selection, multilingual synchronization, wording, and validation.
