### PR TITLE
Add Pace — on-device macOS voice agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -821,6 +821,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Fluent](https://fluentmac.app) - AI assistant that works across apps with model and context integration.
 * [Gemini Collector](https://github.com/FirenzeLor/gemini-collector) - Back up Google Gemini conversations, attachments, and AI-generated media locally as JSON. [![Open-Source Software][OSS Icon]](https://github.com/FirenzeLor/gemini-collector) ![Freeware][Freeware Icon]
 * [GroAsk](https://groask.com) - Menu bar launcher that sends selected text to AI assistants and CLI agents.
+* [Pace](https://heypace.app) - On-device macOS voice agent that can see the screen and take actions locally. Comparison of the field: https://heypace.app/compared. ![Freeware][Freeware Icon]
 * [RecurseChat](https://recurse.chat) - Local-first AI chat app with customizable workflows.
 * [Runtime](https://github.com/runtime-org/runtime) - AI taskmate and take control of the web & your office tools
 * [TokenMeter](https://priyans-hu.github.io/tokenmeter/) - Track Claude Code usage, rate limits, costs, and activity heatmaps. [![Open-Source Software][OSS Icon]](https://github.com/Priyans-hu/tokenmeter) ![Freeware][Freeware Icon]


### PR DESCRIPTION
## Add Pace (HeyPace)

On-device macOS voice agent that can see the screen and take actions locally (privacy-first).

- Site: https://heypace.app
- Field comparison of Mac agents: https://heypace.app/compared

Suggested line under **AI Tools**:
- [Pace](https://heypace.app) - On-device macOS voice agent that can see the screen and take actions locally.