### PR TITLE
Add Eqlume (system-wide EQ with automatic genre detection)

### DIFF
--- a/README.md
+++ b/README.md
@@ -994,7 +994,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 ### Audio Record and Process
 
 * [CapSoftware](https://github.com/CapSoftware/) - An open-source alternative to Loom. Beautiful, shareable screen recording tool. [![Open-Source Software][OSS Icon]](https://github.com/CapSoftware/) ![Freeware][Freeware Icon]
-* [Eqlume](https://github.com/gokturkgocen/Eqlume) - System-wide equalizer that detects the genre of each track and applies a matching EQ preset automatically; menu bar app built on a Core Audio process tap, so it needs no virtual audio driver. [![Open-Source Software][OSS Icon]](https://github.com/gokturkgocen/Eqlume) ![Freeware][Freeware Icon]
+* [Eqlume](https://github.com/gokturkgocen/Eqlume) - System-wide equalizer that detects the genre of each track and applies a matching EQ preset automatically. Menu bar app built on a Core Audio process tap, so it needs no virtual audio driver. [![Open-Source Software][OSS Icon]](https://github.com/gokturkgocen/Eqlume) ![Freeware][Freeware Icon]
 * [GarageBand](https://www.apple.com/mac/garageband/) - Digital audio workstation for recording and music production. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/cn/app/garageband/id682658836?l=zh&ls=1&platform=mac)
 * [Logic Pro X](https://www.apple.com/logic-pro/) - Professional digital audio workstation for music and audio production. [![App Store][app-store Icon]](https://apps.apple.com/cn/app/logic-pro-x/id634148309?l=zh&platform=mac)
 * [Segue](https://segue.npearce.me/) - Broadcast audio playout with crossfade, trim, ramp timers, and pause beds for live radio and podcasts. [![Open-Source Software][OSS Icon]](https://github.com/pearcenuk/Segue) ![Freeware][Freeware Icon]

--- a/README.md
+++ b/README.md
@@ -994,6 +994,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 ### Audio Record and Process
 
 * [CapSoftware](https://github.com/CapSoftware/) - An open-source alternative to Loom. Beautiful, shareable screen recording tool. [![Open-Source Software][OSS Icon]](https://github.com/CapSoftware/) ![Freeware][Freeware Icon]
+* [Eqlume](https://github.com/gokturkgocen/Eqlume) - System-wide equalizer that detects the genre of each track and applies a matching EQ preset automatically; menu bar app built on a Core Audio process tap, so it needs no virtual audio driver. [![Open-Source Software][OSS Icon]](https://github.com/gokturkgocen/Eqlume) ![Freeware][Freeware Icon]
 * [GarageBand](https://www.apple.com/mac/garageband/) - Digital audio workstation for recording and music production. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/cn/app/garageband/id682658836?l=zh&ls=1&platform=mac)
 * [Logic Pro X](https://www.apple.com/logic-pro/) - Professional digital audio workstation for music and audio production. [![App Store][app-store Icon]](https://apps.apple.com/cn/app/logic-pro-x/id634148309?l=zh&platform=mac)
 * [Segue](https://segue.npearce.me/) - Broadcast audio playout with crossfade, trim, ramp timers, and pause beds for live radio and podcasts. [![Open-Source Software][OSS Icon]](https://github.com/pearcenuk/Segue) ![Freeware][Freeware Icon]

--- a/README.md
+++ b/README.md
@@ -994,7 +994,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 ### Audio Record and Process
 
 * [CapSoftware](https://github.com/CapSoftware/) - An open-source alternative to Loom. Beautiful, shareable screen recording tool. [![Open-Source Software][OSS Icon]](https://github.com/CapSoftware/) ![Freeware][Freeware Icon]
-* [Eqlume](https://github.com/gokturkgocen/Eqlume) - System-wide equalizer that detects the genre of each track and applies a matching EQ preset automatically. Menu bar app built on a Core Audio process tap, so it needs no virtual audio driver. [![Open-Source Software][OSS Icon]](https://github.com/gokturkgocen/Eqlume) ![Freeware][Freeware Icon]
+* [EqLume](https://github.com/gokturkgocen/EqLume) - System-wide equalizer that detects the genre of each track and applies a matching EQ preset automatically. Menu bar app built on a Core Audio process tap, so it needs no virtual audio driver. [![Open-Source Software][OSS Icon]](https://github.com/gokturkgocen/EqLume) ![Freeware][Freeware Icon]
 * [GarageBand](https://www.apple.com/mac/garageband/) - Digital audio workstation for recording and music production. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/cn/app/garageband/id682658836?l=zh&ls=1&platform=mac)
 * [Logic Pro X](https://www.apple.com/logic-pro/) - Professional digital audio workstation for music and audio production. [![App Store][app-store Icon]](https://apps.apple.com/cn/app/logic-pro-x/id634148309?l=zh&platform=mac)
 * [Segue](https://segue.npearce.me/) - Broadcast audio playout with crossfade, trim, ramp timers, and pause beds for live radio and podcasts. [![Open-Source Software][OSS Icon]](https://github.com/pearcenuk/Segue) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adding [Eqlume](https://github.com/gokturkgocen/Eqlume), a free and open-source (MIT) system-wide equalizer for macOS, to **Audio Record and Process**.

Unlike the other equalizers listed, it doesn't ask you to choose a preset: it identifies the genre of whatever is playing (MusicBrainz → iTunes Search → an on-device CoreML classifier) and applies a matching curve on the fly. It captures system audio with a Core Audio process tap, so there is no virtual audio driver or kernel extension to install.

Placed alphabetically between CapSoftware and GarageBand, with the OSS and Freeware badges used by the surrounding entries. One line, no other changes.