### PR TITLE
Add Downright to Markdown Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 ### Markdown Tools [![Awesome List][awesome-list Icon]](https://github.com/BubuAnabelas/awesome-markdown#tools)
 
 * [Archimedes](https://furnacecreek.org/archimedes/) - Native macOS Markdown editor geared toward mathematical writing with inline LaTeX support.
+* [Downright](https://downright.cc/) - Native, open-source macOS Markdown reader/editor for ordinary files with Quick Look, Finder thumbnails, and safe review of external rewrites. [![Open-Source Software][OSS Icon]](https://github.com/ezzy1630/Downright) ![Freeware][Freeware Icon] [![Native App][Native Icon]](https://github.com/ezzy1630/Downright)
 * [Edmund](https://github.com/I7T5/Edmund) - Minimal, native macOS Markdown editor with live preview; works with your existing files, no vault. [![Open-Source Software][OSS Icon]](https://github.com/I7T5/Edmund) ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [EME](https://github.com/egoist/eme) - Open-source Markdown editor with an interface like Chrome. ![Open-Source Software][OSS Icon]
 * [iA Writer](https://ia.net/writer/) - Writing app with an emphasis on simplicity and design.


### PR DESCRIPTION
Adds Downright to the Markdown Tools section. Downright is a free, MIT-licensed native macOS Markdown reader/editor for ordinary files with Quick Look, Finder thumbnails, and safe review of external rewrites. Website: https://downright.cc/ Source: https://github.com/ezzy1630/Downright. I maintain Downright and am available for corrections.