### PR TITLE
Add Accelerator Keys to Office

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -219,6 +219,7 @@ Awesome Mac
 
 ### オフィス
 
+* [Accelerator Keys](https://acceleratorkeys.com) - Mac 版 Excel と PowerPoint で Windows スタイルの Alt キーリボンショートカットを使えるようにする。
 * [Keynote](https://apps.apple.com/app/keynote/id409183694?platform=mac) - 美しいプレゼンテーションを作成。 ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/keynote/id409183694?platform=mac)
 * [LibreOffice](https://www.libreoffice.org) - 大規模なコミュニティで日々使用・テストされている無料のオープンソースオフィスソフトウェア。 [![Open-Source Software][OSS Icon]](https://www.libreoffice.org/about-us/source-code/) ![Freeware][Freeware Icon]
 * [Microsoft Office](https://products.office.com/en-us/mac/microsoft-office-for-mac) - 紛れもなくOffice、Mac用に設計。 [![App Store][app-store Icon]](https://www.apple.com/search/office?page=1&sel=accessories&f=software#!&f=software&fh=4649)

--- a/README-ko.md
+++ b/README-ko.md
@@ -193,6 +193,7 @@ Awesome Mac
 
 ### 오피스
 
+* [Accelerator Keys](https://acceleratorkeys.com) - Mac용 Excel과 PowerPoint에서 Windows 스타일 Alt 키 리본 단축키를 사용할 수 있게 해줌.
 * [Keynote](https://apps.apple.com/app/keynote/id409183694?platform=mac) - 멋진 프레젠테이션 제작. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/keynote/id409183694?platform=mac)
 * [LibreOffice](https://www.libreoffice.org) - 대규모 커뮤니티에서 매일 사용하고 테스트하는 무료 오픈 소스 오피스 소프트웨어. [![Open-Source Software][OSS Icon]](https://www.libreoffice.org/about-us/source-code/) ![Freeware][Freeware Icon]
 * [Microsoft Office](https://products.office.com/en-us/mac/microsoft-office-for-mac) - Mac용으로 설계된 확실한 Office. [![App Store][app-store Icon]](https://www.apple.com/search/office?page=1&sel=accessories&f=software#!&f=software&fh=4649)

--- a/README-zh.md
+++ b/README-zh.md
@@ -824,6 +824,7 @@ Awesome Mac
 
 ### Office
 
+* [Accelerator Keys](https://acceleratorkeys.com) - 在 Mac 版 Excel 和 PowerPoint 中使用 Windows 风格的 Alt 键功能区快捷键。
 * [KOffice](https://www.kde.org/applications/office/) - 集成化办公套件，包含文字处理器、电子 表格、幻灯片制作、项目管理等多种工具。![Freeware][Freeware Icon]
 * [Keynote 讲演](https://apps.apple.com/cn/app/keynote/id409183694?platform=mac) - 构建炫目的演示文稿。 ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/cn/app/keynote/id409183694?platform=mac)
 * [LibreOffice](https://www.libreoffice.org) - 免费开源的办公软件，广泛被用户社区日常使用和测试。[![Open-Source Software][OSS Icon]](https://www.libreoffice.org/about-us/source-code/) ![Freeware][Freeware Icon]

--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 
 ### Office
 
+* [Accelerator Keys](https://acceleratorkeys.com) - Windows-style Alt key ribbon shortcuts for Excel and PowerPoint on Mac.
 * [Keynote](https://apps.apple.com/app/keynote/id409183694?platform=mac) - Build stunning presentations. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/keynote/id409183694?platform=mac)
 * [LibreOffice](https://www.libreoffice.org) - Free, open-source office software used and tested daily by a large community. [![Open-Source Software][OSS Icon]](https://www.libreoffice.org/about-us/source-code/) ![Freeware][Freeware Icon]
 * [Microsoft Office](https://products.office.com/en-us/mac/microsoft-office-for-mac) - Unmistakably Office, designed for Mac. [![App Store][app-store Icon]](https://www.apple.com/search/office?page=1&sel=accessories&f=software#!&f=software&fh=4649)


### PR DESCRIPTION
Adds [Accelerator Keys](https://acceleratorkeys.com) to the Office section (alphabetical, first entry) in README.md, README-zh.md, README-ja.md, and README-ko.md.

Accelerator Keys is a native macOS menu bar app that makes Windows-style Alt key ribbon shortcuts (KeyTips) work in Microsoft Excel and PowerPoint for Mac — press Option, then the same letter sequence as on Windows (e.g. Option, H, O, I for AutoFit). 900+ Excel and 380+ PowerPoint shortcuts, Apple Silicon and Intel, 14-day free trial, paid app (no icon added, per list conventions).

Disclosure: I own the company that makes it.