### PR TITLE
Add Nametag to Screenshot Tools 

### DIFF
--- a/README.md
+++ b/README.md
@@ -732,6 +732,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Flameshot](https://github.com/flameshot-org/flameshot) - Powerful yet simple to use screenshot software. ![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]
 * [Lightshot](https://app.prntscr.com/) - The fastest way to take a customizable screenshot. ![Freeware][Freeware Icon]
 * [macshot](https://github.com/sw33tlie/macshot) - Screenshot and annotation tool with screen recording, scrolling capture, and OCR. [![Open-Source Software][OSS Icon]](https://github.com/sw33tlie/macshot) ![Freeware][Freeware Icon]
+* [Nametag](https://github.com) - Menu bar utility that automatically renames screenshots using on-device OCR, image classification, and local AI fallback. ![Open-Source Software][OSS Icon]
 * [Scap](https://wangchujiang.com/scap/) - Screenshot annotation and canvas tool with blur, mosaic, and watermark features. [![App Store][app-store Icon]](https://apps.apple.com/app/Scap/6758053530?platform=mac)
 * [Shottr](https://shottr.cc/) - Screen capture application with features like Scrolling capture, OCR and markup.
 * [Skitch](https://evernote.com/skitch/) - Screen capture application with a powerful annotation capabilities. ![Freeware][Freeware Icon]


### PR DESCRIPTION
NOTE: A similar PR may already be submitted! Please search among the Pull request before creating one.

### Types of Changes

**What types of changes does your PR introduce?** Put an x in all boxes that apply

- [x] New addition to list
- [ ] Fixing bug in existing item in list
- [ ] Removing item from list
- [ ] Changing structure (organization) of list

### Proposed Changes
1. I am suggesting the addition of **Nametag** to the `### Screenshot Tools` section.
2. Nametag is a local, privacy-first macOS menu bar utility that automates screenshot organization. It utilizes Apple's native Vision framework for on-device OCR and image classification, with an optional local Ollama vision fallback to systematically rename cluttered screenshot files. It fits perfectly into this collection as there is no screenshot naming apps in the list yet, and this app added provides a foolproof solution for the weird system generated screenshot names for mac screenshots.

**Describe each of your changes here to communicate to the maintainers why we should accept this pull request.**

1. If you're adding something to the list, be sure to explain why it should be added.
1. If you're fixing a bug or resolving a feature request, be sure to link to that issue.

### PR Checklist

Put an x in the boxes once you've completed each step. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important
- [x] I have added necessary documentation (if appropriate)

### Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
