### PR TITLE
Add BitFun to AI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -800,7 +800,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Apple On-Device OpenAI](https://github.com/gety-ai/apple-on-device-openai) - Runs Apple on-device models behind an OpenAI-compatible API. [![Open-Source Software][OSS Icon]](https://github.com/gety-ai/apple-on-device-openai) ![Freeware][Freeware Icon]
 * [AQBot](https://app.aqbot.top/) - Open-source desktop AI workspace for multi-provider chat, agent workflows, knowledge bases, MCP tools, and an OpenAI-compatible API gateway. [![Open-Source Software][OSS Icon]](https://github.com/AQBot-Desktop/AQBot) ![Freeware][Freeware Icon]
 * [Atomic Chat](https://github.com/AtomicBot-ai/Atomic-Chat) - Open-source AI chat client for local and cloud models with MCP support. [![Open-Source Software][OSS Icon]](https://github.com/AtomicBot-ai/Atomic-Chat)
-* [BitFun](https://openbitfun.com/) - Open-source desktop AI agent with a Rust runtime that works in real repositories and drives the browser, terminal, and desktop apps. [![Open-Source Software][OSS Icon]](https://github.com/GCWing/BitFun) ![Freeware][Freeware Icon]
+* [BitFun](https://openbitfun.com/) - Desktop AI agent that builds each task its own interface — a chart, a board, a panel — with a chat bound to that interface's live state. [![Open-Source Software][OSS Icon]](https://github.com/GCWing/BitFun) ![Freeware][Freeware Icon]
 * [BoltAI](https://boltai.com) - A beautiful & powerful ChatGPT app for Mac. Stay ahead by integrating AI into your workflow today.
 * [ChatGPT](https://openai.com/chatgpt/mac/) - A conversational AI system that listens, learns, and challenges
 * [Claude](https://claude.ai/download) - Your AI partner on desktop. Fast, focused, and designed for deep work.

--- a/README.md
+++ b/README.md
@@ -800,6 +800,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Apple On-Device OpenAI](https://github.com/gety-ai/apple-on-device-openai) - Runs Apple on-device models behind an OpenAI-compatible API. [![Open-Source Software][OSS Icon]](https://github.com/gety-ai/apple-on-device-openai) ![Freeware][Freeware Icon]
 * [AQBot](https://app.aqbot.top/) - Open-source desktop AI workspace for multi-provider chat, agent workflows, knowledge bases, MCP tools, and an OpenAI-compatible API gateway. [![Open-Source Software][OSS Icon]](https://github.com/AQBot-Desktop/AQBot) ![Freeware][Freeware Icon]
 * [Atomic Chat](https://github.com/AtomicBot-ai/Atomic-Chat) - Open-source AI chat client for local and cloud models with MCP support. [![Open-Source Software][OSS Icon]](https://github.com/AtomicBot-ai/Atomic-Chat)
+* [BitFun](https://openbitfun.com/) - Open-source desktop AI agent with a Rust runtime that works in real repositories and drives the browser, terminal, and desktop apps. [![Open-Source Software][OSS Icon]](https://github.com/GCWing/BitFun) ![Freeware][Freeware Icon]
 * [BoltAI](https://boltai.com) - A beautiful & powerful ChatGPT app for Mac. Stay ahead by integrating AI into your workflow today.
 * [ChatGPT](https://openai.com/chatgpt/mac/) - A conversational AI system that listens, learns, and challenges
 * [Claude](https://claude.ai/download) - Your AI partner on desktop. Fast, focused, and designed for deep work.


### PR DESCRIPTION
Adds [BitFun](https://openbitfun.com/) to `## AI Tools`, placed alphabetically between Atomic Chat and BoltAI.

BitFun is an open-source (MIT) desktop AI agent. The agent runtime is written in Rust, the shell is Tauri v2, and it ships a signed-for-arm64/x86 macOS build alongside Windows and Linux. It works inside real Git repositories — planning, editing, running tests, committing — and can also drive the browser, terminal, and desktop applications. Extends through MCP, Skills, custom agents, and Mini Apps; model-agnostic.

- Repo: https://github.com/GCWing/BitFun — 1.4k stars, 168 forks, 23 contributors
- Latest release v0.2.15, roughly a release every two weeks

Entry follows the existing format: website link, one-line description, OSS icon linking to the repo, and the Freeware icon.