### PR TITLE
Add Mac-letterhead to Reading and Writing > Others

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [CHM Reader](https://www.hewbo.com/chm-reader.html) - Read Compiled HTML (.chm) documents on your Mac. ![Freeware][Freeware Icon]
 * [Chmox](https://chmox.sourceforge.net/) - Read CHM documents on your Mac. ![Freeware][Freeware Icon]
 * [Highlights](https://highlightsapp.net) - The PDF Reader for Research on Mac, iPad & iPhone. ![Freeware][Freeware Icon]
+* [Mac-letterhead](https://github.com/easytocloud/Mac-letterhead) - Drag-and-drop droplet that prints Markdown onto any letterhead PDF, auto-fitting around your header, footer, and logo. Also usable as a CLI or MCP server. [![Open-Source Software][OSS Icon]](https://github.com/easytocloud/Mac-letterhead) ![Freeware][Freeware Icon]
 * [PDF Auditor](https://pura-vida.in/apps/pdf-auditor/?utm_source=github&utm_medium=awesome-mac) - PDF inspection tool for analyzing metadata, structure, and security risks. [![App Store][app-store Icon]](https://apps.apple.com/app/apple-store/id6738956506?pt=127483661&ct=GitHub&mt=8&platform=mac)
 * [PDF Expert](https://pdfexpert.com/) - Read, annotate and edit PDFs, change text and images.
 * [PDF Pals](https://pdfpals.com) - Chat with PDF app for Mac. No file size limits!


### PR DESCRIPTION
Adds [Mac-letterhead](https://github.com/easytocloud/Mac-letterhead) — a macOS drag-and-drop droplet (also usable as a CLI and MCP server) that prints Markdown onto any letterhead PDF, auto-fitting content around the header, footer, and logo.

- **Repo**: https://github.com/easytocloud/Mac-letterhead
- **License**: MIT — Open Source + Freeware
- **Platform**: macOS (native via PyObjC + Quartz + AppleScript droplet)
- **Category**: Reading and Writing > Others (sits naturally with the other PDF utilities — bindPDF, Skim, PDF Expert, etc.)
- **Placement**: alphabetical, between `Highlights` and `PDF Auditor`