### PR TITLE
Add WattMate to System Related Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1604,7 +1604,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [TG Pro](https://www.tunabellysoftware.com/tgpro/) - Temperature monitoring, fan control & hardware diagnostics to help keep your Mac cool and healthy.
 * [Time Machine Inspector](https://github.com/probablykasper/time-machine-inspector) - Find out what's hogging up your Time Machine backups. [![Open-Source Software][OSS Icon]](https://github.com/probablykasper/time-machine-inspector) ![Freeware][Freeware Icon]
 * [Tuxera NTFS](https://www.tuxera.com/products/tuxera-ntfs-for-mac/) - Full read-write compatibility with NTFS-formatted drives on a Mac.
-* [WattMate](https://wattmateapp.com) - Shows the power each app uses in watts and how many minutes of battery quitting it returns, then re-measures to check the result.
+* [WattMate](https://wattmateapp.com/?ch=awesome-mac) - Shows the power each app uses in watts and how many minutes of battery quitting it returns, then re-measures to check the result.
 * [Overkill](https://github.com/KrauseFx/overkill-for-mac) - Stop iTunes from opening when you connect your iPhone.
 
 ## Gaming Software

--- a/README.md
+++ b/README.md
@@ -1604,6 +1604,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [TG Pro](https://www.tunabellysoftware.com/tgpro/) - Temperature monitoring, fan control & hardware diagnostics to help keep your Mac cool and healthy.
 * [Time Machine Inspector](https://github.com/probablykasper/time-machine-inspector) - Find out what's hogging up your Time Machine backups. [![Open-Source Software][OSS Icon]](https://github.com/probablykasper/time-machine-inspector) ![Freeware][Freeware Icon]
 * [Tuxera NTFS](https://www.tuxera.com/products/tuxera-ntfs-for-mac/) - Full read-write compatibility with NTFS-formatted drives on a Mac.
+* [WattMate](https://wattmateapp.com) - Shows the power each app uses in watts and how many minutes of battery quitting it returns, then re-measures to check the result.
 * [Overkill](https://github.com/KrauseFx/overkill-for-mac) - Stop iTunes from opening when you connect your iPhone.
 
 ## Gaming Software


### PR DESCRIPTION
Adds WattMate to **System Related Tools**, one line, in alphabetical position after Tuxera NTFS.

```
* [WattMate](https://wattmateapp.com) - Shows the power each app uses in watts and how many minutes of battery quitting it returns, then re-measures to check the result.
```

**What it is:** a menu bar app for Apple silicon Macs that reports per-app power in real watts — rather than Activity Monitor's unitless Energy Impact — projects how many minutes of runtime quitting an app returns, and then re-measures two minutes later to report what actually changed.

**Checklist**
- [x] Searched the list for duplicates — not present
- [x] One sentence, title case, alphabetical order within the section
- [x] No trailing whitespace; single-line diff
- [x] No OSS/Freeware badge: the app is closed source and paid (free 10-day trial, no card)
- [x] Notarized by Apple, distributed directly (macOS 14+, Apple silicon)
