### PR TITLE
Add Breakdown to Network Analysis

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -500,6 +500,7 @@ Awesome Mac
 
 ### ネットワーク分析
 
+* [Breakdown](https://breakdown.live/) - メニューバーから継続的に証拠を記録し、接続問題が Wi-Fi、ISP 経路、アプリのどこで始まったかを示します。標準的な利用は無料です。
 * [Charles](https://www.charlesproxy.com/) - HTTPおよびHTTPSトラフィックを表示するHTTPプロキシ/モニター。
 * [James](https://github.com/james-proxy/james) - httpおよびhttpsでリクエストの確認とマッピングを行うオープンソースのプロキシツール。 [![Open-Source Software][OSS Icon]](https://github.com/james-proxy/james) ![Freeware][Freeware Icon]
 * [Little Snitch](https://www.obdev.at/products/littlesnitch/download.html) - ネットワーク接続を世界地図で可視化するネットワークモニター。

--- a/README-ko.md
+++ b/README-ko.md
@@ -451,6 +451,7 @@ Awesome Mac
 
 ### 네트워크 분석
 
+* [Breakdown](https://breakdown.live/) - 메뉴 막대에서 연결 상태를 지속적으로 기록하고 문제가 Wi-Fi, ISP 경로 또는 앱 중 어디에서 시작되는지 보여줍니다. 표준 용도는 무료입니다.
 * [Charles](https://www.charlesproxy.com/) - HTTP 프록시/모니터.
 * [Little Snitch](https://www.obdev.at/products/littlesnitch/download.html) - 네트워크 연결 시각화 도구.
 * [mitmproxy](https://mitmproxy.org/) - 인터랙티브 가로채기 HTTP 프록시. [![Open-Source Software][OSS Icon]](https://github.com/mitmproxy/mitmproxy) ![Freeware][Freeware Icon]

--- a/README-zh.md
+++ b/README-zh.md
@@ -323,6 +323,7 @@ Awesome Mac
 
 ### 网络分析
 
+* [Breakdown](https://breakdown.live/) - 持续从菜单栏记录证据，显示连接问题源自 Wi-Fi、ISP 路径还是应用。标准用途可免费使用。
 * [bruno](https://www.usebruno.com/) - 一款离线优先、快速且兼容 Git 的开源 API 客户端。 ![Freeware][Freeware Icon]
 * [Charles](https://www.charlesproxy.com/) - 一个代理工具，允许你查看所有的 HTTP 和 HTTPS 流量。
 * [James](https://github.com/james-proxy/james) - 用于 https 和 http 进行查询映射请求。 [![Open-Source Software][OSS Icon]](https://github.com/james-proxy/james) ![Freeware][Freeware Icon]

--- a/README.md
+++ b/README.md
@@ -500,6 +500,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 
 ### Network Analysis
 
+* [Breakdown](https://breakdown.live/) - Shows whether connection trouble starts with Wi-Fi, the ISP path, or the app, with continuous evidence from the menu bar. Free for standard use.
 * [Charles](https://www.charlesproxy.com/) - HTTP proxy/monitor to view HTTP and HTTPS traffic.
 * [James](https://github.com/james-proxy/james) - Open-source proxy tool for checking and mapping requests with http as well as https. [![Open-Source Software][OSS Icon]](https://github.com/james-proxy/james) ![Freeware][Freeware Icon]
 * [Little Snitch](https://www.obdev.at/products/littlesnitch/download.html) - Network monitor with a world map for visualizing network connections.


### PR DESCRIPTION
## What this adds

Adds [Breakdown](https://breakdown.live/) to **Developer Tools → Network Analysis**. Breakdown is a macOS menu-bar utility that continuously distinguishes connection trouble originating on the LAN, ISP path, or app and retains evidence after intermittent issues pass. It is free for standard use, with optional Pro depth.

## Checklist

- Added one app in alphabetical order
- Kept the description to one sentence
- Updated English, Chinese, Japanese, and Korean READMEs
- Used the direct product URL with no tracking parameters
- Did not use the Freeware badge because the product also offers an optional paid Pro tier