### PR TITLE
Add Zmina to Clipboard Tools

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1224,6 +1224,7 @@ Awesome Mac
 * [uPaste](https://okaapps.com/product/1503649026) - クリップボード履歴と定型文を整理して再利用しやすくするマネージャー。 [![App Store][app-store Icon]](https://apps.apple.com/app/id1503649026?pt=119209922&ct=github)
 * [Yippy](https://github.com/mattDavo/Yippy) - ユーザーフレンドリーなUIのクリップボードマネージャー。 [![Open-Source Software][OSS Icon]](https://github.com/mattDavo/Yippy) ![Freeware][Freeware Icon]
 * [ClipFlow](https://github.com/praneeth552/clipflow) - ターミナルスタイルのナビゲーションを備えた無料のクリップボード履歴マネージャー。 [![Open-Source Software][OSS Icon]](https://github.com/praneeth552/clipflow) ![Freeware][Freeware Icon]
+* [Zmina](https://zmina.app) - 貼り付け先のアプリに応じた操作を提案するクリップボードマネージャー。
 
 ### メニューバーツール
 

--- a/README-ko.md
+++ b/README-ko.md
@@ -918,6 +918,7 @@ Awesome Mac
 * [SaneClip](https://saneclip.com) - 기록, Touch ID 보호, 민감 정보 감지를 갖춘 클립보드 관리자. [![Open-Source Software][OSS Icon]](https://github.com/sane-apps/SaneClip) ![Freeware][Freeware Icon]
 * [SnippetCraft](https://getsnippetcraft.com) - macOS용 시스템 전체 텍스트 확장, 스니펫 관리, 클립보드 기록 도구.
 * [uPaste](https://okaapps.com/product/1503649026) - 클립보드 기록과 스니펫을 정리해 재사용하기 쉽게 해주는 관리자. [![App Store][app-store Icon]](https://apps.apple.com/app/id1503649026?pt=119209922&ct=github)
+* [Zmina](https://zmina.app) - 붙여넣을 앱에 따라 알맞은 동작을 제안하는 클립보드 관리자.
 
 ### 메뉴 바 도구
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -1262,6 +1262,7 @@ Awesome Mac
 * [SnippetCraft](https://getsnippetcraft.com) - 适用于 macOS 的全系统文本扩展、片段管理和剪贴板历史工具。
 * [uPaste](https://okaapps.com/product/1503649026) - 自动整理剪贴板历史和常用片段的管理器。 [![App Store][app-store Icon]](https://apps.apple.com/app/id1503649026?pt=119209922&ct=github)
 * [Yippy](https://github.com/mattDavo/Yippy) - 具有用户友好界面的剪贴板管理器。 [![Open-Source Software][OSS Icon]](https://github.com/mattDavo/Yippy) ![Freeware][Freeware Icon]
+* [Zmina](https://zmina.app) - 根据你要粘贴的目标应用推荐相应操作的剪贴板管理器。
 
 ### 菜单栏工具
 

--- a/README.md
+++ b/README.md
@@ -1227,6 +1227,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Yippy](https://github.com/mattDavo/Yippy) - Clipboard manager with user-friendly UI. [![Open-Source Software][OSS Icon]](https://github.com/mattDavo/Yippy) ![Freeware][Freeware Icon]
 * [ClipFlow](https://github.com/praneeth552/clipflow) - Free clipboard history manager with terminal-style navigation. [![Open-Source Software][OSS Icon]](https://github.com/praneeth552/clipflow) ![Freeware][Freeware Icon]
 * [Pesty](https://github.com/momenbasel/pesty) - Free and open-source clipboard manager inspired by Paste, with a slide-up color-coded strip, pinboards, and search. [![Open-Source Software][OSS Icon]](https://github.com/momenbasel/pesty) ![Freeware][Freeware Icon] ![Native App][Native Icon]
+* [Zmina](https://zmina.app) - Clipboard manager that suggests actions based on the app you're pasting into.
 
 ### Menu Bar Tools
 


### PR DESCRIPTION
Adds Zmina to Clipboard Tools, synced across `README.md`, `README-zh.md`, `README-ja.md`, and `README-ko.md`.

Zmina is a paid, closed-source macOS clipboard manager distributed directly rather than through the App Store, so the entry carries no OSS / Freeware / App Store icon, matching how SnippetCraft is listed.

https://zmina.app