### PR TITLE
Add Runclab to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,6 +448,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [ProcessSpy](https://process-spy.app/) - A clean and powerful process monitor.
 * [PushMate](https://pushmate.app) - Solves common push notification problems on macOS.
 * [Responsively](https://responsively.app) - A must-have devtool for web developers for quicker responsive web development. [![Open-Source Software][OSS Icon]](https://github.com/responsively-org/responsively-app) ![Freeware][Freeware Icon]
+* [Runclab](https://github.com/carbonvein/Runclab-) - macOS visual manager for multi-process and local AI services, with terminal log monitoring and Python environment detection. [![Open-Source Software][OSS Icon]](https://github.com/carbonvein/Runclab-) ![Freeware][Freeware Icon]
 * [SCM Breeze](https://github.com/scmbreeze/scm_breeze) - Set of shell scripts (for bash and zsh) that enhance your interaction with git. ![Freeware][Freeware Icon] [![Open-Source Software][OSS Icon]](https://github.com/scmbreeze/scm_breeze)
 * [SecureCRT](https://www.vandyke.com/products/securecrt/) - Terminal emulation which supports SSH, Telnet or other protocols.
 * [Site Sucker](https://ricks-apps.com/osx/sitesucker/) - Automatically downloads websites. [![App Store][app-store Icon]](https://apps.apple.com/in/app/sitesucker/id442168834?platform=mac)


### PR DESCRIPTION
## Description

Add [Runclab](https://github.com/carbonvein/Runclab-) to the **Developer Tools → Developer Utilities** section.

Runclab is a macOS visual manager that helps developers run and observe local tooling:

- Visual management of **multi-process / local AI services**
- **Terminal log monitoring** with search and export
- **Python environment detection** (conda / venv assets)

It is open-source (Apache-2.0) and free to use, currently macOS-only.

## Checklist

- [x] Added to the correct category (Developer Tools → Developer Utilities)
- [x] Entry follows the existing list format (`* [Name](link) - desc. [OSS][Freeware]`)
- [x] Placed alphabetically (after `Responsively`)