### PR TITLE
Add Manticore Search to Databases

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -593,6 +593,7 @@ Awesome Mac
 * [FastoNoSQL](https://fastonosql.com/) - 様々なキーバリューデータベース用のクロスプラットフォームGUIクライアント。 [![OSS][OSS Icon]](https://github.com/fastogt/fastonosql) ![Freeware][Freeware Icon]
 * [FastoRedis](https://fastoredis.com/) - Redis用のクロスプラットフォーム・プロフェッショナルGUI管理ツール。 [![Open-Source Software][OSS Icon]](https://github.com/fastogt/fastoredis) ![Freeware][Freeware Icon]
 * [JackDB](https://www.jackdb.com/) - クエリとデータ駆動のインサイトのための安全で協調的な環境。 [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/yoichiro/chrome_mysql_admin)
+* [Manticore Search](https://manticoresearch.com/) - 全文検索、ベクトル検索、ハイブリッド検索に対応するオープンソースの検索データベース。 [![Open-Source Software][OSS Icon]](https://github.com/manticoresoftware/manticoresearch) ![Freeware][Freeware Icon]
 * [MDB Explorer](http://www.macexplorer.co/en/mdb-explorer.php) - MDBファイルを開き、読み取り、他のフォーマットやデータベースにエクスポートするMDBツール。
 * [Medis](http://getmedis.com) - Redis用のGUIマネージャー。 [![Open-Source Software][OSS Icon]](https://github.com/luin/medis)
 * [Mingo](https://mingo.io/) - 驚くべき機能を備えた使いやすいMongoDB GUI。

--- a/README-ko.md
+++ b/README-ko.md
@@ -510,6 +510,7 @@ Awesome Mac
 * [DB Browser for SQLite](http://sqlitebrowser.org/) - SQLite를 위한 공식 DB 브라우저. [![Open-Source Software][OSS Icon]](https://github.com/sqlitebrowser/sqlitebrowser) ![Freeware][Freeware Icon]
 * [DBeaver](https://dbeaver.io/) - 유니버설 SQL 클라이언트.
 * [DB Pro](https://dbpro.app) - SQL 데이터베이스를 조회하고 관리하는 클라이언트.
+* [Manticore Search](https://manticoresearch.com/) - 전체 텍스트 검색, 벡터 검색 및 하이브리드 검색을 위한 오픈 소스 검색 데이터베이스. [![Open-Source Software][OSS Icon]](https://github.com/manticoresoftware/manticoresearch) ![Freeware][Freeware Icon]
 * [Navicat Premium](https://www.navicat.com/en/products/navicat-premium) - 데이터베이스 관리 도구.
 * [Paul](https://guillim.github.io/products/paul) - 기본 읽기 전용으로 데이터베이스에서 빠르게 답을 찾을 수 있게 해주는 AI 우선 PostgreSQL 클라이언트.
 * [Postico](https://eggerapps.at/postico/) - 현대적인 PostgreSQL 클라이언트.

--- a/README-zh.md
+++ b/README-zh.md
@@ -383,6 +383,7 @@ Awesome Mac
 * [ElectroCRUD](http://garrylachman.github.io/ElectroCRUD/) - MySQL 数据库 CRUD 应用程序。[![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/garrylachman/ElectroCRUD)
 * [Sequel Pro](https://github.com/sequelpro/sequelpro) - 一个 MySQL 数据库管理软件。[![Open-Source Software][OSS Icon]](https://github.com/sequelpro/sequelpro) ![Freeware][Freeware Icon]
 * [JackDB](https://www.jackdb.com/) - 直接的 SQL 访问你所有的数据，无论在哪里。[![Open-Source Software][OSS Icon]](https://github.com/yoichiro/chrome_mysql_admin) ![Freeware][Freeware Icon]
+* [Manticore Search](https://manticoresearch.com/) - 用于全文、向量和混合搜索的开源搜索数据库。 [![Open-Source Software][OSS Icon]](https://github.com/manticoresoftware/manticoresearch) ![Freeware][Freeware Icon]
 * [medis](http://getmedis.com) - 漂亮的 Redis 管理软件。[![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/luin/medis)
 * [MongoDB](https://www.mongodb.com) - 一个基于分布式文件存储的数据库。 [![Open-Source Software][OSS Icon]](https://github.com/gcollazo/mongodbapp) ![Freeware][Freeware Icon] [![Awesome List][awesome-list Icon]](https://github.com/ramnes/awesome-mongodb#desktop)
 * [MongoBooster](http://www.mongobooster.com/) - MongoDB 图形化管理软件，内嵌 MongoShell，ES6 语法，流畅查询及智能感知。![Freeware][Freeware Icon]

--- a/README.md
+++ b/README.md
@@ -593,6 +593,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [FastoNoSQL](https://fastonosql.com/) - Cross-platform GUI client for various key-value databases. [![OSS][OSS Icon]](https://github.com/fastogt/fastonosql) ![Freeware][Freeware Icon]
 * [FastoRedis](https://fastoredis.com/) - Cross-platform professional GUI management tool for Redis. [![Open-Source Software][OSS Icon]](https://github.com/fastogt/fastoredis) ![Freeware][Freeware Icon]
 * [JackDB](https://www.jackdb.com/) - Secure, collaborative environment for your queries and data-driven insights. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/yoichiro/chrome_mysql_admin)
+* [Manticore Search](https://manticoresearch.com/) - Open-source search database for full-text, vector, and hybrid search. [![Open-Source Software][OSS Icon]](https://github.com/manticoresoftware/manticoresearch) ![Freeware][Freeware Icon]
 * [MDB Explorer](https://www.macexplorer.co/en/mdb-explorer.php) - MDB tool to open, read, export your MDB files to other formats and databases.
 * [Medis](https://getmedis.com) - GUI Manager for Redis. [![Open-Source Software][OSS Icon]](https://github.com/luin/medis)
 * [Mingo](https://mingo.io/) - Easy to use MongoDB GUI with mind-blowing features.


### PR DESCRIPTION
Add the open-source search database to the English, Chinese, Japanese, and Korean database sections.

### Types of Changes

**What types of changes does your PR introduce?** Put an x in all boxes that apply

- [x] New addition to list
- [ ] Fixing bug in existing item in list
- [ ] Removing item from list
- [ ] Changing structure (organization) of list

### Proposed Changes

Adds [Manticore Search](https://manticoresearch.com/) to the Databases section in the English, Chinese, Japanese, and Korean READMEs.

Manticore Search is an open-source search database for full-text, vector, and hybrid search. It supports macOS installation through Homebrew, making it useful to Mac developers building and testing search applications locally.

The entries follow each README's local ordering, wording, and badge conventions.

### PR Checklist

- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important
- [x] I have added necessary documentation (if appropriate)