### PR TITLE
Add Zielzeit to Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1106,6 +1106,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [SubManager](https://submanager.app) - Subscription tracker with renewal reminders. [![App Store][app-store Icon]](https://apps.apple.com/app/submanager-subscription-list/id1632853914?platform=mac)
 * [SubList](https://apps.apple.com/app/sublist-subscription-list/id6757860829?platform=mac) - Track subscriptions, renewals, and spending in one place with reminders, analytics, and iCloud sync.
 * [StockDock](https://github.com/simonsruggi/StockDock) - Menu bar app for real-time stocks, ETFs, crypto and portfolio P&L. Privacy-first, no account, multi-currency. [![Open-Source Software][OSS Icon]](https://github.com/simonsruggi/StockDock) ![Freeware][Freeware Icon]
+* [Zielzeit](https://mannafee.github.io/zielzeit-scalable-capital/) - Menu bar app projecting the year your Scalable Capital portfolio reaches a savings goal, read-only through the official broker CLI. English and German. [![Open-Source Software][OSS Icon]](https://github.com/Mannafee/zielzeit-scalable-capital) ![Freeware][Freeware Icon]
 
 ## Encryption
 


### PR DESCRIPTION
Adding [Zielzeit](https://github.com/Mannafee/zielzeit-scalable-capital), an open-source macOS menu bar app for Scalable Capital investors. It answers one question — when will my portfolio reach my goal? — and keeps the projected year in the menu bar.

* Native SwiftUI/AppKit, macOS 15+, universal build, MIT.
* Reads the account through Scalable Capital's own official CLI, read-only. No scraping, no unofficial API, no credentials, and no networking code in the app.
* English and German.

One entry, in Finance. It is also a menu bar app, but Finance is the more specific home and the guidelines ask for one place.

Disclosure: I am the author.