### PR TITLE
Add Agent Process Manager

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1215,6 +1215,7 @@ Awesome Mac
 ### メニューバーツール
 
 * [Agent Island](https://github.com/tristan666666/agent-island) - MacBookのノッチにClaude CodeとCodexのセッション状態を表示し、選択した長時間タスクを自動再開できるツール。 [![Open-Source Software][OSS Icon]](https://github.com/tristan666666/agent-island) ![Freeware][Freeware Icon]
+* [Agent Process Manager](https://github.com/ozzyocak/agent-process-manager) - 残ったコーディングセッションやPlaywrightのプロセスグループを見つけて停止できる、ネイティブmacOSメニューバーアプリ。 [![Open-Source Software][OSS Icon]](https://github.com/ozzyocak/agent-process-manager) ![Freeware][Freeware Icon]
 * [Anvil](https://anvilformac.com/) - ローカルの静的サイトやRackアプリを手軽に公開できるツール。 ![Freeware][Freeware Icon]
 * [Atoll](https://github.com/Ebullioscopic/Atoll) - ノッチを、メディア操作・ライブアクティビティ・クイックユーティリティをまとめたDynamic Island風ハブに変える。 [![Open-Source Software][OSS Icon]](https://github.com/Ebullioscopic/Atoll)
 * [Bartender](https://www.macbartender.com) - Macのメニューバーアイコンを整理または非表示。

--- a/README-ko.md
+++ b/README-ko.md
@@ -910,6 +910,7 @@ Awesome Mac
 ### 메뉴 바 도구
 
 * [Agent Island](https://github.com/tristan666666/agent-island) - MacBook 노치에서 Claude Code와 Codex 세션 상태를 보여주고 선택한 장시간 작업을 자동으로 이어서 실행하는 도구. [![Open-Source Software][OSS Icon]](https://github.com/tristan666666/agent-island) ![Freeware][Freeware Icon]
+* [Agent Process Manager](https://github.com/ozzyocak/agent-process-manager) - 남아 있는 코딩 세션과 Playwright 프로세스 그룹을 찾고 중지하는 네이티브 macOS 메뉴 바 앱. [![Open-Source Software][OSS Icon]](https://github.com/ozzyocak/agent-process-manager) ![Freeware][Freeware Icon]
 * [Anvil](https://anvilformac.com/) - 로컬 정적 사이트와 Rack 앱을 손쉽게 띄우는 도구. ![Freeware][Freeware Icon]
 * [Atoll](https://github.com/Ebullioscopic/Atoll) - 노치를 미디어 제어, 라이브 활동, 빠른 유틸리티를 담은 다이내믹 아일랜드형 허브로 바꿔준다. [![Open-Source Software][OSS Icon]](https://github.com/Ebullioscopic/Atoll)
 * [Bartender](https://www.macbartender.com/) - 메뉴 바 아이콘 정리 및 관리.

--- a/README-zh.md
+++ b/README-zh.md
@@ -1253,6 +1253,7 @@ Awesome Mac
 ### 菜单栏工具
 
 * [Agent Island](https://github.com/tristan666666/agent-island) - 将 MacBook 刘海变成 Claude Code 与 Codex 会话状态看板，并可自动续跑选定的长任务。 [![Open-Source Software][OSS Icon]](https://github.com/tristan666666/agent-island) ![Freeware][Freeware Icon]
+* [Agent Process Manager](https://github.com/ozzyocak/agent-process-manager) - 原生 macOS 菜单栏工具，用于查找并停止遗留的编码会话和 Playwright 进程组。 [![Open-Source Software][OSS Icon]](https://github.com/ozzyocak/agent-process-manager) ![Freeware][Freeware Icon]
 * [Anvil](https://anvilformac.com/) - 轻松托管本地静态网站和 Rack 应用的工具。 ![Freeware][Freeware Icon]
 * [Atoll](https://github.com/Ebullioscopic/Atoll) - 将刘海区域变成集媒体控制、实时活动和快捷工具于一体的动态面板。 [![Open-Source Software][OSS Icon]](https://github.com/Ebullioscopic/Atoll)
 * [Bartender](https://www.macbartender.com) - 组织或隐藏Mac上的菜单栏图标。

--- a/README.md
+++ b/README.md
@@ -1218,6 +1218,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 ### Menu Bar Tools
 
 * [Agent Island](https://github.com/tristan666666/agent-island) - MacBook notch companion for Claude Code and Codex sessions, showing live status and auto-resuming selected long-running tasks. [![Open-Source Software][OSS Icon]](https://github.com/tristan666666/agent-island) ![Freeware][Freeware Icon]
+* [Agent Process Manager](https://github.com/ozzyocak/agent-process-manager) - Native macOS menu bar app for finding and stopping stale coding-session and Playwright process groups. [![Open-Source Software][OSS Icon]](https://github.com/ozzyocak/agent-process-manager) ![Freeware][Freeware Icon]
 * [Anvil](https://anvilformac.com/) - Tool for serving local static sites and Rack apps with simple URLs. ![Freeware][Freeware Icon]
 * [Atoll](https://github.com/Ebullioscopic/Atoll) - Turns the notch into a Dynamic Island-style hub for media controls, live activities, and quick utilities. [![Open-Source Software][OSS Icon]](https://github.com/Ebullioscopic/Atoll)
 * [Bartender](https://www.macbartender.com) - Organize or hide menu bar icons on your Mac.


### PR DESCRIPTION
Adds Agent Process Manager to Menu Bar Tools. It is a native macOS menu bar utility for viewing CPU and memory usage and stopping stale coding-session and Playwright process groups. The linked project is free, open source, and ships a Universal 2 release.