### PR TITLE
Add VoxFlow - 100% On-Device AI Voice Dictation App for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1001,6 +1001,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Segue](https://segue.npearce.me/) - Broadcast audio playout with crossfade, trim, ramp timers, and pause beds for live radio and podcasts. [![Open-Source Software][OSS Icon]](https://github.com/pearcenuk/Segue) ![Freeware][Freeware Icon]
 * [Stargate DAW](https://github.com/stargatedaw/stargate) - An all-in-one digital audio workstation (DAW) and plugin suite. [![Open-Source Software][OSS Icon]](https://github.com/aria2) ![Freeware][Freeware Icon]
 * [SystemEQ for Mac](https://denzam.github.io/SystemEQ-for-Mac/) - Free, open-source system-wide parametric equalizer with AutoEQ presets, hearing calibration, and real-time visualization. [![Open-Source Software][OSS Icon]](https://github.com/denzam/SystemEQ-for-Mac) ![Freeware][Freeware Icon]
+* [VoxFlow](https://github.com/ameerhmz/VoxFlow) - Native, 100% on-device AI voice dictation app for macOS built with Apple Speech and FoundationModels. [![Open-Source Software][OSS Icon]](https://github.com/ameerhmz/VoxFlow) ![Freeware][Freeware Icon]
 
 ## Download Management Tools
 


### PR DESCRIPTION
Adds VoxFlow (https://github.com/ameerhmz/VoxFlow) to the Audio Record and Process section. VoxFlow is a native open-source macOS voice dictation app using Apple Speech & FoundationModels.