### PR TITLE
Add ArtDeck to Design Tools

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -648,6 +648,7 @@ Awesome Mac
 * [Affinity Photo](https://affinity.serif.com/en-us/photo/) - Mac用のプロフェッショナルな画像編集ソフトウェア。
 * [Alchemy](http://al.chemy.org/) - コンセプトアートの作成に重点を置いた、実験的なオープンソースのドローイングアプリケーション。 [![Open-Source Software][OSS Icon]](http://svn.al.chemy.org/)
 * [Amadine](https://amadine.com) - グラフィックデザイナー向けの直感的なインターフェースを備えたベクタードローイングアプリ。
+* [ArtDeck](https://getartdeck.com/) - 色、明度、構図、動きを研究するためのツールを備えたビジュアルリファレンスボード。 [![App Store][app-store Icon]](https://apps.apple.com/app/artdeck/id6764851724?platform=mac)
 * [Art Text 3](https://www.belightsoft.com/art-text/) - レタリング、タイポグラフィ、テキストエフェクト用のグラフィックデザインソフトウェア。
 * [Blender](https://www.blender.org/) - 無料でオープンな3D制作ソフトウェア。 [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://developer.blender.org/)
 * [Colorpicker](https://colorpicker.fr/) - ピッキング機能付きの完全なオープンソースカラー操作ツール! [![Open-Source Software][OSS Icon]](https://github.com/toinane/colorpicker) ![Freeware][Freeware Icon]

--- a/README-ko.md
+++ b/README-ko.md
@@ -541,6 +541,7 @@ Awesome Mac
 * [Acorn](https://secure.flyingmeat.com/acorn/) - 인간을 위해 만들어진 훌륭한 macOS용 이미지 및 사진 편집기.
 * [Affinity Designer](https://affinity.serif.com/en-us/designer/) - 전문적인 그래픽 디자인 소프트웨어.
 * [Affinity Photo](https://affinity.serif.com/en-us/photo/) - 전문적인 이미지 편집 소프트웨어.
+* [ArtDeck](https://getartdeck.com/) - 색상, 명도, 구도, 움직임을 연구하기 위한 도구를 갖춘 비주얼 레퍼런스 보드. [![App Store][app-store Icon]](https://apps.apple.com/app/artdeck/id6764851724?platform=mac)
 * [Blender](https://www.blender.org/) - 무료 오픈 소스 3D 제작 소프트웨어. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://developer.blender.org/)
 * [Colorpicker](https://colorpicker.fr/) - 오픈 소스 색상 조작 및 선택 도구. [![Open-Source Software][OSS Icon]](https://github.com/toinane/colorpicker) ![Freeware][Freeware Icon]
 * [darktable](https://www.darktable.org) - 오픈 소스 사진 워크플로우 및 RAW 현상 프로그램. [![Open-Source Software][OSS Icon]](https://github.com/darktable-org/darktable) ![Freeware][Freeware Icon]

--- a/README-zh.md
+++ b/README-zh.md
@@ -431,6 +431,7 @@ Awesome Mac
 * [Affinity Photo](https://affinity.serif.com/en-us/photo/) - 光栅图像设计工具，可以替代 Adobe PS 图象处理软件。
 * [Alchemy](http://al.chemy.org/) - 开源的绘图工具软件，用于素描、会话以及一种新的绘图方式。[![Open-Source Software][OSS Icon]](http://svn.al.chemy.org/)
 * [Amadine](https://amadine.com) - 一款矢量绘图应用程序，将图形设计师所需的一切包装在一个整洁直观的界面中。
+* [ArtDeck](https://getartdeck.com/) - 视觉参考板，配备用于研究色彩、明度、构图和动态的工具。 [![App Store][app-store Icon]](https://apps.apple.com/app/artdeck/id6764851724?platform=mac)
 * [Art Text 3](https://www.belightsoft.com/art-text/) - 生成各种特效字体。
 * [Blender](https://www.blender.org/) - 全功能可扩展的跨平台 3D 内容套件。[![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://developer.blender.org/)
 * [Colorpicker](https://colorpicker.fr/) - 一个完整的开源颜色处理工具！ [![Open-Source Software][OSS Icon]](https://github.com/toinane/colorpicker) ![Freeware][Freeware Icon]

--- a/README.md
+++ b/README.md
@@ -648,6 +648,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Affinity Photo](https://affinity.serif.com/en-us/photo/) - Professional image editing software for Mac.
 * [Alchemy](https://al.chemy.org/) - Experimental, open-source drawing application with an emphasis on creating conceptual art. [![Open-Source Software][OSS Icon]](https://svn.al.chemy.org/)
 * [Amadine](https://amadine.com) - Vector drawing app with an intuitive interface for graphic designers.
+* [ArtDeck](https://getartdeck.com/) - Visual reference boards with tools for studying color, value, composition, and motion. [![App Store][app-store Icon]](https://apps.apple.com/app/artdeck/id6764851724?platform=mac)
 * [Art Text 3](https://www.belightsoft.com/art-text/) - Graphic design software for lettering, typography, and text effects.
 * [Blender](https://www.blender.org/) - Free and open 3D creation software. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://developer.blender.org/)
 * [Colorpicker](https://colorpicker.fr/) - Colorpicker is a complete open-source colors manipulation tool with picking! [![Open-Source Software][OSS Icon]](https://github.com/toinane/colorpicker) ![Freeware][Freeware Icon]


### PR DESCRIPTION
### Types of Changes

- [x] New addition to list
- [ ] Fixing bug in existing item in list
- [ ] Removing item from list
- [ ] Changing structure (organization) of list

### Proposed Changes

Add ArtDeck to **Design and Product → Design Tools** in the English, Chinese, Japanese, and Korean lists.

ArtDeck is a visual reference board for artists and designers, with tools for studying color, value, composition, and motion. It is available for Mac through the App Store as a one-time purchase. I am the developer.

### PR Checklist

- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important
- [x] I have added necessary documentation

### Validation

- Confirmed the entry appears once in each of the four localized lists.
- Confirmed alphabetical placement in each Design Tools section.
- Ran `git diff --check`.
- Verified the product and App Store links resolve successfully.
