### PR TITLE
Add Boomkey to Input Methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -1041,6 +1041,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Type2Phone](https://www.houdah.com/type2Phone/) - Use Your Mac as Keyboard for iPhone, iPad & Apple TV.
 * [betterglobekey](https://github.com/Serpentiel/betterglobekey) - Make macOS Globe key great again! [![Open-Source Software][OSS Icon]](https://github.com/Serpentiel/betterglobekey) ![Freeware][Freeware Icon]
 * [InputSourcePro](https://inputsource.pro/) - Tool for automatically switching input sources by app or website. [![Open-Source Software][OSS Icon]](https://github.com/runjuu/InputSourcePro) ![Freeware][Freeware Icon]
+* [Boomkey](https://boomkey.pro) - Fixes text typed in the wrong keyboard layout: converts selected text or the last word with a hotkey, or corrects layout automatically as you type.
 
 ## Voice-to-Text
 


### PR DESCRIPTION
  What this adds

  Boomkey (https://boomkey.pro)- a native macOS menu bar app that fixes text typed in the wrong keyboard layout. If youtype in two or more languages, you know the problem: you write "hello" and get "руддщ" because the layout was still Cyrillic.

  What it does:
  - Converts selected text between any two installed layouts with a hotkey (double-tap Shift by default) — a word, a sentence, or a whole paragraph, in place.
  - Can also auto-correct the layout as you type.
  - Works system-wide in any app; supports 50+ languages and layouts.

  Details:
  - Native Swift, no Electron; tiny footprint.
  - Free tier included; one-time purchase for unlimited (no subscription).
  
  Added to Input Methods, next to related tools (LangSwitcher, InputSourcePro).