### PR TITLE
feat: add Filemorph to File Organization Tools

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1320,6 +1320,7 @@ Awesome Mac
 
 * [BetterZip](https://macitbetter.com/) - ZIP、TAR、TGZ、TBZ、TXZ（新規）、7-ZIP、RARをサポートするアーカイブツール。
 * [eZip](http://ezip.awehunt.com) - ZIP、RAR、7Z などに対応した軽量な圧縮・解凍ツール。 ![Freeware][Freeware Icon]
+* [Filemorph](https://filemorph.app) - 80以上のファイル形式（画像・PDF・動画・音声・文書・アーカイブ）を完全オンデバイスで変換・圧縮・編集。アップロードは一切なし。 [![App Store][app-store Icon]](https://apps.apple.com/us/app/filemorph-convert-edit/id6761300676?platform=mac)
 * [Fileside](https://www.fileside.app) - 無制限のペインを持つモダンなタイリングファイルマネージャー。
 * [Folders File Manager](https://foldersapp.dev) - Windowsエクスプローラーに似た展開可能なフォルダツリーを持つファイルマネージャー。
 * [Hazel](https://www.noodlesoft.com) - Macのためのファイル自動整理ツール。責任を持って美しくデザインされています。

--- a/README-ko.md
+++ b/README-ko.md
@@ -969,6 +969,7 @@ Awesome Mac
 ### 파일 정리 도구
 
 * [AppPorts](https://github.com/wzh4869/AppPorts) - `/Applications`의 실행 링크를 유지한 채 앱을 외부 저장소로 옮기는 도구. [![Open-Source Software][OSS Icon]](https://github.com/wzh4869/AppPorts) ![Freeware][Freeware Icon]
+* [Filemorph](https://filemorph.app) - 80개 이상의 파일 형식(이미지, PDF, 동영상, 오디오, 문서, 아카이브)을 완전히 온디바이스로 변환·압축·편집. 파일을 절대 업로드하지 않음. [![App Store][app-store Icon]](https://apps.apple.com/us/app/filemorph-convert-edit/id6761300676?platform=mac)
 * [Modal File Manager](https://github.com/raguay/ModalFileManager/) - Vim 스타일 단축키를 갖춘 듀얼 패널 파일 관리자. [![Open-Source Software][OSS Icon]](https://GitHub.com/raguay/ModalFileManager) ![Freeware][Freeware Icon]
 * [cmd+x](https://apps.apple.com/app/cmd-x/id6754665762?platform=mac) - Ctrl+Opt+Delete로 활동 모니터를 실행하고 Finder에서 Cmd+X로 파일을 잘라 이동.
 * [Oka Unarchiver](https://okaapps.com/product/1441507725) - RAR와 암호 보호 압축 파일까지 다루는 압축 해제 도구. [![App Store][app-store Icon]](https://apps.apple.com/app/id1441507725?pt=119209922&ct=github)

--- a/README-zh.md
+++ b/README-zh.md
@@ -1159,6 +1159,7 @@ Awesome Mac
 * [Deskmark](https://apps.apple.com/app/Deskmark/6755948110?platform=mac) - 给桌面添加水印，适合录制视频时使用。[![App Store][app-store Icon]](https://apps.apple.com/app/Deskmark/6755948110?platform=mac)
 * [escrcpy](https://github.com/viarotel-org/escrcpy) - 使用图形化的 Scrcpy 显示和控制您的 Android 设备，由 Electron 驱动。[![Open-Source Software][OSS Icon]](https://github.com/viarotel-org/escrcpy) ![Freeware][Freeware Icon]
 * [eZip](http://ezip.awehunt.com) - 轻量压缩解压工具，支持 ZIP、RAR、7Z 等常见格式。 ![Freeware][Freeware Icon]
+* [Filemorph](https://filemorph.app) - 完全在本机转换、压缩和编辑 80 多种文件格式（图片、PDF、视频、音频、文档、压缩包），绝不上传任何文件。 [![App Store][app-store Icon]](https://apps.apple.com/us/app/filemorph-convert-edit/id6761300676?platform=mac)
 * [Final2x](https://github.com/Tohrusky/Final2x) - 这是一个强大的工具，允许使用多种模型对图像进行任意大小的超分辨率处理，旨在提高图像的分辨率和质量，使其更加清晰和详细。[![Open-Source Software][OSS Icon]](https://github.com/Tohrusky/Final2x) ![Freeware][Freeware Icon]
 * [f.lux](https://justgetflux.com/) - 自动调整您的电脑屏幕，以匹配亮度。![Freeware][Freeware Icon]
 * [Grayscale Mode](https://github.com/rkbhochalya/grayscale-mode) - 通过菜单栏或快捷键快速切换灰度显示。 [![Open-Source Software][OSS Icon]](https://github.com/rkbhochalya/grayscale-mode) ![Freeware][Freeware Icon]

--- a/README.md
+++ b/README.md
@@ -1324,6 +1324,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [AppPorts](https://github.com/wzh4869/AppPorts) - Move apps to external storage while keeping working launch links in `/Applications`. [![Open-Source Software][OSS Icon]](https://github.com/wzh4869/AppPorts) ![Freeware][Freeware Icon]
 * [BetterZip](https://macitbetter.com/) - Archive tool supports ZIP, TAR, TGZ, TBZ, TXZ (new), 7-ZIP, RAR.
 * [eZip](https://ezip.awehunt.com) - Lightweight archive tool for ZIP, RAR, 7Z, and other common formats. ![Freeware][Freeware Icon]
+* [Filemorph](https://filemorph.app) - Convert, compress and edit 80+ file formats fully on-device — images, PDF, video, audio, documents and archives — nothing is ever uploaded. [![App Store][app-store Icon]](https://apps.apple.com/us/app/filemorph-convert-edit/id6761300676?platform=mac)
 * [Fileside](https://www.fileside.app) - A modern, tiling file manager with unlimited panes.
 * [Folders File Manager](https://foldersapp.dev) - A file manager with an expandable folder tree, similar to that of Windows Explorer.
 * [Hazel](https://www.noodlesoft.com) - Automated file organization for your Mac. Responsibly and beautifully designed.


### PR DESCRIPTION
## What

Adds [Filemorph](https://filemorph.app) to `File Organization Tools` in all four READMEs (EN/ZH/JA/KO), alphabetically between eZip and Fileside (KO placement follows that section's local ordering).

Filemorph is a native Swift app that converts, compresses and edits 80+ file formats — images, PDF, video, audio, documents and archives — fully on-device; nothing is ever uploaded and it works offline. Mac App Store: https://apps.apple.com/us/app/filemorph-convert-edit/id6761300676?platform=mac (requires macOS 14+).

## Why this section

Comparable to the file-transformation tools already listed there (BetterZip, Keka, The Unarchiver): format conversion and compression across file types.

## Checklist

- [x] Searched existing entries and PRs — not a duplicate
- [x] One suggestion per PR
- [x] Alphabetical order kept in all four READMEs
- [x] One-sentence description, synced across EN/ZH/JA/KO

**Disclosure:** I'm the developer of Filemorph.