### PR TITLE
Add MailTwin to Email Clients

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -894,6 +894,7 @@ Awesome Mac
 * [ElectronMail](https://github.com/vladimiry/ElectronMail) - Electronベースの非公式ProtonMailデスクトップクライアント。 [![Open-Source Software][OSS Icon]](https://github.com/vladimiry/ElectronMail) ![Freeware][Freeware Icon]
 * [Foxmail](http://www.foxmail.com/mac/en) - 高速メールクライアント。 ![Freeware][Freeware Icon]
 * [MailTags](https://smallcubed.com/) - タグを使用してメールを整理し、スケジュールを管理。
+* [MailTwin](https://www.mailtwin.ai/ja/) - Apple Mail の中で返信を作成。要点を入力すると、アカウントごとにローカルで学習した文体で完成した返信を書き上げます。8 つのプロバイダーから選び、自分の API キーを使用。
 * [Mailspring](https://getmailspring.com/) - 美しく、高速で、完全にオープンソースのメールクライアント。 [![Open-Source Software][OSS Icon]](https://github.com/Foundry376/Mailspring) ![Freeware][Freeware Icon]
 * [N1](https://www.nylas.com/) - 拡張可能なオープンソースのメールアプリ。開発者は無料、Proは月額$7。 ![Open-Source Software][OSS Icon]
 * [Nylas Mail](https://nylas.com/nylas-mail/) - モダンなWebテクノロジーで構築された拡張可能なデスクトップメールアプリ。 [![Open-Source Software][OSS Icon]](https://github.com/nylas/nylas-mail) ![Freeware][Freeware Icon]

--- a/README-ko.md
+++ b/README-ko.md
@@ -726,6 +726,7 @@ Awesome Mac
 * [Airmail](https://airmailapp.com/) - Mac용 빠른 메일 클라이언트.
 * [Canary Mail](https://canarymail.io/) - PGP 및 AI를 지원하는 안전한 이메일 앱. ![Freeware][Freeware Icon]
 * [Foxmail](http://www.foxmail.com/) - 빠른 이메일 클라이언트. ![Freeware][Freeware Icon]
+* [MailTwin](https://www.mailtwin.ai/ko/) - Apple Mail 안에서 답장을 작성. 요점만 입력하면 계정별로 로컬에서 학습한 문체로 완성된 메일을 작성해 줌. 여덟 개 제공업체 중 선택해 본인 API 키를 사용.
 * [Mailspring](https://getmailspring.com/) - 아름답고 빠른 오픈 소스 메일 클라이언트. [![Open-Source Software][OSS Icon]](https://github.com/Foundry376/Mailspring) ![Freeware][Freeware Icon]
 * [Spark](https://sparkmailapp.com/) - 스마트한 이메일 클라이언트. ![Freeware][Freeware Icon]
 * [Thunderbird](https://www.thunderbird.net/) - 무료 오픈 소스 이메일 클라이언트. [![Open-Source Software][OSS Icon]](https://github.com/mozilla/thunderbird) ![Freeware][Freeware Icon]

--- a/README-zh.md
+++ b/README-zh.md
@@ -687,6 +687,7 @@ Awesome Mac
 * [Foxmail](http://www.foxmail.com/mac/) - 快速的邮件客户端。![Freeware][Freeware Icon]
 * [网易邮箱大师](http://mail.163.com/dashi/) - 全平台的邮箱管理客户端，网易邮箱大师电脑版。 ![Freeware][Freeware Icon]
 * [MailTags](https://smallcubed.com/) - 管理和组织邮件，日程和标签进行分类邮件。
+* [MailTwin](https://www.mailtwin.ai/zh-Hans/) - 在 Apple Mail 里写回复：输入要点，自动生成完整邮件，写作风格按邮箱账户分别在本机从已发送邮件中学习，可选八家 AI 服务商并自带密钥。
 * [Nylas Mail](https://nylas.com/nylas-mail/) - 免费邮件客户端。  [![Open-Source Software][OSS Icon]](https://github.com/nylas/nylas-mail) ![Freeware][Freeware Icon]
 * [N1](https://www.nylas.com/) - 可以扩展的开源收费邮件客户端。
 * [Newton(原Cloudmagic)](https://newtonhq.com) - 界面非常简洁的一个邮件客户端。

--- a/README.md
+++ b/README.md
@@ -894,6 +894,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [ElectronMail](https://github.com/vladimiry/ElectronMail) - An Electron-based unofficial desktop client for ProtonMail. [![Open-Source Software][OSS Icon]](https://github.com/vladimiry/ElectronMail) ![Freeware][Freeware Icon]
 * [Foxmail](https://www.foxmail.com/mac/en) - Fast email client. ![Freeware][Freeware Icon]
 * [MailTags](https://smallcubed.com/) - Use tags to organize email and schedule.
+* [MailTwin](https://www.mailtwin.ai/) - Writes replies inside Apple Mail: type the points your answer needs to make and it produces the finished email in your own writing style, learned locally and separately for each mail account, using your own key from any of eight AI providers.
 * [Mailspring](https://getmailspring.com/) - A beautiful, fast, and fully open source mail client. [![Open-Source Software][OSS Icon]](https://github.com/Foundry376/Mailspring) ![Freeware][Freeware Icon]
 * [N1](https://www.nylas.com/) - Extensible, open-source mail app, free for developers and $7/month for Pro. ![Open-Source Software][OSS Icon]
 * [Nylas Mail](https://nylas.com/nylas-mail/) - Extensible desktop mail app built on the modern web.  [![Open-Source Software][OSS Icon]](https://github.com/nylas/nylas-mail) ![Freeware][Freeware Icon]


### PR DESCRIPTION
### Types of Changes

- [x] New addition to list
- [ ] Fixing bug in existing item in list
- [ ] Removing item from list
- [ ] Changing structure (organization) of list

### Proposed Changes

I'm the developer, so weigh this accordingly.

MailTwin isn't a mail client. It sits in the menu bar and works inside Apple Mail: you select a message, type the points your reply needs to make, and it writes the finished email the way that account normally writes. It learns that from your own sent mail, on your own Mac, and it learns each mail account separately, so the work address and the personal one don't end up sounding the same.

You bring your own API key. Eight providers, and two of them, Apple Intelligence and Ollama, run on the machine, so with those nothing is sent anywhere at all. There is no MailTwin server and no MailTwin account.

macOS 13 or later, one-time licence with a 30-day trial, 15 interface languages.

Placement: I put it beside MailTags, which is also an Apple Mail add-on rather than a standalone client, in alphabetical position. README-ko.md has no MailTags entry and its own ordering, so there it sits after Foxmail instead.

No icon on the line: it is neither open source nor freeware, which matches how Airmail, MailTags and Postbox are listed.

Happy to reword it or move it somewhere else if you'd rather.

### PR Checklist

- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important
- [x] I have added necessary documentation (if appropriate)

### Further Comments

Synced across README.md, README-zh.md, README-ja.md and README-ko.md in one pull request, as CONTRIBUTING asks. Each description is written in that language rather than translated word for word.