### PR TITLE
Add Cropy.it to Screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -718,6 +718,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [capcap](https://capcap.skyrin.fun) - Native menu bar screenshot tool with double-tap Command capture, annotation, scrolling capture, beautify, pinning, and image-host upload. [![Open-Source Software][OSS Icon]](https://github.com/realskyrin/capcap) ![Freeware][Freeware Icon]
 * [CleanShot X](https://cleanshot.com/) - Discover a superior way to capture your Mac's screen.
 * [CloudApp](https://www.getcloudapp.com/) - Work at the speed of sight. ![Freeware][Freeware Icon]
+* [Cropy.it](https://cropy.it/) - Screenshot & clipboard app with annotation, blur, OCR, scrolling capture and a searchable clipboard history. 100% local
 * [Dropbox](https://www.dropbox.com/) - Dropbox app offers easy screenshot capturing and sharing ![Freeware][Freeware Icon]
 * [Flameshot](https://github.com/flameshot-org/flameshot) - Powerful yet simple to use screenshot software. ![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]
 * [Lightshot](https://app.prntscr.com/) - The fastest way to take a customizable screenshot. ![Freeware][Freeware Icon]


### PR DESCRIPTION
Native macOS & Windows screenshot + clipboard app: capture, annotate, blur, OCR, scrolling capture and searchable clipboard history. 100% local.

NOTE: A similar PR may already be submitted! Please search among the Pull request before creating one.

### Types of Changes

**What types of changes does your PR introduce?** Put an x in all boxes that apply

- [X] New addition to list
- [ ] Fixing bug in existing item in list
- [ ] Removing item from list
- [ ] Changing structure (organization) of list

### Proposed Changes

**Describe each of your changes here to communicate to the maintainers why we should accept this pull request.**

1. 1. Adds **Cropy.it** to the **Screenshot** section — a native screenshot & clipboard app for macOS (and Windows). It captures a region, window, full screen or an entire scrolling page, then lets you annotate (arrows, shapes, text, numbered badges), blur/pixelate sensitive data, pull text out of images via OCR, and keeps a searchable clipboard history. Everything runs 100% locally — no account, no cloud, no tracking. It fits right next to CleanShot X, Shottr and Xnapper.


### PR Checklist

Put an x in the boxes once you've completed each step. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- [X] I have read the CONTRIBUTING guide
- [X] I have explained why this PR is important
- [X] I have added necessary documentation (if appropriate)

### Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
