### PR TITLE
Add Glyph to Note-taking

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -247,6 +247,7 @@ Awesome Mac
 * [Email Me](https://emailmeapp.net/) - ワンタップで自分にメール。macOS、iOS、WatchOSにネイティブ対応。 [![App Store][app-store Icon]](https://apps.apple.com/us/app/email-me-notes-in-one-tap/id1090744587?platform=mac)
 * [Evernote](https://evernote.com/) - 多くのプラットフォームで利用可能な有名なメモアプリ。 ![Freeware][Freeware Icon]
 * [FSNotes](https://fsnot.es/) - macOSとiOSにネイティブ対応したモダンなメモ管理アプリ。 [![Open-Source Software][OSS Icon]](https://github.com/glushchenko/fsnotes) [![App Store][app-store Icon]](https://apps.apple.com/gb/app/fsnotes/id1277179284?platform=mac)
+* [Glyph](https://glyphformac.com/) - ノート、ドキュメント、タスク、オプションのAIツールに対応した、オープンソースでローカルファーストのMarkdownワークスペース。 [![Open-Source Software][OSS Icon]](https://github.com/SidhuK/Glyph)
 * [Gooba](https://goobapp.com/) - シンプルでインタラクティブなデザインのライティングアプリ兼タスクマネージャー。
 * [Inkdrop](https://www.inkdrop.info/) - Electron上に構築されたMarkdown愛好者のためのノートブックアプリ。
 * [Joplin](https://joplinapp.org/) - Markdownサポートとタスク管理機能を備えたクロスプラットフォームオープンソースメモアプリ。 [![Open-Source Software][OSS Icon]](https://github.com/laurent22/joplin) ![Freeware][Freeware Icon]

--- a/README-ko.md
+++ b/README-ko.md
@@ -221,6 +221,7 @@ Awesome Mac
 * [Email Me](https://emailmeapp.net/) - 단 한 번의 탭으로 자신에게 이메일을 보낼 수 있는 앱. [![App Store][app-store Icon]](https://apps.apple.com/us/app/email-me-notes-in-one-tap/id1090744587?platform=mac)
 * [Evernote](https://evernote.com/) - 다양한 플랫폼에서 사용 가능한 유명 노트 앱. ![Freeware][Freeware Icon]
 * [FSNotes](https://fsnot.es/) - macOS 및 iOS 네이티브 현대적 노트 관리자. [![Open-Source Software][OSS Icon]](https://github.com/glushchenko/fsnotes) [![App Store][app-store Icon]](https://apps.apple.com/gb/app/fsnotes/id1277179284?platform=mac)
+* [Glyph](https://glyphformac.com/) - 노트, 문서, 작업, 선택적 AI 도구를 지원하는 오픈 소스 로컬 우선 Markdown 워크스페이스. [![Open-Source Software][OSS Icon]](https://github.com/SidhuK/Glyph)
 * [Gooba](https://goobapp.com/) - 간단하고 대화형 디자인의 쓰기 앱 및 작업 관리자.
 * [Inkdrop](https://www.inkdrop.info/) - Electron 기반의 마크다운 애호가를 위한 노트북 앱.
 * [Joplin](https://joplinapp.org/) - 마크다운과 할 일 관리를 지원하는 오픈 소스 메모장. [![Open-Source Software][OSS Icon]](https://github.com/laurent22/joplin) ![Freeware][Freeware Icon]

--- a/README-zh.md
+++ b/README-zh.md
@@ -858,6 +858,7 @@ Awesome Mac
 * [Anytype](https://anytype.io/) - 本地优先的笔记与知识管理应用。 ![Freeware][Freeware Icon]
 * [Email Me](https://emailmeapp.net/) - 使用单次点击，在macOS、iOS 和 WatchOS上原生地给自己发送邮件以及更多功能。[![App Store][app-store Icon]](https://apps.apple.com/us/app/email-me-notes-in-one-tap/id1090744587?platform=mac)
 * [Evernote](https://evernote.com/) - 笔记本应用程序。 ![Freeware][Freeware Icon]
+* [Glyph](https://glyphformac.com/) - 开源、本地优先的 Markdown 工作空间，用于管理笔记、文档和任务，并提供可选的 AI 工具。 [![Open-Source Software][OSS Icon]](https://github.com/SidhuK/Glyph)
 * [Inkdrop](https://www.inkdrop.info/) - Markdown 爱好者的笔记本应用程序。
 * [Knopo](https://github.com/alkalim/Knopo) - 原生 macOS 本地优先大纲笔记应用，以纯 Markdown 文件存储笔记。 [![Open-Source Software][OSS Icon]](https://github.com/alkalim/Knopo) ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [leanote](http://app.leanote.com) - 支持 Markdown 的一款开源笔记软件，支持直接成为个人博客。[![Open-Source Software][OSS Icon]](https://github.com/leanote/leanote) ![Freeware][Freeware Icon]

--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Email Me](https://emailmeapp.net/) - Email yourself and much more with just one tap, native on macOS, iOS and WatchOS. [![App Store][app-store Icon]](https://apps.apple.com/us/app/email-me-notes-in-one-tap/id1090744587?platform=mac)
 * [Evernote](https://evernote.com/) - Infamous note-taking app, available on many platforms. ![Freeware][Freeware Icon]
 * [FSNotes](https://fsnot.es/) - File System Notes is a modern notes manager, native on macOS and iOS. [![Open-Source Software][OSS Icon]](https://github.com/glushchenko/fsnotes) [![App Store][app-store Icon]](https://apps.apple.com/gb/app/fsnotes/id1277179284?platform=mac)
+* [Glyph](https://glyphformac.com/) - Open-source, local-first Markdown workspace for notes, documents, tasks, and optional AI tools. [![Open-Source Software][OSS Icon]](https://github.com/SidhuK/Glyph)
 * [Gooba](https://goobapp.com/) - Writing app and task manager with a simple and interactive design.
 * [Inkdrop](https://www.inkdrop.info/) - Notebook app for Markdown lovers built on top of Electron.
 * [Joplin](https://joplinapp.org/) - Cross-platform open-source notepad with markdown support and to-do list management. [![Open-Source Software][OSS Icon]](https://github.com/laurent22/joplin) ![Freeware][Freeware Icon]


### PR DESCRIPTION
### Types of Changes

- [x] New addition to list
- [ ] Fixing bug in existing item in list
- [ ] Removing item from list
- [ ] Changing structure (organization) of list

### Proposed Changes

Add [Glyph](https://glyphformac.com/) to the **Note-taking** section in all four localized READMEs.

Glyph is an open-source, local-first Markdown workspace for notes, documents, tasks, and optional AI tools. Its source is available under [AGPL-3.0](https://github.com/SidhuK/Glyph), while official release builds use a one-time purchase with a 7-day trial, so the listing uses the Open-Source Software badge without the Freeware badge.

The entry is synchronized across `README.md`, `README-zh.md`, `README-ja.md`, and `README-ko.md`, follows the local alphabetical ordering, and links to both the official website and source repository.

### PR Checklist

- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important
- [x] I have added necessary documentation (if appropriate)

### Further Comments

This is the `SidhuK/Glyph` project, distinct from [#2146](https://github.com/jaywcjlove/awesome-mac/pull/2146), which refers to a different project at `hamidfzm/glyph`.
