### PR TITLE
Add Inventory to AI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -821,6 +821,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Fluent](https://fluentmac.app) - AI assistant that works across apps with model and context integration.
 * [Gemini Collector](https://github.com/FirenzeLor/gemini-collector) - Back up Google Gemini conversations, attachments, and AI-generated media locally as JSON. [![Open-Source Software][OSS Icon]](https://github.com/FirenzeLor/gemini-collector) ![Freeware][Freeware Icon]
 * [GroAsk](https://groask.com) - Menu bar launcher that sends selected text to AI assistants and CLI agents.
+* [Inventory](https://www.myinventory.site) - Menu bar search across your Claude Code, Codex, Cursor, Zed, Kiro and Antigravity chat history, fully local and encrypted on disk.
 * [RecurseChat](https://recurse.chat) - Local-first AI chat app with customizable workflows.
 * [Runtime](https://github.com/runtime-org/runtime) - AI taskmate and take control of the web & your office tools
 * [TokenMeter](https://priyans-hu.github.io/tokenmeter/) - Track Claude Code usage, rate limits, costs, and activity heatmaps. [![Open-Source Software][OSS Icon]](https://github.com/Priyans-hu/tokenmeter) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds Inventory, a menu bar app for macOS that indexes and searches Claude Code, Codex, Cursor, Zed, Kiro and Antigravity chat history in one place. It runs fully local (no account, no server), searches by keyword and by meaning, and the index is encrypted on disk.

- Added under AI Tools, alphabetically between GroAsk and RecurseChat.
- One sentence, matching the style of neighboring entries.