### PR TITLE
Add MacMonitor to system monitoring tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1594,6 +1594,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [NitroShare](https://nitroshare.net/) - Cross-platform network file transfer utility. [![Open-Source Software][OSS Icon]](https://github.com/nitroshare/nitroshare-desktop) ![Freeware][Freeware Icon]
 * [OnyX](https://www.titanium-software.fr/en/onyx.html) - System maintenance utility for cleanup, verification, and hidden settings. ![Freeware][Freeware Icon]
 * [Paragon NTFS](https://www.paragon-software.com/home/ntfs-mac/) - Read/write access to NTFS in macOS Sierra.
+* [MacMonitor](https://macmonitor.pages.dev) - Free native Swift menu bar app showing CPU thermal state, RAM, disk and battery in real time. [![Open-Source Software][OSS Icon]](https://github.com/bulldozestore/macmonitor) ![Freeware][Freeware Icon]
 * [stats](https://github.com/exelban/stats) - free Mac system monitor for the menubar. [![Open-Source Software][OSS Icon]](https://github.com/exelban/stats)
 * [Sensei](https://sensei.app/) - Performance toolkit for monitoring, cleanup, and hardware diagnostics.
 * [SiliconScope](https://siliconscope.calidalab.ai) - Sudoless Apple Silicon system monitor (menu bar + dashboard) with first-class ANE, Media Engine and memory-bandwidth tracking plus an E/P-core breakdown — the chip-level signals Activity Monitor doesn't show. [![Open-Source Software][OSS Icon]](https://github.com/kennss/SiliconScope) ![Freeware][Freeware Icon]


### PR DESCRIPTION
### Types of Changes
- [x] New addition to list

### Proposed Changes
Adding MacMonitor — a free, open source native Swift macOS menu bar app that shows CPU thermal state, RAM, disk and battery in real time. MIT license, Universal Binary (Apple Silicon + Intel).

- Homepage: https://macmonitor.pages.dev
- GitHub: https://github.com/bulldozestore/macmonitor

### PR Checklist
- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important
- [x] I have added necessary documentation (if appropriate)