### PR TITLE
Add claude-session-tint to Developer

### DIFF
--- a/command-line-apps-ja.md
+++ b/command-line-apps-ja.md
@@ -111,6 +111,7 @@ Awesome Command Line Apps
 
 ## 開発者向け
 
+* [claude-session-tint](https://github.com/dotcomjack/claude-session-tint) - Terminal.appの各ウィンドウをプロジェクトごとに色分けし、目を離している間にClaude Codeの応答が届いたウィンドウを点灯させ、フォーカスすると元に戻す。 [![Open-Source Software][OSS Icon]](https://github.com/dotcomjack/claude-session-tint) ![Freeware][Freeware Icon]
 * [Fruitbox](https://github.com/urjitbhatia/fruitbox) - Apple siliconのネイティブcontainerランタイム向けDocker Compose互換CLI。 [![Open-Source Software][OSS Icon]](https://github.com/urjitbhatia/fruitbox) ![Freeware][Freeware Icon]
 * [httpie](https://httpie.org) - モダンなコマンドラインHTTPクライアント。 [![OSS][OSS Icon]](https://github.com/jakubroztocil/httpie) ![Freeware][Freeware Icon]
 * [JSON Schema CLI](https://github.com/sourcemeta/jsonschema) - JSON Schemaを扱うためのCLI。フォーマット、リンティング、テスト、バンドリングなど、ローカル開発からCI/CDパイプラインまでカバー。 [![Open-Source Software][OSS Icon]](https://github.com/sourcemeta/jsonschema) ![Freeware][Freeware Icon]

--- a/command-line-apps-ko.md
+++ b/command-line-apps-ko.md
@@ -111,6 +111,7 @@
 
 ## 개발자 도구
 
+* [claude-session-tint](https://github.com/dotcomjack/claude-session-tint) - 각 Terminal.app 창을 프로젝트별로 색칠하고, 다른 곳을 보는 동안 Claude Code 응답이 도착한 창을 밝게 표시하며 포커스하면 원래대로 되돌림. [![Open-Source Software][OSS Icon]](https://github.com/dotcomjack/claude-session-tint) ![Freeware][Freeware Icon]
 * [Fruitbox](https://github.com/urjitbhatia/fruitbox) - Apple silicon의 기본 container 런타임을 위한 Docker Compose 호환 CLI. [![Open-Source Software][OSS Icon]](https://github.com/urjitbhatia/fruitbox) ![Freeware][Freeware Icon]
 * [httpie](https://httpie.org) - 당신을 미소 짓게 할 명령줄 HTTP 클라이언트. [![Open-Source Software][OSS Icon]](https://github.com/jakubroztocil/httpie) ![Freeware][Freeware Icon]
 * [JSON Schema CLI](https://github.com/sourcemeta/jsonschema) - JSON 스키마 작업을 위한 CLI. 포맷팅, 린팅, 테스트, 번들링 등을 지원하며 로컬 개발 및 CI/CD 파이프라인에서 사용 가능. [![Open-Source Software][OSS Icon]](https://github.com/sourcemeta/jsonschema) ![Freeware][Freeware Icon]

--- a/command-line-apps-zh.md
+++ b/command-line-apps-zh.md
@@ -111,6 +111,7 @@
 
 ## 开发者工具
 
+* [claude-session-tint](https://github.com/dotcomjack/claude-session-tint) - 按项目为每个 Terminal.app 窗口着色，当某个 Claude Code 会话在你不在时返回结果便将其点亮，重新聚焦后自动恢复。 [![Open-Source Software][OSS Icon]](https://github.com/dotcomjack/claude-session-tint) ![Freeware][Freeware Icon]
 * [Fruitbox](https://github.com/urjitbhatia/fruitbox) - 适用于 Apple silicon 原生 container 运行时、兼容 Docker Compose 的 CLI。 [![Open-Source Software][OSS Icon]](https://github.com/urjitbhatia/fruitbox) ![Freeware][Freeware Icon]
 * [httpie](https://httpie.org) - HTTPie 是一个让你微笑的命令行 HTTP 客户端。 [![Open-Source Software][OSS Icon]](https://github.com/jakubroztocil/httpie) ![Freeware][Freeware Icon]
 * [JSON Schema CLI](https://github.com/sourcemeta/jsonschema) - The CLI for working with JSON Schema. Covers formatting, linting, testing, bundling, and more for both local development and CI/CD pipelines. [![Open-Source Software][OSS Icon]](https://github.com/sourcemeta/jsonschema) ![Freeware][Freeware Icon]

--- a/command-line-apps.md
+++ b/command-line-apps.md
@@ -111,6 +111,7 @@ A curated list of useful command line apps
 
 ## Developer
 
+* [claude-session-tint](https://github.com/dotcomjack/claude-session-tint) - Tints each Terminal.app window by project and brightens the one whose Claude Code response landed while you were looking elsewhere, clearing it again on focus. [![Open-Source Software][OSS Icon]](https://github.com/dotcomjack/claude-session-tint) ![Freeware][Freeware Icon]
 * [Fruitbox](https://github.com/urjitbhatia/fruitbox) - Docker Compose-compatible CLI for Apple's native container runtime on Apple silicon. [![Open-Source Software][OSS Icon]](https://github.com/urjitbhatia/fruitbox) ![Freeware][Freeware Icon]
 * [httpie](https://httpie.org) - Modern command line HTTP client. [![OSS][OSS Icon]](https://github.com/jakubroztocil/httpie) ![Freeware][Freeware Icon]
 * [JSON Schema CLI](https://github.com/sourcemeta/jsonschema) - The CLI for working with JSON Schema. Covers formatting, linting, testing, bundling, and more for both local development and CI/CD pipelines. [![Open-Source Software][OSS Icon]](https://github.com/sourcemeta/jsonschema) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds [claude-session-tint](https://github.com/dotcomjack/claude-session-tint) to the Developer section of the command line apps list.

It colours each macOS Terminal.app window by project and brightens whichever one finished a Claude Code response while you were looking somewhere else, clearing on focus. Useful when several sessions are running at once and you cannot tell which is waiting on you.

MIT, macOS only, no network calls.

Guidelines checked:
- Not a duplicate, searched the list and open PRs.
- Alphabetical: sorts above `Fruitbox` at the head of Developer.
- One sentence, matching the surrounding entry style and icon format.
- Synced across all four language files (`command-line-apps.md`, `-zh`, `-ja`, `-ko`).
- No trailing whitespace.

Disclosure per the AI-assisted contributions section: the edit was prepared with an AI agent, and follows the repository's category, ordering, wording and multilingual sync rules.