### PR TITLE
Add YazSes to Voice-to-Text

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1069,6 +1069,7 @@ Awesome Mac
 * [Voxt](https://github.com/hehehai/voxt) - 押して話し離すと貼り付けられる音声入力・翻訳ツールで、アプリやURLごとに異なるAI転写ルールを設定できます。 [![Open-Source Software][OSS Icon]](https://github.com/hehehai/voxt) ![Freeware][Freeware Icon]
 * [Whispering](https://epicenter.md/whispering/) - AI変換とキーボードショートカットを備えたマルチプロバイダー音声テキスト変換。 [![Open-Source Software][OSS Icon]](https://github.com/EpicenterHQ/epicenter/tree/main/apps/whispering) ![Freeware][Freeware Icon]
 * [Willow Voice](https://willowvoice.com/) - 自動編集、スタイルマッチング、ノイズ最適化を備えたAIディクテーション。
+* [YazSes](https://mskazemi.com/yazses/) - Apple Silicon Mac 向けの押しながら話すディクテーションツール。faster-whisper でオンデバイス文字起こしし、任意のアプリに入力。 [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/MSKazemi/yazses)
 
 ## ブラウザ
 

--- a/README-ko.md
+++ b/README-ko.md
@@ -821,6 +821,7 @@ Awesome Mac
 * [VoxFlow](https://github.com/xingbofeng/VoxFlow) - 로컬/클라우드 ASR, OCR, 기록, 코딩 에이전트 워크플로를 지원하는 오픈 소스 음성 입력 워크스페이스. [![Open-Source Software][OSS Icon]](https://github.com/xingbofeng/VoxFlow) ![Freeware][Freeware Icon]
 * [Voxt](https://github.com/hehehai/voxt) - 누르고 말한 뒤 놓으면 바로 붙여넣는 음성 입력·번역 도구로, 앱과 URL별로 AI 전사 규칙을 다르게 설정할 수 있습니다. [![Open-Source Software][OSS Icon]](https://github.com/hehehai/voxt) ![Freeware][Freeware Icon]
 * [Whispering](https://epicenter.md/whispering/) - AI 변환 및 키보드 단축키를 지원하는 음성 텍스트 변환 도구. [![Open-Source Software][OSS Icon]](https://github.com/EpicenterHQ/epicenter) ![Freeware][Freeware Icon]
+* [YazSes](https://mskazemi.com/yazses/) - Apple Silicon Mac용 눌러서 말하는 받아쓰기 도구로, faster-whisper로 기기에서 전사해 모든 앱에 입력합니다. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/MSKazemi/yazses)
 
 ## 브라우저
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -728,6 +728,7 @@ Awesome Mac
 * [OpenTypeless](https://github.com/tover0314-w/opentypeless) - 开源 AI 语音输入工具，可将润色后的文本输入到任意应用。 [![Open-Source Software][OSS Icon]](https://github.com/tover0314-w/opentypeless) ![Freeware][Freeware Icon]
 * [Presspeech](https://github.com/rcourtman/presspeech) - 基于 Parakeet TDT v3（CoreML/ANE）的 Apple Silicon Mac 本地极速全局热键语音输入工具。 [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/rcourtman/presspeech)
 * [TypeWhisper](https://www.typewhisper.com) - 支持全局热键的本地 Whisper 语音转文字工具。 [![Open-Source Software][OSS Icon]](https://github.com/TypeWhisper/typewhisper-mac) ![Freeware][Freeware Icon]
+* [YazSes](https://mskazemi.com/yazses/) - 面向 Apple Silicon Mac 的按住说话听写工具，使用 faster-whisper 在本地转写并输入到任意应用。 [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/MSKazemi/yazses)
 * [Audio Profile Manager](https://apps.apple.com/us/app/audio-profile-manager/id1484150558?ls=1&platform=mac) - 用于保存输入和输出设备配置的音频管理工具。 [![App Store][app-store Icon]](https://apps.apple.com/us/app/audio-profile-manager/id1484150558?ls=1&platform=mac)
 * [Ardour](http://ardour.org/) - 录制，编辑和混合多轨音频。[![Open-Source Software][OSS Icon]](https://github.com/Ardour/ardour)
 * [Audacity](http://www.audacityteam.org/) - 免费开源的编辑音频的软件。[![Open-Source Software][OSS Icon]](https://github.com/audacity/audacity)

--- a/README.md
+++ b/README.md
@@ -1070,6 +1070,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Voxt](https://github.com/hehehai/voxt) - Hold-to-talk voice input tool with AI transcription rules per app and URL, and built-in translation. [![Open-Source Software][OSS Icon]](https://github.com/hehehai/voxt) ![Freeware][Freeware Icon]
 * [Whispering](https://epicenter.md/whispering/) - Multi-provider speech-to-text with AI transformations and keyboard shortcuts. [![Open-Source Software][OSS Icon]](https://github.com/EpicenterHQ/epicenter/tree/main/apps/whispering) ![Freeware][Freeware Icon]
 * [Willow Voice](https://willowvoice.com/) - AI dictation with automatic editing, style-matching, and noise optimization.
+* [YazSes](https://mskazemi.com/yazses/) - Hold-to-talk dictation for Apple Silicon Macs that transcribes on-device with faster-whisper and types into any app. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/MSKazemi/yazses)
 
 ## Browsers
 


### PR DESCRIPTION
Adds [YazSes](https://github.com/MSKazemi/yazses) to **Voice-to-Text**.

> Offline hold-to-talk dictation. Hold a key, speak, release — the text is transcribed on your own machine with faster-whisper and typed into whatever window has focus. No cloud, no account, no API key, no telemetry. Apache-2.0.

**Disclosure: I am the author.**

### Guidelines checklist

- [x] Searched previous suggestions — no existing YazSes entry or open PR
- [x] Single suggestion in this PR
- [x] Added in alphabetical order (end of the section — `YazSes` sorts after `Willow Voice`)
- [x] Synced across `README.md`, `README-zh.md`, `README-ja.md`, `README-ko.md`
- [x] One-sentence description, matching the surrounding style
- [x] `Open-Source Software` + `Freeware` icons, matching the reference-style links already defined in each file
- [x] No trailing whitespace; both links return 200

### Note on scope, so the entry is not misleading

The description says **"for Apple Silicon Macs"** deliberately, matching how `Presspeech` is worded in the same section. The `.dmg` is built host-architecture on an arm64 runner and carries no `x86_64` slice, so it will not launch on an Intel Mac — Intel users install via `pipx install yazses` instead, which is architecture-independent. I would rather the entry be narrow and accurate than broad and wrong.

The app is also an **unsigned developer preview**, so macOS Gatekeeper warns on first launch (right-click → Open). That is documented prominently in the project's own [macOS install guide](https://github.com/MSKazemi/yazses/blob/main/docs/macos-install.md); signing and notarisation are already wired into CI and switch on when a certificate is available. Happy to drop the entry until then if the list prefers signed apps only — no hard feelings either way.

Thanks for maintaining this list.