### PR TITLE
Add Screen Dimmer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1557,6 +1557,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Luminescent](https://naden.co) - Bring back Keyboard Backlight Shortcuts for the MacBook.
 * [MaCursor](https://github.com/writronic/MaCursor) - Custom cursor themes for macOS. [![Open-Source Software][OSS Icon]](https://github.com/writronic/MaCursor) ![Freeware][Freeware Icon]
 * [Lunar](https://lunar.fyi/) -  Help you adujst brightness, contrast and volumn of your external display. [![Open-Source Software][OSS Icon]](https://github.com/alin23/Lunar) ![Freeware][Freeware Icon]
+* [Screen Dimmer](https://github.com/painfulChen/screen-dimmer) - Dim any display, even external monitors that ignore DDC/CI. Per-screen sliders in a local web app. [![Open-Source Software][OSS Icon]](https://github.com/painfulChen/screen-dimmer) ![Freeware][Freeware Icon]
 * [Shifty](https://shifty.natethompson.io) - A macOS menu bar app that gives you more control over Night Shift. [![Open-Source Software][OSS Icon]](https://github.com/thompsonate/Shifty)
 * [Snap](https://indragie.com/snap) - Launch an app in a snap. Ridiculously easy shortcut management. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id418073146?platform=mac)
 * [Shareful](https://sindresorhus.com/shareful) - Supercharge the system share menu with copy, save, and open actions. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id1522267256?platform=mac)


### PR DESCRIPTION
**[Screen Dimmer](https://github.com/painfulChen/screen-dimmer)** — Dim any display on macOS, even external monitors that ignore DDC/CI (common with docks/adapters, where MonitorControl-style tools fail). It places a click-through dimming overlay per screen, controlled from a tiny local web app with per-display sliders. Zero dependencies (Python stdlib + Swift).

Inserted next to Lunar in Quality of Life Improvements, as it solves the same problem via a different (software-overlay) route.