### PR TITLE
Add TetherShot to Screenshot Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -728,6 +728,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Snip](https://snip.qq.com/) - Application for sharing captured images on QQ Mail. ![Freeware][Freeware Icon]
 * [Snipaste](https://www.snipaste.com) -  Simple but powerful snipping tool. ![Freeware][Freeware Icon]
 * [Teampaper Snap](https://teampaper.me/snap/) - Let your screenshots speak up. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/monosnap/id1199502670?platform=mac)
+* [TetherShot](https://tethershot.apoorvdarshan.com) - Capture pixel-perfect iPhone screenshots from the macOS menu bar over USB or Wi-Fi. [![Open-Source Software][OSS Icon]](https://github.com/apoorvdarshan/TetherShot) ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [Tuji](https://tuji.app/) - Take a screenshot, annotate it, and beautify it. [![App Store][app-store Icon]](https://apps.apple.com/us/app/tuji/id6479216439?platform=mac) ![Freeware][Freeware Icon]
 * [Xnip](https://xnipapp.com/) - Handy Screenshot App. [![App Store][app-store Icon]](https://apps.apple.com/app/xnip-handy-screenshot-app/id1221250572?platform=mac) ![Freeware][Freeware Icon]
 

--- a/README.md
+++ b/README.md
@@ -728,7 +728,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Snip](https://snip.qq.com/) - Application for sharing captured images on QQ Mail. ![Freeware][Freeware Icon]
 * [Snipaste](https://www.snipaste.com) -  Simple but powerful snipping tool. ![Freeware][Freeware Icon]
 * [Teampaper Snap](https://teampaper.me/snap/) - Let your screenshots speak up. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/monosnap/id1199502670?platform=mac)
-* [TetherShot](https://tethershot.apoorvdarshan.com) - Capture pixel-perfect iPhone screenshots from the macOS menu bar over USB or Wi-Fi. [![Open-Source Software][OSS Icon]](https://github.com/apoorvdarshan/TetherShot) ![Freeware][Freeware Icon] ![Native App][Native Icon]
+* [TetherShot](https://tethershot.apoorvdarshan.com) - Capture pixel-perfect iPhone screenshots from the macOS menu bar over USB or Wi-Fi. [![Open-Source Software][OSS Icon]](https://github.com/aopv/TetherShot) ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [Tuji](https://tuji.app/) - Take a screenshot, annotate it, and beautify it. [![App Store][app-store Icon]](https://apps.apple.com/us/app/tuji/id6479216439?platform=mac) ![Freeware][Freeware Icon]
 * [Xnip](https://xnipapp.com/) - Handy Screenshot App. [![App Store][app-store Icon]](https://apps.apple.com/app/xnip-handy-screenshot-app/id1221250572?platform=mac) ![Freeware][Freeware Icon]
 

--- a/README.md
+++ b/README.md
@@ -728,7 +728,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Snip](https://snip.qq.com/) - Application for sharing captured images on QQ Mail. ![Freeware][Freeware Icon]
 * [Snipaste](https://www.snipaste.com) -  Simple but powerful snipping tool. ![Freeware][Freeware Icon]
 * [Teampaper Snap](https://teampaper.me/snap/) - Let your screenshots speak up. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/monosnap/id1199502670?platform=mac)
-* [TetherShot](https://tethershot.apoorvdarshan.com) - Capture pixel-perfect iPhone screenshots from the macOS menu bar over USB or Wi-Fi. [![Open-Source Software][OSS Icon]](https://github.com/aopv/TetherShot) ![Freeware][Freeware Icon] ![Native App][Native Icon]
+* [TetherShot](https://tethershot.apoorvdarshan.com) - Capture pixel-perfect iPhone screenshots from the macOS menu bar over USB or Wi-Fi. [![Open-Source Software][OSS Icon]](https://github.com/apoorvdarshan/TetherShot) ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [Tuji](https://tuji.app/) - Take a screenshot, annotate it, and beautify it. [![App Store][app-store Icon]](https://apps.apple.com/us/app/tuji/id6479216439?platform=mac) ![Freeware][Freeware Icon]
 * [Xnip](https://xnipapp.com/) - Handy Screenshot App. [![App Store][app-store Icon]](https://apps.apple.com/app/xnip-handy-screenshot-app/id1221250572?platform=mac) ![Freeware][Freeware Icon]
 


### PR DESCRIPTION
Adds **[TetherShot](https://tethershot.apoorvdarshan.com)** to **Screenshot Tools**, alphabetically between Teampaper Snap and Tuji.

TetherShot is a free, MIT-licensed native macOS menu-bar utility for capturing pixel-perfect iPhone screenshots over USB or Wi-Fi.

- [x] Alphabetical order within the section
- [x] Open-source badge links to the public repository
- [x] Freeware and Native badges included
- [x] Website and source links verified
- [x] One README entry only