### PR TITLE
Add Ampere to System Related Tools

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1561,6 +1561,7 @@ Awesome Mac
 
 * [Adrafinil](https://kagerou.glass/adrafinil/) - AI エージェントが作業している間だけ Mac をスリープさせず、終わったら通常どおりスリープさせます。 [![Open-Source Software][OSS Icon]](https://github.com/kageroumado/adrafinil) ![Freeware][Freeware Icon]
 * [AlDente](https://apphousekitchen.com/) - MacBook用バッテリー充電制限ツール。 [![Open-Source Software][OSS Icon]](https://github.com/davidwernhart/AlDente)
+* [Ampere](https://amperebattery.app/) - Apple Silicon Mac のバッテリー残量を設定した範囲内に保つ、メニューバー常駐の監視・充電制限ツール。 [![Open-Source Software][OSS Icon]](https://github.com/az-code-lab/ampere)
 * [Amphetamine](https://apps.apple.com/us/app/amphetamine/id937984704?platform=mac) - Macのスリープを防止。 ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/us/app/amphetamine/id937984704?platform=mac)
 * [AdBlock One](https://cleanerone.trendmicro.com/ad-block-one-for-mac/?utm_source=github&utm_medium=referral&utm_campaign=githubproject) - Safari用の無料広告ブロッカー。 ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/apple-store/id1491889901?pt=444218&ct=GitHub&mt=8&platform=mac)
 * [Apple Silicon App Test](https://doesitarm.com/apple-silicon-app-test/) - Apple Siliconアプリの互換性をチェック。 [![Open-Source Software][OSS Icon]](https://github.com/ThatGuySam/doesitarm) ![Freeware][Freeware Icon]

--- a/README-ko.md
+++ b/README-ko.md
@@ -991,6 +991,7 @@ Awesome Mac
 * [MaCursor](https://github.com/writronic/MaCursor) - macOS용 커스텀 커서 테마 도구. [![Open-Source Software][OSS Icon]](https://github.com/writronic/MaCursor) ![Freeware][Freeware Icon]
 * [MagicQuit](https://magicquit.com/) - 비활성 앱을 자동 종료해 리소스와 화면을 정리하는 도구. [![Open-Source Software][OSS Icon]](https://github.com/BigBerny/magicquit) ![Freeware][Freeware Icon]
 * [Adrafinil](https://kagerou.glass/adrafinil/) - AI 에이전트가 작업 중일 때만 Mac을 깨어 있게 하고, 작업이 끝나면 정상적으로 잠자기 상태로 전환합니다. [![Open-Source Software][OSS Icon]](https://github.com/kageroumado/adrafinil) ![Freeware][Freeware Icon]
+* [Ampere](https://amperebattery.app/) - Apple Silicon Mac의 배터리 잔량을 설정한 범위 안에서 유지하는 메뉴 막대 배터리 모니터 겸 충전 제한 도구. [![Open-Source Software][OSS Icon]](https://github.com/az-code-lab/ampere)
 * [OnyX](https://www.titanium-software.fr/en/onyx.html) - 정리, 점검, 숨은 설정 변경을 묶은 시스템 유지보수 도구. ![Freeware][Freeware Icon]
 * [Sensei](https://sensei.app/) - 모니터링, 정리, 하드웨어 진단을 제공하는 성능 관리 도구.
 * [SiliconScope](https://siliconscope.calidalab.ai) - 免授权的 Apple Silicon 系统监控工具（菜单栏 + 仪表盘），支持 ANE、媒体引擎、内存带宽追踪以及 E/P 核性能分解。 [![Open-Source Software][OSS Icon]](https://github.com/kennss/SiliconScope) ![Freeware][Freeware Icon]

--- a/README-zh.md
+++ b/README-zh.md
@@ -1367,6 +1367,7 @@ Awesome Mac
 * [Adrafinil](https://kagerou.glass/adrafinil/) - 仅在 AI 智能体仍在工作时保持 Mac 唤醒，任务结束后恢复正常睡眠。 [![Open-Source Software][OSS Icon]](https://github.com/kageroumado/adrafinil) ![Freeware][Freeware Icon]
 * [AlDente](https://apphousekitchen.com/) - 充电保护软件，延长 MacBook 电池寿命。 [![Open-Source Software][OSS Icon]](https://github.com/davidwernhart/AlDente)
 * [AltStore](https://altstore.io/) - 非越狱 iOS 设备的替代应用商店。[![Open-Source Software][OSS Icon]](https://altstore.io/#Downloads) ![Freeware][Freeware Icon]
+* [Ampere](https://amperebattery.app/) - 菜单栏电池监控与充电限制工具，将 Apple Silicon Mac 的电量维持在可配置的区间内。 [![Open-Source Software][OSS Icon]](https://github.com/az-code-lab/ampere)
 * [Amphetamine](https://apps.apple.com/cn/app/amphetamine/id937984704?platform=mac) - 覆盖您的节能设置并让您的Mac保持唤醒状态。 ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/cn/app/amphetamine/id937984704?platform=mac)
 * [AirBattery](https://lihaoyun6.github.io/airbattery/) - 获取你所有设备的电量信息并显示在Dock/状态栏/小组件上。 [![Open-Source Software][OSS Icon]](https://github.com/lihaoyun6/AirBattery) ![Freeware][Freeware Icon]
 * [BackgroundMusic](https://github.com/kyleneideck/BackgroundMusic) - 自动暂停音乐、设置各个应用程序的音量并录制系统音频。![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]

--- a/README.md
+++ b/README.md
@@ -1564,6 +1564,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 
 * [Adrafinil](https://kagerou.glass/adrafinil/) - Keep your Mac awake only while AI agents are still working, then let it sleep normally. [![Open-Source Software][OSS Icon]](https://github.com/kageroumado/adrafinil) ![Freeware][Freeware Icon]
 * [AlDente](https://apphousekitchen.com/) - Battery charge limiter for MacBooks. [![Open-Source Software][OSS Icon]](https://github.com/davidwernhart/AlDente)
+* [Ampere](https://amperebattery.app/) - Menu bar battery monitor and charge limiter that keeps Apple Silicon Macs within configurable charge bounds. [![Open-Source Software][OSS Icon]](https://github.com/az-code-lab/ampere)
 * [Amphetamine](https://apps.apple.com/us/app/amphetamine/id937984704?platform=mac) - Keep your Mac awake. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/us/app/amphetamine/id937984704?platform=mac)
 * [AdBlock One](https://cleanerone.trendmicro.com/ad-block-one-for-mac/?utm_source=github&utm_medium=referral&utm_campaign=githubproject) - Free ad blocker for Safari.![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/apple-store/id1491889901?pt=444218&ct=GitHub&mt=8&platform=mac)
 * [Apple Silicon App Test](https://doesitarm.com/apple-silicon-app-test/) - Check Apple Silicon app compatibility. [![Open-Source Software][OSS Icon]](https://github.com/ThatGuySam/doesitarm) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds **Ampere** to System Related Tools, synced across `README.md`, `README-zh.md`, `README-ja.md`, and `README-ko.md`.

```
* [Ampere](https://amperebattery.app/) - Menu bar battery monitor and charge limiter that keeps Apple Silicon Macs within configurable charge bounds. [![Open-Source Software][OSS Icon]](https://github.com/az-code-lab/ampere)
```

**Links**

| | |
|---|---|
| Website | https://amperebattery.app/ |
| Technical details | https://amperebattery.app/tech.html |
| Changelog | https://amperebattery.app/changelog.html |
| Source | https://github.com/az-code-lab/ampere |
| Releases | https://github.com/az-code-lab/ampere/releases |

**What it is:** a menu bar app for Apple Silicon Macs that reports live battery stats (cycle count, health, temperature, wattage, voltage, current) and controls charging through the SMC. Auto charge holds the battery between a configurable upper and lower bound, and avoids fragmented micro-charges by only starting a cycle from below the lower bound or on explicit request. A pre-sleep pause and a sleep hold keep an in-progress charge from overshooting the upper bound while the Mac is asleep, which software charge limiters otherwise miss because no poll runs during sleep. A root watchdog restores all SMC and `pmset` state within seconds if the app crashes or is force-killed. The technical details page above documents the SMC keys, the clamshell power-delivery problem and its fix, and the process architecture.

**Placement:** alphabetically between AlDente and Amphetamine in `README.md` and `README-ja.md`, and between AltStore and Amphetamine in `README-zh.md`. The `시스템 도구` section in `README-ko.md` is not alphabetically ordered and has no AlDente or Amphetamine entry, so the line is placed beside the nearest existing entry, following the precedent in #2466.

**Checklist**

- [x] Searched issues and PRs for duplicates, none found
- [x] One sentence per language, title case, single-line diff per file
- [x] No trailing whitespace, no other content touched
- [x] OSS icon links to the MIT-licensed repository. No Freeware icon: the app requires a paid registration key, matching how coconutBattery and TG Pro are listed in the same section

**Disclosure:** I am the developer. Requires macOS 14 (Sonoma) or later on Apple Silicon. AI assistance was used to prepare this PR per the repository's AI-assisted contribution guidelines; category, ordering, icon style, and translations follow the existing entries in each file. Happy to reword the entry or any translation if it reads off.
