### PR TITLE
Add Vanpelt Studio to Audio and Video Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -979,6 +979,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [trax](https://github.com/nbonamy/trax) - Music library manager with audio conversion and tag editing. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/nbonamy/trax)
 * [Tiny Player](https://www.catnapgames.com/tiny-player-for-mac/) - As the name suggests, a tiny player. ![Freeware][Freeware Icon]
 * [Tuneful](https://www.tuneful.dev) - Controller for Spotify and Apple Music from the menu bar or mini player. [![App Store][app-store Icon]](https://apps.apple.com/app/tuneful/id6739804295?platform=mac)
+* [Vanpelt Studio](https://vanpelt.studio) - Storytelling copilot for long-form video; checks your footage against your story plan before you edit.
 * [VLC](https://www.videolan.org/index.html) - Open-source multimedia player for most audio, video, and streaming formats. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/videolan/vlc)
 * [VOX Player](https://vox.rocks/mac-music-player) - High-definition audio player for Mac and iPhone. Music just sounds better! ![Freeware][Freeware Icon]
 * [VidCrop](https://apps.apple.com/app/VidCrop/6752624705?platform=mac) - A simple video cropping tool that supports multiple formats and precise trimming.


### PR DESCRIPTION
## What is this app?

[Vanpelt Studio](https://vanpelt.studio) is a local-first macOS (and Windows) desktop app for solo YouTube creators making long-form video. It holds the planned story (beat sheet, script, shot list) and the captured footage (on-device Whisper transcripts + a visual index) side by side, and checks one against the other before editing starts — surfacing which story beats are covered and which need a pickup shot. It never uploads footage and never cuts it; it's the pre-edit planning/verification layer, not an editor.

## Entry

Added alphabetically to **Audio and Video Tools** (between Tuneful and VLC), matching the existing format. No OSS/Freeware marks — it's proprietary (currently in beta).

Disclosure: I'm the maker. Happy to adjust the wording or placement however you prefer.