### PR TITLE
Add Yaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1070,6 +1070,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Voxt](https://github.com/hehehai/voxt) - Hold-to-talk voice input tool with AI transcription rules per app and URL, and built-in translation. [![Open-Source Software][OSS Icon]](https://github.com/hehehai/voxt) ![Freeware][Freeware Icon]
 * [Whispering](https://epicenter.md/whispering/) - Multi-provider speech-to-text with AI transformations and keyboard shortcuts. [![Open-Source Software][OSS Icon]](https://github.com/EpicenterHQ/epicenter/tree/main/apps/whispering) ![Freeware][Freeware Icon]
 * [Willow Voice](https://willowvoice.com/) - AI dictation with automatic editing, style-matching, and noise optimization.
+* [Yaps](https://yaps.ai) - Privacy-first dictation, transcription, and text-to-speech that runs entirely offline.
 
 ## Browsers
 


### PR DESCRIPTION
Adding Yaps (https://yaps.ai), an offline, on-device AI app for voice dictation, audio/video transcription, and text-to-speech. Speech recognition and speech synthesis both run locally on the device, no audio or text is sent to a server. Available for macOS, Windows, Linux, and Android. Happy to answer any questions or adjust placement/wording.