### PR TITLE
Add HanziKey as a Chinese reading assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -1108,6 +1108,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [DeepL](https://www.deepl.com/en/app/) - Best quality translations ![Freeware][Freeware Icon]
 * [Easydict](https://github.com/tisfeng/Easydict) - A concise dictionary and translator for looking up words and translating text. [![Open-Source Software][OSS Icon]](https://github.com/tisfeng/Easydict)
 * [Grammarly](https://app.grammarly.com/) - Refine your english
+* [HanziKey](https://www.hanzikey.com/) - Chinese reading assistant with hover popups for pinyin and definitions in any app. ![Freeware][Freeware Icon]
 * [iTranslate](https://www.itranslate.com/) - Translation app for text and web pages in multiple languages. ![Freeware][Freeware Icon]
 * [Live Translator](https://github.com/umutcetinkaya/live-translator) - Real-time on-screen translation of any system audio (YouTube, podcasts, meetings) using OpenAI or Gemini. [![Open-Source Software][OSS Icon]](https://github.com/umutcetinkaya/live-translator) ![Freeware][Freeware Icon]
 * [Ludwig](https://ludwig.guru) - Linguistic search engine that helps you to write better in English.


### PR DESCRIPTION
Free macOS pop-up dictionary for Chinese. Works in any app (PDFs, native apps, video subtitles), not just the browser

NOTE: A similar PR may already be submitted! Please search among the Pull request before creating one.

### Types of Changes

**What types of changes does your PR introduce?** Put an x in all boxes that apply

- [x] New addition to list
- [ ] Fixing bug in existing item in list
- [ ] Removing item from list
- [ ] Changing structure (organization) of list

### Proposed Changes

**Describe each of your changes here to communicate to the maintainers why we should accept this pull request.**

HanziKey fills a specific niche not currently covered by any Translation Tools entry: a native macOS hover-popup dictionary for Chinese, working anywhere on screen (any app, video subtitles, PDFs, images).

Chinese learners typically use browser extensions like Zhongwen or Yomitan for hover popups, but those are stuck inside the browser. HanziKey brings that hover-popup workflow to the whole Mac (including PDFs, native apps, video players, and iMessage) using the offline Vision framework for OCR and CC-CEDICT for dictionary data. Everything runs locally, no accounts, no network required.

### PR Checklist

Put an x in the boxes once you've completed each step. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important
- [x] I have added necessary documentation (if appropriate)
