### PR TITLE
Add Fanctl (smart fan control for Apple Silicon)

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -1390,6 +1390,7 @@ Awesome Mac
 * [SwiftQuit](https://swiftquit.com/) - 关闭窗口时自动退出 macOS 应用程序。![Freeware][Freeware Icon] [![Open-Source Software][OSS Icon]](https://github.com/onebadidea/swiftquit)
 * [SwiftMTP](https://github.com/Neighbor-Z/SwiftMTP) - 用于在 Mac 与 Android 设备之间浏览和传输文件的开源 MTP 管理工具。 [![Open-Source Software][OSS Icon]](https://github.com/Neighbor-Z/SwiftMTP) ![Freeware][Freeware Icon]
 * [TG Pro](https://www.tunabellysoftware.com/tgpro/) - 温度监控，风扇控制和硬件诊断，帮助您保持 Mac的 凉爽和健康。
+* [Fanctl](https://github.com/TomEageer/fanctl) - Apple Silicon 智能风扇控制，自学习温控算法，菜单栏实时温度曲线。 [![Open-Source Software][OSS Icon]](https://github.com/TomEageer/fanctl) ![Freeware][Freeware Icon]
 * [Tuxera NTFS](http://www.tuxera.com/products/tuxera-ntfs-for-mac/) - Mac 上的 NTFS 文件系统驱动。
 
 ### 窗口管理

--- a/README.md
+++ b/README.md
@@ -1588,6 +1588,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [SwiftMTP](https://github.com/Neighbor-Z/SwiftMTP) - Open-source MTP device manager for browsing and transferring files between Mac and Android devices. [![Open-Source Software][OSS Icon]](https://github.com/Neighbor-Z/SwiftMTP) ![Freeware][Freeware Icon]
 * [Core Tunnel](https://codinn.com/tunnel/) - Application for managing SSH connections. [![App Store][app-store Icon]](https://apps.apple.com/us/app/core-tunnel/id1354318707?platform=mac)
 * [TG Pro](https://www.tunabellysoftware.com/tgpro/) - Temperature monitoring, fan control & hardware diagnostics to help keep your Mac cool and healthy.
+* [Fanctl](https://github.com/TomEageer/fanctl) - Smart fan control for Apple Silicon with a self-learning thermal controller. [![Open-Source Software][OSS Icon]](https://github.com/TomEageer/fanctl) ![Freeware][Freeware Icon]
 * [Time Machine Inspector](https://github.com/probablykasper/time-machine-inspector) - Find out what's hogging up your Time Machine backups. [![Open-Source Software][OSS Icon]](https://github.com/probablykasper/time-machine-inspector) ![Freeware][Freeware Icon]
 * [Tuxera NTFS](https://www.tuxera.com/products/tuxera-ntfs-for-mac/) - Full read-write compatibility with NTFS-formatted drives on a Mac.
 * [Overkill](https://github.com/KrauseFx/overkill-for-mac) - Stop iTunes from opening when you connect your iPhone.


### PR DESCRIPTION
Adds [Fanctl](https://github.com/TomEageer/fanctl) — free, open-source (MIT) smart fan control for Apple Silicon Macs (M1–M4): self-learning thermal controller (power feedforward + PI + anti-windup), menu bar app with temperature/RPM history chart, localized in 8 languages. Added to both README.md and README-zh.md next to the other fan utility.