### PR TITLE
Add Gibson to General Tools

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1335,6 +1335,7 @@ Awesome Mac
 * [Deskmark](https://apps.apple.com/app/Deskmark/6755948110?platform=mac) - デスクトップにウォーターマークを追加、動画録画に最適。 [![App Store][app-store Icon]](https://apps.apple.com/app/Deskmark/6755948110?platform=mac)
 * [Etcher](https://www.balena.io/etcher/) - OSイメージをSDカードやUSBドライブに安全かつ簡単に書き込み。 [![Open-Source Software][OSS Icon]](https://github.com/balena-io/etcher) ![Freeware][Freeware Icon]
 * [Equinox](https://github.com/rlxone/Equinox) - macOS用のダイナミック壁紙を作成。 ![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/us/app/equinox-create-wallpaper/id1591510203?platform=mac)
+* [Gibson](https://github.com/PerfectoWeb/Gibson) - 実際のシステム情報で動くハッカー映画風ダッシュボードのスクリーンセーバー。 [![Open-Source Software][OSS Icon]](https://github.com/PerfectoWeb/Gibson) ![Freeware][Freeware Icon]
 * [HTTrack](http://www.httrack.com) - Webサイト全体をダウンロードしてオフラインブラウジングするのに便利なツール。 ![Freeware][Freeware Icon]
 * [Latest](https://github.com/mangerlahn/Latest) - あらゆるソースからインストールしたアプリが最新かどうかをチェックする小さなアプリ。 [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/mangerlahn/Latest)
 * [Lungo](https://sindresorhus.com/lungo) - Macのスリープを防止。 [![App Store][app-store Icon]](https://apps.apple.com/us/app/lungo/id1263070803?platform=mac)

--- a/README-zh.md
+++ b/README-zh.md
@@ -1153,6 +1153,7 @@ Awesome Mac
 * [Grayscale Mode](https://github.com/rkbhochalya/grayscale-mode) - 通过菜单栏或快捷键快速切换灰度显示。 [![Open-Source Software][OSS Icon]](https://github.com/rkbhochalya/grayscale-mode) ![Freeware][Freeware Icon]
 * [FnKeyboard](https://github.com/kotique123/FnKeyboard) - 在菜单栏快速调用功能键。 [![Open-Source Software][OSS Icon]](https://github.com/kotique123/FnKeyboard) ![Freeware][Freeware Icon]
 * [Freeter](https://freeter.io/) - 按项目整理应用、链接和文件的工作台。 [![Open-Source Software][OSS Icon]](https://github.com/FreeterApp/Freeter) ![Freeware][Freeware Icon]
+* [Gibson](https://github.com/PerfectoWeb/Gibson) - 用真实系统数据驱动的黑客电影风格仪表盘屏保。 [![Open-Source Software][OSS Icon]](https://github.com/PerfectoWeb/Gibson) ![Freeware][Freeware Icon]
 * [Hammerspoon](http://www.hammerspoon.org/) - 功能强大的自动化工具，Lua 脚本驱动，支持窗口管理。[![Open-Source Software][OSS Icon]](https://github.com/Hammerspoon/hammerspoon) ![Freeware][Freeware Icon]
 * [HapticKey](https://github.com/niw/HapticKey/releases) - 为 Touch Bar 点击加入触觉反馈。 [![Open-Source Software][OSS Icon]](https://github.com/niw/HapticKey) ![Freeware][Freeware Icon]
 * [Hook for Mac](https://hookproductivity.com/) - 关联文件、邮件和笔记，方便快速跳转。

--- a/README.md
+++ b/README.md
@@ -1339,6 +1339,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Deskmark](https://apps.apple.com/app/Deskmark/6755948110?platform=mac) - Add watermarks to the desktop, ideal for recording videos. [![App Store][app-store Icon]](https://apps.apple.com/app/Deskmark/6755948110?platform=mac)
 * [Etcher](https://www.balena.io/etcher/) - Flash OS images to SD cards & USB drives, safely and easily. [![Open-Source Software][OSS Icon]](https://github.com/balena-io/etcher) ![Freeware][Freeware Icon]
 * [Equinox](https://github.com/rlxone/Equinox) - Create dynamic wallpapers for macOS. ![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/us/app/equinox-create-wallpaper/id1591510203?platform=mac)
+* [Gibson](https://github.com/PerfectoWeb/Gibson) - Screen saver that turns an idle Mac into a hacker film dashboard driven by real system telemetry. [![Open-Source Software][OSS Icon]](https://github.com/PerfectoWeb/Gibson) ![Freeware][Freeware Icon]
 * [HTTrack](https://www.httrack.com) - Useful tool for downloading a whole website and offline browsing. ![Freeware][Freeware Icon]
 * [Latest](https://github.com/mangerlahn/Latest) - A tiny app that checks if all your apps from any source are up to date. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/mangerlahn/Latest)
 * [Lungo](https://sindresorhus.com/lungo) - Prevent your Mac from going to sleep. [![App Store][app-store Icon]](https://apps.apple.com/us/app/lungo/id1263070803?platform=mac)


### PR DESCRIPTION
### Types of Changes

- [x] New addition to list
- [ ] Fixing bug in existing item in list
- [ ] Removing item from list
- [ ] Changing structure (organization) of list

### Proposed Changes

1. Adds **Gibson** to `Utilities > General Tools`, placed alphabetically between Equinox and HTTrack.

   Gibson is an open source macOS screen saver that turns an idle display into a hacker film dashboard, except the readings are real: it samples the process table, CPU load per core, memory pressure, swap, disk capacity and network throughput from the machine it runs on. Written in Swift against the system frameworks only, no dependencies and no package manager, MIT licensed. The bundle is universal, signed with a Developer ID and notarised by Apple, and there is a privacy switch that masks the host name, user name and addresses so it is safe to leave running on a lock screen.

2. Mirrors the same entry into `README-zh.md` and `README-ja.md`, translated and placed alphabetically in each, as the contributing guide asks.

### PR Checklist

- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important
- [x] I have added necessary documentation (if appropriate)

### Further Comments

`README-ko.md` is deliberately untouched: it has no General Tools section under Utilities, so there is nowhere to put the entry without inventing a category. Happy to add one if you would rather the Korean list matched the others.

Description is a single sentence in every list, badges follow the existing style, and no trailing whitespace was introduced.