### PR TITLE
Add Lockbook to Note-taking

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -267,6 +267,7 @@ Awesome Mac
 * [Inkdrop](https://www.inkdrop.info/) - Electron上に構築されたMarkdown愛好者のためのノートブックアプリ。
 * [Joplin](https://joplinapp.org/) - Markdownサポートとタスク管理機能を備えたクロスプラットフォームオープンソースメモアプリ。 [![Open-Source Software][OSS Icon]](https://github.com/laurent22/joplin) ![Freeware][Freeware Icon]
 * [Knopo](https://github.com/alkalim/Knopo) - ノートをプレーンMarkdownファイルとして保存するmacOSネイティブのローカルファーストアウトライナー。 [![Open-Source Software][OSS Icon]](https://github.com/alkalim/Knopo) ![Freeware][Freeware Icon] ![Native App][Native Icon]
+* [Lockbook](https://lockbook.net/) - エンドツーエンド暗号化で共同編集できるノート・ドキュメント・手描きアプリ。クロスプラットフォーム同期とセルフホストサーバーに対応。 [![Open-Source Software][OSS Icon]](https://github.com/lockbook/lockbook) ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/us/app/lockbook-private-notes/id1526775001?platform=mac) ![Native App][Native Icon]
 * [Logseq](https://logseq.com/) - プライバシー重視のオープンソースナレッジベース。 [![OSS][OSS Icon]](https://github.com/logseq/logseq) ![Freeware][Freeware Icon]
 * [MarginNote 4](https://marginnote.com/) - PDFとEPUBの深い読書、学習、管理、メモ取りアプリ。
 * [massCode](https://masscode.io/) - MarkdownとMermaidをサポートしたクロスプラットフォームオープンソースコードスニペット管理ツール。 [![Open-Source Software][OSS Icon]](https://github.com/massCodeIO/massCode) ![Freeware][Freeware Icon]

--- a/README-ko.md
+++ b/README-ko.md
@@ -240,6 +240,7 @@ Awesome Mac
 * [Inkdrop](https://www.inkdrop.info/) - Electron 기반의 마크다운 애호가를 위한 노트북 앱.
 * [Joplin](https://joplinapp.org/) - 마크다운과 할 일 관리를 지원하는 오픈 소스 메모장. [![Open-Source Software][OSS Icon]](https://github.com/laurent22/joplin) ![Freeware][Freeware Icon]
 * [Knopo](https://github.com/alkalim/Knopo) - 노트를 일반 Markdown 파일로 저장하는 macOS 네이티브 로컬 우선 아웃라이너. [![Open-Source Software][OSS Icon]](https://github.com/alkalim/Knopo) ![Freeware][Freeware Icon] ![Native App][Native Icon]
+* [Lockbook](https://lockbook.net/) - 엔드투엔드 암호화된 협업 노트, 문서, 드로잉 앱으로 크로스 플랫폼 동기화와 자체 호스팅 서버를 지원. [![Open-Source Software][OSS Icon]](https://github.com/lockbook/lockbook) ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/us/app/lockbook-private-notes/id1526775001?platform=mac) ![Native App][Native Icon]
 * [Logseq](https://logseq.com/) - 개인정보 우선의 오픈 소스 지식 베이스. [![OSS][OSS Icon]](https://github.com/logseq/logseq) ![Freeware][Freeware Icon]
 * [MarginNote 4](https://marginnote.com/) - 심도 있는 PDF 및 EPUB 읽기, 학습 및 노트 앱.
 * [massCode](https://masscode.io/) - 마크다운 및 Mermaid를 지원하는 오픈 소스 코드 스니펫 관리자. [![Open-Source Software][OSS Icon]](https://github.com/massCodeIO/massCode) ![Freeware][Freeware Icon]

--- a/README-zh.md
+++ b/README-zh.md
@@ -882,6 +882,7 @@ Awesome Mac
 * [Inkdrop](https://www.inkdrop.info/) - Markdown 爱好者的笔记本应用程序。
 * [Knopo](https://github.com/alkalim/Knopo) - 原生 macOS 本地优先大纲笔记应用，以纯 Markdown 文件存储笔记。 [![Open-Source Software][OSS Icon]](https://github.com/alkalim/Knopo) ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [leanote](http://app.leanote.com) - 支持 Markdown 的一款开源笔记软件，支持直接成为个人博客。[![Open-Source Software][OSS Icon]](https://github.com/leanote/leanote) ![Freeware][Freeware Icon]
+* [Lockbook](https://lockbook.net/) - 端到端加密的协作式笔记、文档与手绘应用，支持跨平台同步，服务端可自行部署。 [![Open-Source Software][OSS Icon]](https://github.com/lockbook/lockbook) ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/cn/app/lockbook-private-notes/id1526775001?platform=mac) ![Native App][Native Icon]
 * [Logseq](https://logseq.com/) - 一个以隐私为先的开源平台，用于知识管理和协作。 [![Open-Source Software][OSS Icon]](https://github.com/logseq/logseq) ![Freeware][Freeware Icon]
 * [MarginNote 4](https://apps.apple.com/cn/app/marginnote-4/id1531657269?platform=mac) - 笔记界的瑞士军刀，功能强大的笔记软件工具[![App Store][app-store Icon]](https://apps.apple.com/cn/app/marginnote-4/id1531657269?platform=mac)
 * [massCode](https://github.com/massCodeIO/massCode) - 跨平台开源代码片段管理器，支持 Markdown 和 Mermaid。 [![Open-Source Software][OSS Icon]](https://github.com/massCodeIO/massCode) ![Freeware][Freeware Icon]

--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Inkdrop](https://www.inkdrop.info/) - Notebook app for Markdown lovers built on top of Electron.
 * [Joplin](https://joplinapp.org/) - Cross-platform open-source notepad with markdown support and to-do list management. [![Open-Source Software][OSS Icon]](https://github.com/laurent22/joplin) ![Freeware][Freeware Icon]
 * [Knopo](https://github.com/alkalim/Knopo) - Native macOS outliner for local-first notes stored as plain Markdown files. [![Open-Source Software][OSS Icon]](https://github.com/alkalim/Knopo) ![Freeware][Freeware Icon] ![Native App][Native Icon]
+* [Lockbook](https://lockbook.net/) - Collaborative end-to-end encrypted notes, documents, and drawings with cross-platform sync and an optional self-hosted server. [![Open-Source Software][OSS Icon]](https://github.com/lockbook/lockbook) ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/us/app/lockbook-private-notes/id1526775001?platform=mac) ![Native App][Native Icon]
 * [Logseq](https://logseq.com/) - Privacy-first, open-source knowledge base. [![OSS][OSS Icon]](https://github.com/logseq/logseq) ![Freeware][Freeware Icon]
 * [MarginNote 4](https://marginnote.com/) - In-depth PDF and EPUB reading, learning, managing and note taking app.
 * [massCode](https://masscode.io/) - Cross-platform open-source code snippets manager with markdown and mermaid support. [![Open-Source Software][OSS Icon]](https://github.com/massCodeIO/massCode) ![Freeware][Freeware Icon]


### PR DESCRIPTION
# Add Lockbook to Note-taking

### Types of Changes

**What types of changes does your PR introduce?** Put an x in all boxes that apply

- [x] New addition to list
- [ ] Fixing bug in existing item in list
- [ ] Removing item from list
- [ ] Changing structure (organization) of list

### Proposed Changes

Adds [Lockbook](https://lockbook.net/) to **Reading and Writing Tools → Note-taking**, synced across `README.md`, `README-zh.md`, `README-ja.md`, and `README-ko.md`.

Lockbook is an end-to-end encrypted notes app. The macOS client is a native SwiftUI app on the Mac App Store, and it's free — the whole project is public domain (Unlicense), server included, so you can point the client at your own server instead of ours.

Why it belongs in this section: It's a note taking app

Entry as added:

```markdown
* [Lockbook](https://lockbook.net/) - End-to-end encrypted notes, documents, and drawings with cross-platform sync and an optional self-hosted server. [![Open-Source Software][OSS Icon]](https://github.com/lockbook/lockbook) ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/us/app/lockbook-private-notes/id1526775001?platform=mac) ![Native App][Native Icon]
```

### PR Checklist

- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important
- [x] I have added necessary documentation (if appropriate)

### Further Comments

Notes on the details, so you don't have to check them yourself:

- Placed alphabetically between `Knopo` and `Logseq` in all four files (after `leanote` in `README-zh.md`, which carries an entry the others don't).
- `README-zh.md` uses the `apps.apple.com/cn/` App Store link to match the surrounding entries in that file; the other three use `/us/`.
- Descriptions are a single sentence in each language. No trailing whitespace.
- `Freeware` icon: Lockbook is free to use, with a paid tier only for storage above the free cap — the same basis on which Standard Notes and Joplin carry the icon in this section. Happy to drop it if you read that differently.

Disclosure: I'm a Lockbook maintainer.