### PR TITLE
Add XCopy to clipboard tools

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -1256,6 +1256,7 @@ Awesome Mac
 * [SaneClip](https://saneclip.com) - 带历史记录、隐私保护和敏感信息检测的剪贴板管理器。 [![Open-Source Software][OSS Icon]](https://github.com/sane-apps/SaneClip) ![Freeware][Freeware Icon]
 * [SnippetCraft](https://getsnippetcraft.com) - 适用于 macOS 的全系统文本扩展、片段管理和剪贴板历史工具。
 * [uPaste](https://okaapps.com/product/1503649026) - 自动整理剪贴板历史和常用片段的管理器。 [![App Store][app-store Icon]](https://apps.apple.com/app/id1503649026?pt=119209922&ct=github)
+* [XCopy](https://kelvenbit.github.io/xcopy-app/) - 免费的 macOS 剪贴板管理器，支持文本、图片、链接和文件历史。 ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [Yippy](https://github.com/mattDavo/Yippy) - 具有用户友好界面的剪贴板管理器。 [![Open-Source Software][OSS Icon]](https://github.com/mattDavo/Yippy) ![Freeware][Freeware Icon]
 
 ### 菜单栏工具

--- a/README-zh.md
+++ b/README-zh.md
@@ -1256,7 +1256,7 @@ Awesome Mac
 * [SaneClip](https://saneclip.com) - 带历史记录、隐私保护和敏感信息检测的剪贴板管理器。 [![Open-Source Software][OSS Icon]](https://github.com/sane-apps/SaneClip) ![Freeware][Freeware Icon]
 * [SnippetCraft](https://getsnippetcraft.com) - 适用于 macOS 的全系统文本扩展、片段管理和剪贴板历史工具。
 * [uPaste](https://okaapps.com/product/1503649026) - 自动整理剪贴板历史和常用片段的管理器。 [![App Store][app-store Icon]](https://apps.apple.com/app/id1503649026?pt=119209922&ct=github)
-* [XCopy](https://kelvenbit.github.io/xcopy-app/) - 免费的 macOS 剪贴板管理器，支持文本、图片、链接和文件历史。 ![Freeware][Freeware Icon] ![Native App][Native Icon]
+* [XCopy](https://kelvenbit.github.io/XCopy-Website/) - 免费的 macOS 剪贴板管理器，支持文本、图片、链接和文件历史。 ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [Yippy](https://github.com/mattDavo/Yippy) - 具有用户友好界面的剪贴板管理器。 [![Open-Source Software][OSS Icon]](https://github.com/mattDavo/Yippy) ![Freeware][Freeware Icon]
 
 ### 菜单栏工具


### PR DESCRIPTION
## Summary

- Add XCopy to the Chinese Clipboard Tools section.
- Mark it as freeware and native, without the open-source badge.

## Notes

XCopy is a free macOS clipboard manager. The linked page is the public website and download page; the app source code is not open source.