### PR TITLE
Add SSH Config Manager

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -461,6 +461,7 @@ Awesome Mac
 * [Site Sucker](https://ricks-apps.com/osx/sitesucker/) - ウェブサイトを自動的にダウンロードするツール。 [![App Store][app-store Icon]](https://apps.apple.com/in/app/sitesucker/id442168834?platform=mac)
 * [SnippetsLab](https://www.renfei.org/snippets-lab/) - 使いやすいコードスニペット管理ツール。
 * [Solarized](http://ethanschoonover.com/solarized) - クリーンで美しいカラーテーマ。iTerm、JetBrains製品、Vimなどとの相性が良い。
+* [SSH Config Manager](https://www.sshmanager.app) - ssh_config を無損失で編集し、SSH キー、known_hosts、ポートフォワードのトンネルも管理できるアプリ。 ![Freeware][Freeware Icon] ![Native App][Native Icon] [![App Store][app-store Icon]](https://apps.apple.com/us/app/ssh-config-manager/id6777915057?platform=mac)
 * [SSH Keys Manager](https://github.com/Stmol/ssh-keys-manager-macos-app) - ローカルSSHキーとGitアイデンティティを管理するためのネイティブmacOSアプリ。 [![Open-Source Software][OSS Icon]](https://github.com/Stmol/ssh-keys-manager-macos-app) ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [StarUML](http://staruml.io) - 強力なUMLアプリ。
 * [Swiftify](https://objectivec2swift.com/#/xcode-extension/) - Objective-CからSwiftへのコードコンバーター、およびXcode & Finder拡張機能。

--- a/README-ko.md
+++ b/README-ko.md
@@ -425,6 +425,7 @@ Awesome Mac
 * [SCM Breeze](https://github.com/scmbreeze/scm_breeze) - Git 인터랙션 강화 쉘 스크립트. ![Freeware][Freeware Icon] [![Open-Source Software][OSS Icon]](https://github.com/scmbreeze/scm_breeze)
 * [SaneHosts](https://sanehosts.com) - hosts 기반 광고 및 추적기 차단 도구. [![Open-Source Software][OSS Icon]](https://github.com/sane-apps/SaneHosts)
 * [SnippetsLab](https://www.renfei.org/snippets-lab/) - 코드 스니펫 관리자.
+* [SSH Config Manager](https://www.sshmanager.app) - ssh_config를 손실 없이 편집하고 SSH 키, known_hosts, 포트 포워딩 터널을 관리하는 앱입니다. ![Freeware][Freeware Icon] ![Native App][Native Icon] [![App Store][app-store Icon]](https://apps.apple.com/us/app/ssh-config-manager/id6777915057?platform=mac)
 * [SSH Keys Manager](https://github.com/Stmol/ssh-keys-manager-macos-app) - 로컬 SSH 키와 Git 신원을 관리하는 네이티브 macOS 앱입니다. [![Open-Source Software][OSS Icon]](https://github.com/Stmol/ssh-keys-manager-macos-app) ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [StarUML](http://staruml.io) - 강력한 UML 앱.
 * [Swiftify](https://objectivec2swift.com/#/xcode-extension/) - Objective-C to Swift 변환기.

--- a/README-zh.md
+++ b/README-zh.md
@@ -290,6 +290,7 @@ Awesome Mac
 * [SCM Breeze](https://github.com/scmbreeze/scm_breeze) - 用于增强与git交互的shell脚本集(用于bash和zsh)。![Freeware][Freeware Icon] [![Open-Source Software][OSS Icon]](https://github.com/scmbreeze/scm_breeze)
 * [SecureCRT](https://www.vandyke.com/products/securecrt/) - 一款支持 SSH、Telnet 等多种协议的终端仿真程序。
 * [SnippetsLab](https://www.renfei.org/snippets-lab/) - 管理和组织你的代码片段。
+* [SSH Config Manager](https://www.sshmanager.app) - 无损编辑 ssh_config 的工具，同时管理 SSH 密钥、known_hosts 和端口转发隧道。 ![Freeware][Freeware Icon] ![Native App][Native Icon] [![App Store][app-store Icon]](https://apps.apple.com/us/app/ssh-config-manager/id6777915057?platform=mac)
 * [SSH Keys Manager](https://github.com/Stmol/ssh-keys-manager-macos-app) - 用于管理本地 SSH 密钥和 Git 身份的原生 macOS 应用。 [![Open-Source Software][OSS Icon]](https://github.com/Stmol/ssh-keys-manager-macos-app) ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [StarUML](http://staruml.io) - 强大的软件建模软件。
 * [Swiftify](https://objectivec2swift.com/#/xcode-extension/) - Xcode ＆ Finder 扩展 Objective-C 转 Swift 代码转换器

--- a/README.md
+++ b/README.md
@@ -461,6 +461,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Site Sucker](https://ricks-apps.com/osx/sitesucker/) - Automatically downloads websites. [![App Store][app-store Icon]](https://apps.apple.com/in/app/sitesucker/id442168834?platform=mac)
 * [SnippetsLab](https://www.renfei.org/snippets-lab/) - Easy-to-use code snippets manager.
 * [Solarized](https://ethanschoonover.com/solarized) - Clean and beautiful color theme. Works well with iTerm, JetBrains products, Vim etc.
+* [SSH Config Manager](https://www.sshmanager.app) - Lossless ssh_config editor that also manages SSH keys, known_hosts, and port-forwarding tunnels. ![Freeware][Freeware Icon] ![Native App][Native Icon] [![App Store][app-store Icon]](https://apps.apple.com/us/app/ssh-config-manager/id6777915057?platform=mac)
 * [SSH Keys Manager](https://github.com/Stmol/ssh-keys-manager-macos-app) - Native macOS app for managing local SSH keys and Git identities. [![Open-Source Software][OSS Icon]](https://github.com/Stmol/ssh-keys-manager-macos-app) ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [StarUML](https://staruml.io) - Powerful UML app.
 * [Swiftify](https://objectivec2swift.com/#/xcode-extension/) - Objective-C to Swift code converter and Xcode & Finder extensions.


### PR DESCRIPTION
### 🪩 Link

https://www.sshmanager.app — Mac App Store: https://apps.apple.com/us/app/ssh-config-manager/id6777915057?platform=mac

### 😳 Why it should be added

A native macOS app for `~/.ssh/config` itself, rather than a terminal that keeps hosts in its own database. It edits the file losslessly (comments, ordering and `Include` directives survive a save), resolves the effective configuration for a host so you can see which block supplied each value, lints for weak crypto and stale `IdentityFile` paths, manages keys and `known_hosts`, and runs local, remote and dynamic port forwards including multi-hop `ProxyJump` chains.

The closest existing entries are **SSH Keys Manager** and **Switzy** in the same section, which cover keys and Git identities but not the config file or tunnels. **Core Tunnel**, currently under *System Related Tools*, covers tunnels but not config editing.

### 📖 Additional context

- Free to use; a one-time in-app purchase unlocks the Pro features. Marked `Freeware` in line with Termius and other freemium entries.
- Native SwiftUI, sandboxed, universal binary. Marked `Native App` in line with SSH Keys Manager.
- Added to `README.md`, `README-zh.md`, `README-ja.md` and `README-ko.md`, placed alphabetically before `SSH Keys Manager` in each, one sentence per language, following `.codex/skills/awesome-mac-maintainer`.

### 🧨 Checklist

- [x] I have checked for other similar issues
- [x] I have explained why this change is important
- [x] I have added necessary documentation (if appropriate)