### PR TITLE
Add amtrino to Menu Bar Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1229,6 +1229,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 ### Menu Bar Tools
 
 * [Agent Island](https://github.com/tristan666666/agent-island) - MacBook notch companion for Claude Code and Codex sessions, showing live status and auto-resuming selected long-running tasks. [![Open-Source Software][OSS Icon]](https://github.com/tristan666666/agent-island) ![Freeware][Freeware Icon]
+* [amtrino](https://github.com/arian-shamaei/amtrino) - Every local AI coding session (Claude Code, Codex CLI) as a breathing identity-colored dot in the menu bar; finish notifications jump to the session's tmux pane. [![Open-Source Software][OSS Icon]](https://github.com/arian-shamaei/amtrino) ![Freeware][Freeware Icon]
 * [Anvil](https://anvilformac.com/) - Tool for serving local static sites and Rack apps with simple URLs. ![Freeware][Freeware Icon]
 * [Atoll](https://github.com/Ebullioscopic/Atoll) - Turns the notch into a Dynamic Island-style hub for media controls, live activities, and quick utilities. [![Open-Source Software][OSS Icon]](https://github.com/Ebullioscopic/Atoll)
 * [Bartender](https://www.macbartender.com) - Organize or hide menu bar icons on your Mac.


### PR DESCRIPTION
Adds **[amtrino](https://github.com/arian-shamaei/amtrino)** to Menu Bar Tools (alphabetical, after Agent Island).

![the amtrino menu bar icon, live](https://raw.githubusercontent.com/arian-shamaei/amtrino/main/docs/assets/hero-icon.gif)

Every local AI coding session (Claude Code, Codex CLI) as a breathing identity-colored dot in a 3×3 menu bar grid — pulsing while the model responds, flashing when a response finishes, with a notification that jumps you to the session's exact tmux pane. Free, open source (MIT), notarized releases + Homebrew cask.