### PR TITLE
Add AIUsageBar to Menu Bar Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1216,6 +1216,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 ### Menu Bar Tools
 
 * [Agent Island](https://github.com/tristan666666/agent-island) - MacBook notch companion for Claude Code and Codex sessions, showing live status and auto-resuming selected long-running tasks. [![Open-Source Software][OSS Icon]](https://github.com/tristan666666/agent-island) ![Freeware][Freeware Icon]
+* [AIUsageBar](https://aiusagebar.com) - Native AI usage tracker for your Mac menu bar with rate limits, reset countdowns, and spend tracking for Claude, ChatGPT, Codex, Cursor, Gemini, Copilot, and 47+ AI tools. ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [Anvil](https://anvilformac.com/) - Tool for serving local static sites and Rack apps with simple URLs. ![Freeware][Freeware Icon]
 * [Atoll](https://github.com/Ebullioscopic/Atoll) - Turns the notch into a Dynamic Island-style hub for media controls, live activities, and quick utilities. [![Open-Source Software][OSS Icon]](https://github.com/Ebullioscopic/Atoll)
 * [Bartender](https://www.macbartender.com) - Organize or hide menu bar icons on your Mac.


### PR DESCRIPTION
Adds AIUsageBar to the Menu Bar Tools section.

AIUsageBar is a native macOS menu bar app that tracks AI usage, rate limits, reset windows, and spend across Claude, ChatGPT, Codex, Cursor, Gemini, Copilot, and 47+ other AI provider tools. It has a free tier plus an optional one-time paid upgrade.

### Types of Changes

**What types of changes does your PR introduce?** Put an x in all boxes that apply

- [x] New addition to list
- [ ] Fixing bug in existing item in list
- [ ] Removing item from list
- [ ] Changing structure (organization) of list

### Proposed Changes

**Describe each of your changes here to communicate to the maintainers why we should accept this pull request.**

1. Added [AIUsageBar](https://aiusagebar.com) alphabetically between "Agent Island" and "Anvil" in the Menu Bar Tools section. It fits alongside similar existing entries like ChargeMonitor and CodexIsland, providing menu-bar visibility into AI tool usage/rate limits.

### PR Checklist

Put an x in the boxes once you've completed each step. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important
- [x] I have added necessary documentation (if appropriate)

### Further Comments
