### PR TITLE
Add ZBee to Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1116,6 +1116,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [SubManager](https://submanager.app) - Subscription tracker with renewal reminders. [![App Store][app-store Icon]](https://apps.apple.com/app/submanager-subscription-list/id1632853914?platform=mac)
 * [SubList](https://apps.apple.com/app/sublist-subscription-list/id6757860829?platform=mac) - Track subscriptions, renewals, and spending in one place with reminders, analytics, and iCloud sync.
 * [StockDock](https://github.com/simonsruggi/StockDock) - Menu bar app for real-time stocks, ETFs, crypto and portfolio P&L. Privacy-first, no account, multi-currency. [![Open-Source Software][OSS Icon]](https://github.com/simonsruggi/StockDock) ![Freeware][Freeware Icon]
+* [ZBee](https://zbee.app) - Retirement planner that measures the most you can safely spend per year. Computes locally with taxes, RMDs and Social Security; your data never leaves your Mac. ![Native App][Native Icon]
 
 ## Encryption
 


### PR DESCRIPTION
Adds ZBee (https://zbee.app) to the Finance section - a native Mac app that measures the most you can safely spend per year in retirement. All computation is local (taxes, RMDs, Social Security, Monte Carlo plus a replay through every market sequence since 1928); it runs free on sample data with no account, so it's easy to evaluate. One line, alphabetical-end of the section, native-app icon per the legend.