### PR TITLE
Add MacCleaner to Cleanup and Uninstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -1298,6 +1298,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [DaisyDisk](https://daisydiskapp.com/) - Disk usage analyzer and cleaner.
 * [Harbofly](https://harbofly.app/) - Menu bar app that auto-discovers and frees the disk space dev build artifacts and caches hog (DerivedData, node_modules, SPM/Homebrew caches). Zero telemetry, notarized. [![Open-Source Software][OSS Icon]](https://github.com/carloshpdoc/Harbofly) ![Freeware][Freeware Icon]
 * [Mac Cache Cleaner](https://github.com/kaunteya/MacCacheCleaner) - Cache cleaner for Mac [![Open-Source Software][OSS Icon]](https://github.com/kaunteya/MacCacheCleaner) ![Freeware][Freeware Icon]
+* [MacCleaner](https://maccleaner.io) - Trust-first storage cleaner that scans read-only, shows what's safe to remove (caches, dev build artifacts), and lets you choose Trash or permanent. No ads or tracking, notarized. ![Freeware][Freeware Icon]
 * [MacSift](https://lcharvol.github.io/MacSift/) - Open-source disk cleaner that groups files by app and moves them to the Trash. [![Open-Source Software][OSS Icon]](https://github.com/Lcharvol/MacSift) ![Freeware][Freeware Icon]
 * [OmniDiskSweeper](https://www.omnigroup.com/more) - Scans files by size so you can quickly find space hogs. ![Freeware][Freeware Icon]
 * [Pearcleaner](https://itsalin.com/appInfo/?id=pearcleaner) - A free, source-available and fair-code licensed mac app cleaner. ![Freeware][Freeware Icon] [![Open-Source Software][OSS Icon]](https://github.com/alienator88/Pearcleaner)


### PR DESCRIPTION
Adds **MacCleaner** to the Cleanup and Uninstall section.

- **Site:** https://maccleaner.io
- **What it is:** a trust-first macOS storage cleaner — it scans read-only, shows exactly what's safe to remove (app caches, developer build artifacts like DerivedData/node_modules/Docker), and lets you choose Move to Trash (recoverable) or delete permanently. Nothing is deleted automatically.
- Signed and notarized, universal (Apple Silicon + Intel), no ads or tracking. Free tier included.

Fits alongside the existing commercial cleaners in this section (CleanMyMac, DaisyDisk, Cleaner One). Placed alphabetically after Mac Cache Cleaner. Thanks for the great list!