### PR TITLE
Add Envy (Note-taking)

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Craft](https://www.craft.do/) - Notetaking and writing made beautiful. [![App Store][app-store Icon]](https://apps.apple.com/se/app/craft-docs-and-notes-editor/id1487937127?platform=mac)
 * [Dnote](https://www.getdnote.com/) - A simple command line notebook with multi-device sync and a web interface. [![Open-Source Software][OSS Icon]](https://github.com/dnote/dnote) ![Freeware][Freeware Icon]
 * [Email Me](https://emailmeapp.net/) - Email yourself and much more with just one tap, native on macOS, iOS and WatchOS. [![App Store][app-store Icon]](https://apps.apple.com/us/app/email-me-notes-in-one-tap/id1090744587?platform=mac)
+* [Envy](https://envynote.app/) - Fast, local-first Markdown notes app with one-box search, in the Notational Velocity tradition. ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [Evernote](https://evernote.com/) - Infamous note-taking app, available on many platforms. ![Freeware][Freeware Icon]
 * [FSNotes](https://fsnot.es/) - File System Notes is a modern notes manager, native on macOS and iOS. [![Open-Source Software][OSS Icon]](https://github.com/glushchenko/fsnotes) [![App Store][app-store Icon]](https://apps.apple.com/gb/app/fsnotes/id1277179284?platform=mac)
 * [Gooba](https://goobapp.com/) - Writing app and task manager with a simple and interactive design.


### PR DESCRIPTION
Adds Envy under Note-taking, placed alphabetically between Email Me and Evernote.

Envy is a free, native macOS Markdown note-taking app: every note is a flat `.md` file in one folder, with one-box search-and-create in the Notational Velocity tradition, wiki-links, and no lock-in.

- Website: https://envynote.app
- Tagged Freeware and Native App (the license is proprietary, so no open-source badge).