### PR TITLE
Add BracePaste to Clipboard Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1195,6 +1195,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 
 ### Clipboard Tools
 
+* [BracePaste](https://github.com/vishalnarkhede/BracePaste) - Format JSON and SQL from the clipboard with a double Command-C gesture. [![Open-Source Software][OSS Icon]](https://github.com/vishalnarkhede/BracePaste) ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [Buffer](https://samirpatil2000.github.io/products/buffer/) - Lightweight native clipboard manager with bookmarks and OCR for images. [![Open-Source Software][OSS Icon]](https://github.com/samirpatil2000/Buffer) ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [CleanClip](https://cleanclip.cc) - The cleanest Clipboard Manager on macOS, ever! ![Freeware][Freeware Icon]
 * [Clipboard](https://getclipboard.app/) - Easy-to-use terminal clipboard manager for all platforms. [![Open-Source Software][OSS Icon]](https://github.com/Slackadays/Clipboard) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds [BracePaste](https://github.com/vishalnarkhede/BracePaste) — a native, open-source (MIT) macOS menu bar app that formats JSON and SQL from the clipboard with a double ⌘C gesture. All processing is local (no network). Inserted alphabetically in Clipboard Tools.