### PR TITLE
Add DBTool to Databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,6 +597,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [DB Browser for SQLite](https://sqlitebrowser.org/) - Official home of the DB Browser for SQLite. [![Open-Source Software][OSS Icon]](https://github.com/sqlitebrowser/sqlitebrowser) ![Freeware][Freeware Icon]
 * [DBeaver](https://dbeaver.io/) - Universal SQL Client.
 * [DB Pro](https://dbpro.app) - Database client for querying and managing SQL databases.
+* [DBTool](https://codemake.co/software) - Desktop client for PostgreSQL, MySQL, MariaDB, SQLite, Oracle and SQL Server, with server-side pagination, a visual join builder and ER diagrams. [![Open-Source Software][OSS Icon]](https://github.com/achi777/db-tool) ![Freeware][Freeware Icon]
 * [ElectroCRUD](https://garrylachman.github.io/ElectroCRUD/) - Modern MySQL CRUD application. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/garrylachman/ElectroCRUD)
 * [FastoNoSQL](https://fastonosql.com/) - Cross-platform GUI client for various key-value databases. [![OSS][OSS Icon]](https://github.com/fastogt/fastonosql) ![Freeware][Freeware Icon]
 * [FastoRedis](https://fastoredis.com/) - Cross-platform professional GUI management tool for Redis. [![Open-Source Software][OSS Icon]](https://github.com/fastogt/fastoredis) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds **DBTool** to Developer Tools > Databases, in alphabetical order after DB Pro.

[DBTool](https://github.com/achi777/db-tool) is a free, open-source (AGPL-3.0) desktop database client covering PostgreSQL, MySQL, MariaDB, SQLite, Oracle and Microsoft SQL Server behind one interface. Universal macOS builds for both Apple Silicon and Intel.

What distinguishes it from the clients already in the section: true server-side pagination (ordering, counting and paging happen in the database, not the client), a drag-to-join visual query builder that generates the `SELECT`, a visual table designer with a live DDL preview, and editable ER diagrams. Connection passwords go to the macOS Keychain; there is no telemetry and no account.

Tagged with both the OSS and Freeware icons, matching the other free open-source entries in the section.

I am the author of this project.
