### PR TITLE
Add DueFlow to To-Do Lists

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1369,6 +1369,7 @@ Awesome Mac
 
 * [2Do](http://www.2doapp.com/) - 優れたTodoアプリ。
 * [Day-O 2](http://www.shauninman.com/archive/2016/10/20/day_o_2_mac_menu_bar_clock) - カレンダー内蔵のメニューバー時計の代替アプリ。 ![Freeware][Freeware Icon]
+* [DueFlow](https://ustinian5.github.io/DueFlow/) - 散在する通知を実行可能なスケジュールに整理する、オープンソースでローカルファーストの締め切りプランナー。 [![Open-Source Software][OSS Icon]](https://github.com/Ustinian5/DueFlow) ![Freeware][Freeware Icon]
 * [Fantastical](https://flexibits.com/fantastical) - 手放せなくなるカレンダーアプリ。
 * [Focus](https://meaningful-things.com/focus) - ポモドーロベースの美しいタイムマネージャー。 [![App Store][app-store Icon]](https://apps.apple.com/us/app/focus-productivity-timer/id777233759?platform=mac)
 * [Focused Work: Focus Timer](https://focusedwork.app) - シンプルで柔軟なフォーカスタイマー。 [![App Store][app-store Icon]](https://apps.apple.com/us/app/focused-work-focus-timer/id1523968394?uo=4&platform=mac)

--- a/README-ko.md
+++ b/README-ko.md
@@ -996,6 +996,7 @@ Awesome Mac
 
 ### 할 일 목록 (To-Do Lists)
 
+* [DueFlow](https://ustinian5.github.io/DueFlow/) - 흩어진 공지를 실행 가능한 일정으로 정리하는 오픈 소스 로컬 우선 마감일 플래너. [![Open-Source Software][OSS Icon]](https://github.com/Ustinian5/DueFlow) ![Freeware][Freeware Icon]
 * [Nozbe](https://nozbe.com) - 개인과 팀을 위한 GTD 작업 관리자. [![App Store][app-store Icon]](https://apps.apple.com/pl/app/nozbe-tasks-projects-team/id508957583?platform=mac)
 * [Super Productivity](https://super-productivity.com) - 타임박싱과 시간 추적을 갖춘 작업 관리자. [![Open-Source Software][OSS Icon]](https://github.com/johannesjo/super-productivity) ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/cn/app/super-productivity/id1482572463?platform=mac)
 * [Things](https://culturedcode.com/things/) - 수상 경력이 있는 작업 관리자.

--- a/README-zh.md
+++ b/README-zh.md
@@ -1316,6 +1316,7 @@ Awesome Mac
 
 * [2Do](http://www.2doapp.com/) - 比较好的 TODO 应用程序。
 * [Day-O 2](http://www.shauninman.com/archive/2016/10/20/day_o_2_mac_menu_bar_clock) - 菜单日历更换内置日历。![Freeware][Freeware Icon]
+* [DueFlow](https://ustinian5.github.io/DueFlow/) - 开源、本地优先的截止日期规划工具，可将零散通知整理为可执行日程。 [![Open-Source Software][OSS Icon]](https://github.com/Ustinian5/DueFlow) ![Freeware][Freeware Icon]
 * [Fantastical](https://flexibits.com/fantastical) - 日历应用程序，你将管理好生活。
 * [Focus](https://masterbuilders.io) - 一个漂亮的番茄工作法为基础的时间管理工具。 [![App Store][app-store Icon]](https://apps.apple.com/cn/app/focus-productivity-timer/id777233759?platform=mac)
 * [Microsoft To-Do](https://todo.microsoft.com/) - 任务管理工具微软出品。 ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/cn/app/microsoft-to-do/id1274495053?platform=mac)

--- a/README.md
+++ b/README.md
@@ -1372,6 +1372,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 
 * [2Do](https://www.2doapp.com/) - Nice todo app.
 * [Day-O 2](https://www.shauninman.com/archive/2016/10/20/day_o_2_mac_menu_bar_clock) - Menu bar clock replacement with built-in calendar. ![Freeware][Freeware Icon]
+* [DueFlow](https://ustinian5.github.io/DueFlow/) - Open-source, local-first deadline planner for turning scattered notices into actionable schedules. [![Open-Source Software][OSS Icon]](https://github.com/Ustinian5/DueFlow) ![Freeware][Freeware Icon]
 * [Fantastical](https://flexibits.com/fantastical) - The calendar app you won't be able to live without.
 * [Focus](https://meaningful-things.com/focus) - Beautiful pomodoro-based time manager. [![App Store][app-store Icon]](https://apps.apple.com/us/app/focus-productivity-timer/id777233759?platform=mac)
 * [Focused Work: Focus Timer](https://focusedwork.app) - A simple, flexible Focus Timer. [![App Store][app-store Icon]](https://apps.apple.com/us/app/focused-work-focus-timer/id1523968394?uo=4&platform=mac)


### PR DESCRIPTION
## Summary

Add [DueFlow](https://ustinian5.github.io/DueFlow/) to the **To-Do Lists** section in the English, Chinese, Japanese, and Korean READMEs.

DueFlow is an MIT-licensed, open-source, local-first deadline planner that turns scattered notices into actionable schedules. The repository provides a deterministic local demo, current source release, screenshot, project site, and Python/React/Tauri verification gates.

## Repository

https://github.com/Ustinian5/DueFlow

## Validation

- Followed `.codex/skills/awesome-mac-maintainer/SKILL.md`.
- Added exactly one entry to each of `README.md`, `README-zh.md`, `README-ja.md`, and `README-ko.md`.
- Preserved the local To-Do Lists section and alphabetical placement.
- Kept every localized description to one sentence.
- Used the project site as the main link and the GitHub repository for the OSS icon.
- Project site and repository both return HTTP 200.
- Diff scope: 4 files, 4 insertions, 0 deletions.
