### PR TITLE
Add Traveler's VPN to Proxy and VPN Tools

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -1102,6 +1102,7 @@ Awesome Mac
 * [Shimo](https://www.shimovpn.com/) - 连接大量 VPN 的应用。
 * [Surge](https://nssurge.com/) - 科学上网。
 * [tinc](https://www.tinc-vpn.org) - VPN 软件。[![Open-Source Software][OSS Icon]](https://www.tinc-vpn.org/git/browse?p=tinc)![Freeware][Freeware Icon]
+* [Traveler's VPN](https://travelersvpn.com/) - 基于 sing-box 的智能分流旅行 VPN 客户端，支持 Outline/Shadowsocks、WireGuard 和 Trojan 服务器。![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/us/app/travelers-vpn/id6764288591?platform=mac)
 * [Tailscale](https://tailscale.com) - 用于安全连接设备、服务和用户的网状 VPN。 ![Freeware][Freeware Icon]
 * [TrustTunnel](https://trusttunnel.org/) - 现代开源 VPN 协议，最初由 AdGuard VPN 开发。 [![Open-Source Software][OSS Icon]](https://github.com/TrustTunnel/TrustTunnel) ![Freeware][Freeware Icon]
 * [Tunnelbear](https://www.tunnelbear.com) - 用于安全上网和切换地区的简洁 VPN 服务。 ![Freeware][Freeware Icon]

--- a/README.md
+++ b/README.md
@@ -1160,6 +1160,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [SpechtLite](https://github.com/zhuhaow/SpechtLite) - Rule-based proxy app for macOS.  [![Open-Source Software][OSS Icon]](https://github.com/shadowsocks) ![Freeware][Freeware Icon]
 * [Surge](https://nssurge.com/) - Web developer tool and proxy utility for iOS 9.
 * [tinc](https://www.tinc-vpn.org) - Secure mesh VPN software. [![Open-Source Software][OSS Icon]](https://www.tinc-vpn.org/git/browse?p=tinc) ![Freeware][Freeware Icon]
+* [Traveler's VPN](https://travelersvpn.com/) - Smart split-tunnel travel VPN client for Outline/Shadowsocks, WireGuard and Trojan servers, built on sing-box. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/us/app/travelers-vpn/id6764288591?platform=mac)
 * [TrustTunnel](https://trusttunnel.org/) - A modern, open-source VPN protocol originally developed by AdGuard VPN. [![Open-Source Software][OSS Icon]](https://github.com/TrustTunnel/TrustTunnel) ![Freeware][Freeware Icon]
 * [Tunnelbear](https://www.tunnelbear.com) - Simple VPN service for secure browsing and location switching. ![Freeware][Freeware Icon]
 * [Tunnelblick](https://tunnelblick.net/downloads.html) - Free, open-source graphic user interface for OpenVPN on OS X. ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds [Traveler's VPN](https://travelersvpn.com/), a smart split-tunnel travel VPN client for the Mac (and iPhone/iPad) built on the sing-box engine. It connects to user-supplied Outline/Shadowsocks, WireGuard, or Trojan servers (or an optional managed server) and routes per destination so local apps stay direct while blocked/home traffic tunnels.

- Free to download on the App Store (native menu-bar Mac app), entry formatted to match the existing DashVPN/Surge entries with Freeware + App Store icons
- Added to both README.md and README-zh.md, alphabetical position after tinc

Disclosure: I'm the developer.