### PR TITLE
Add DynoTable to Databases

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -579,6 +579,7 @@ Awesome Mac
 * [DB Browser for SQLite](http://sqlitebrowser.org/) - DB Browser for SQLiteの公式ホームページ。 [![Open-Source Software][OSS Icon]](https://github.com/sqlitebrowser/sqlitebrowser) ![Freeware][Freeware Icon]
 * [DBeaver](https://dbeaver.io/) - ユニバーサルSQLクライアント。
 * [DB Pro](https://dbpro.app) - SQLデータベースのクエリと管理を行うクライアント。
+* [DynoTable](https://dynotable.com) - SQLワークベンチでライブテーブルに対してJOIN、GROUP BY、集計を実行できるDynamoDB GUIクライアント。
 * [ElectroCRUD](http://garrylachman.github.io/ElectroCRUD/) - モダンなMySQL CRUDアプリケーション。 [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/garrylachman/ElectroCRUD)
 * [FastoNoSQL](https://fastonosql.com/) - 様々なキーバリューデータベース用のクロスプラットフォームGUIクライアント。 [![OSS][OSS Icon]](https://github.com/fastogt/fastonosql) ![Freeware][Freeware Icon]
 * [FastoRedis](https://fastoredis.com/) - Redis用のクロスプラットフォーム・プロフェッショナルGUI管理ツール。 [![Open-Source Software][OSS Icon]](https://github.com/fastogt/fastoredis) ![Freeware][Freeware Icon]

--- a/README-ko.md
+++ b/README-ko.md
@@ -500,6 +500,7 @@ Awesome Mac
 * [DB Browser for SQLite](http://sqlitebrowser.org/) - SQLite를 위한 공식 DB 브라우저. [![Open-Source Software][OSS Icon]](https://github.com/sqlitebrowser/sqlitebrowser) ![Freeware][Freeware Icon]
 * [DBeaver](https://dbeaver.io/) - 유니버설 SQL 클라이언트.
 * [DB Pro](https://dbpro.app) - SQL 데이터베이스를 조회하고 관리하는 클라이언트.
+* [DynoTable](https://dynotable.com) - SQL 워크벤치로 라이브 테이블에 JOIN, GROUP BY, 집계를 실행할 수 있는 DynamoDB GUI 클라이언트.
 * [Navicat Premium](https://www.navicat.com/en/products/navicat-premium) - 데이터베이스 관리 도구.
 * [Paul](https://guillim.github.io/products/paul) - 기본 읽기 전용으로 데이터베이스에서 빠르게 답을 찾을 수 있게 해주는 AI 우선 PostgreSQL 클라이언트.
 * [Postico](https://eggerapps.at/postico/) - 현대적인 PostgreSQL 클라이언트.

--- a/README-zh.md
+++ b/README-zh.md
@@ -372,6 +372,7 @@ Awesome Mac
 * [DataGrip](http://www.jetbrains.com/datagrip/) - JetBrains 公司旗下一款数据库管理工具。[点击这里](https://www.jetbrains.com/student/) **学生**免费。
 * [DBeaver](https://dbeaver.jkiss.org/) - 跨平台 SQL 客户端，支持大部分主流数据库
 * [DB Pro](https://dbpro.app) - 用于查询和管理 SQL 数据库的客户端。
+* [DynoTable](https://dynotable.com) - DynamoDB 图形客户端，SQL 工作台支持对线上表执行 JOIN、GROUP BY 和聚合查询。
 * [ElectroCRUD](http://garrylachman.github.io/ElectroCRUD/) - MySQL 数据库 CRUD 应用程序。[![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/garrylachman/ElectroCRUD)
 * [Sequel Pro](https://github.com/sequelpro/sequelpro) - 一个 MySQL 数据库管理软件。[![Open-Source Software][OSS Icon]](https://github.com/sequelpro/sequelpro) ![Freeware][Freeware Icon]
 * [JackDB](https://www.jackdb.com/) - 直接的 SQL 访问你所有的数据，无论在哪里。[![Open-Source Software][OSS Icon]](https://github.com/yoichiro/chrome_mysql_admin) ![Freeware][Freeware Icon]

--- a/README.md
+++ b/README.md
@@ -580,6 +580,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [DB Browser for SQLite](https://sqlitebrowser.org/) - Official home of the DB Browser for SQLite. [![Open-Source Software][OSS Icon]](https://github.com/sqlitebrowser/sqlitebrowser) ![Freeware][Freeware Icon]
 * [DBeaver](https://dbeaver.io/) - Universal SQL Client.
 * [DB Pro](https://dbpro.app) - Database client for querying and managing SQL databases.
+* [DynoTable](https://dynotable.com) - DynamoDB GUI with a SQL Workbench for JOIN, GROUP BY and aggregates over live tables.
 * [ElectroCRUD](https://garrylachman.github.io/ElectroCRUD/) - Modern MySQL CRUD application. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/garrylachman/ElectroCRUD)
 * [FastoNoSQL](https://fastonosql.com/) - Cross-platform GUI client for various key-value databases. [![OSS][OSS Icon]](https://github.com/fastogt/fastonosql) ![Freeware][Freeware Icon]
 * [FastoRedis](https://fastoredis.com/) - Cross-platform professional GUI management tool for Redis. [![Open-Source Software][OSS Icon]](https://github.com/fastogt/fastoredis) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds DynoTable to `### Databases` in all four READMEs (en / zh / ja / ko).

DynoTable is a cross-platform desktop GUI for Amazon DynamoDB. Its SQL Workbench runs SELECT with JOIN, GROUP BY and aggregates over live tables, which PartiQL and the AWS console cannot express.

- Site: https://dynotable.com
- Platforms: macOS (Apple Silicon), Windows, Linux
- Freemium: permanent free read-only plan, paid seats from $9/month billed annually

No icon on the entry, since it is closed-source commercial. That matches Base 2, Dataflare, TablePlus and Navicat in the same section.

The list currently has no DynamoDB entries.