### PR TITLE
Add Renomee (https://renomeeai.com) to File Organization Tools

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1316,6 +1316,7 @@ Awesome Mac
 * [Oka Unarchiver](https://okaapps.com/product/1441507725) - RARやパスワード付きアーカイブに対応した圧縮・解凍ツール。 [![App Store][app-store Icon]](https://apps.apple.com/app/id1441507725?pt=119209922&ct=github)
 * [PDF Archiver](https://github.com/JulianKahnert/PDF-Archiver) - タグ付けとアーカイブ作業に便利なツール。 [![Open-Source Software][OSS Icon]](https://github.com/JulianKahnert/PDF-Archiver) [![App Store][app-store Icon]](https://apps.apple.com/app/pdf-archivar/id1352719750?platform=mac)
 * [Rapidmg](https://rapidmg.branchseer.com/) ワンクリックでDMGイメージからアプリを「アプリケーション」フォルダに展開。 [![App Store][app-store Icon]](https://apps.apple.com/app/rapidmg/id6451349778?platform=mac)
+* [RenomeeAI](https://renomeeai.com) - PDF・写真・音声の内容を読み取り、自然言語でファイル名を生成するAIバッチリネームツール。
 * [Shuffle](https://shuffleapp.co) - Rustで開発されたGPUレンダリングの高速ファイルマネージャー、Finderの代替。 [![Open-Source Software][OSS Icon]](https://github.com/WizenPainter/shuffle) ![Freeware][Freeware Icon]
 * [The Unarchiver](https://theunarchiver.com/) - 様々な種類のアーカイブファイルを解凍。 ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/us/app/the-unarchiver/id425424353?platform=mac)
 * [Unarchive One](https://cleanerone.trendmicro.com/unarchiver-one/?utm_source=github&utm_medium=referral&utm_campaign=githubproject) - 多くの一般的な形式に対応した圧縮・解凍ツール。 ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/apple-store/id1127253508?pt=444218&ct=GitHub&mt=8&platform=mac)

--- a/README-ko.md
+++ b/README-ko.md
@@ -960,6 +960,7 @@ Awesome Mac
 * [Modal File Manager](https://github.com/raguay/ModalFileManager/) - Vim 스타일 단축키를 갖춘 듀얼 패널 파일 관리자. [![Open-Source Software][OSS Icon]](https://GitHub.com/raguay/ModalFileManager) ![Freeware][Freeware Icon]
 * [cmd+x](https://apps.apple.com/app/cmd-x/id6754665762?platform=mac) - Ctrl+Opt+Delete로 활동 모니터를 실행하고 Finder에서 Cmd+X로 파일을 잘라 이동.
 * [Oka Unarchiver](https://okaapps.com/product/1441507725) - RAR와 암호 보호 압축 파일까지 다루는 압축 해제 도구. [![App Store][app-store Icon]](https://apps.apple.com/app/id1441507725?pt=119209922&ct=github)
+* [RenomeeAI](https://renomeeai.com) - PDF, 사진, 오디오 내용을 읽고 자연어로 파일명을 생성하는 AI 일괄 이름 변경 도구.
 * [SaneClick](https://saneclick.com) - Finder 우클릭 메뉴에 파일 작업, 변환, 개발자 액션을 추가하는 확장. [![Open-Source Software][OSS Icon]](https://github.com/sane-apps/SaneClick) ![Freeware][Freeware Icon]
 * [Shuffle](https://shuffleapp.co) - Rust로 개발된 GPU 렌더링 고속 파일 관리자이자 Finder 대안. [![Open-Source Software][OSS Icon]](https://github.com/WizenPainter/shuffle) ![Freeware][Freeware Icon]
 * [SwiftyMenu](https://apps.apple.com/us/app/swiftymenu/id1567748223?platform=mac) - 선택한 파일이나 폴더를 지정 앱으로 빠르게 여는 Finder 확장.

--- a/README-zh.md
+++ b/README-zh.md
@@ -1451,6 +1451,7 @@ Awesome Mac
 * [Quicklook-Plugins](https://github.com/sindresorhus/quick-look-plugins) - Finder 快速预览文件插件。
 * [QSpace](https://qspace.awehunt.com) - 一款简洁高效的多视图文件管理器。 [![App Store][app-store Icon]](https://apps.apple.com/cn/app/id1469774098?platform=mac)
 * [RClick](https://github.com/wflixu/RClick) - 一款简洁实用的 Finder 右键菜单增强工具 [![Open-Source Software][OSS Icon]](https://github.com/wflixu/RClick) ![Freeware][Freeware Icon]
+* [RenomeeAI](https://renomeeai.com) - AI 批量重命名工具，可读 PDF、照片与音频内容，并用自然语言生成文件名。
 * [SaneClick](https://saneclick.com) - 为 Finder 右键菜单增加文件处理、转换和开发者操作。 [![Open-Source Software][OSS Icon]](https://github.com/sane-apps/SaneClick) ![Freeware][Freeware Icon]
 * [Shuffle](https://shuffleapp.co) - 使用 Rust 构建的 GPU 渲染高速文件管理器，Finder 的替代品。 [![Open-Source Software][OSS Icon]](https://github.com/WizenPainter/shuffle) ![Freeware][Freeware Icon]
 * [SwiftyMenu](https://apps.apple.com/us/app/swiftymenu/id1567748223?platform=mac) - 用常用应用快速打开所选文件或文件夹的 Finder 扩展。


### PR DESCRIPTION
### Types of Changes

- [x] Adding a new item to the list
- [ ] Updating an existing item
- [ ] Removing an item from the list
- [ ] Changing structure (organization) of the list

### Proposed Changes

Adds [Renomee](https://renomeeai.com) to File Organization Tools (and the equivalent sections in `README-zh.md`, `README-ja.md`, and `README-ko.md`), in alphabetical order.

**Why this addition is valuable:**

1. **Useful for Mac users** — Renomee is a native desktop batch renamer for macOS (also Windows/Linux). It reads PDF titles, photo EXIF, and audio ID3 tags, then generates filenames from natural-language instructions — no regex required.
2. **Fits the category** — File renamers and file-organization utilities belong with Hazel / similar tools, not Productivity (launchers/keyboard tools).
3. **Differentiated from existing entries** — Unlike BetterRename (rule/regex-first) and NameQuick (AI rename), Renomee focuses on content-based renaming across PDFs, photos, and audio at batch scale, with local-first file reading.
4. **Synced across languages** — Entries added to `README.md`, `README-zh.md`, `README-ja.md`, and `README-ko.md`.

### PR Checklist

- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important
- [x] I have verified the entry is in alphabetical order
- [x] I have checked spelling and grammar
- [x] I have verified there are no duplicate entries
- [x] I have synced the four README language files
- [x] I have adhered to the Code of Conduct