### PR TITLE
Add Cadre screen recorder

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -745,6 +745,7 @@ Awesome Mac
 ### 画面録画
 
 * [BetterCapture](https://jsattler.github.io/BetterCapture/) - プロフェッショナルなエンコーディングサポートを備えた無料のオープンソーススクリーンレコーダー。 [![Open-Source Software][OSS Icon]](https://github.com/jsattler/BetterCapture) ![Freeware][Freeware Icon]
+* [Cadre](https://cadre.cam/) - AppleシリコンMac向けの画面録画・タイムライン動画編集ツールで、シネマティックズーム、オンデバイス字幕、MCPエージェント操作に対応。
 * [Capty](https://capty.app/) - 編集機能と注釈機能を備えた画面キャプチャ・録画ツール。
 * [Capso](https://github.com/lzhgus/Capso) - 注釈、OCR、Webcamオーバーレイに対応したオープンソースのスクリーンショット・画面録画ツール。 [![Open-Source Software][OSS Icon]](https://github.com/lzhgus/Capso) ![Freeware][Freeware Icon]
 * [Gifox](https://gifox.app) - GIF録画と共有。

--- a/README-ko.md
+++ b/README-ko.md
@@ -598,6 +598,7 @@ Awesome Mac
 ### 화면 녹화
 
 * [BetterCapture](https://jsattler.github.io/BetterCapture/) - 전문적인 인코딩을 지원하는 무료 오픈소스 화면 녹화기. [![Open-Source Software][OSS Icon]](https://github.com/jsattler/BetterCapture) ![Freeware][Freeware Icon]
+* [Cadre](https://cadre.cam/) - Apple Silicon Mac용 화면 녹화 및 타임라인 동영상 편집 도구로, 시네마틱 줌, 온디바이스 자막, MCP 에이전트 제어를 지원합니다.
 * [Capty](https://capty.app/) - 편집과 주석 기능을 갖춘 화면 캡처 및 녹화 도구.
 * [Capso](https://github.com/lzhgus/Capso) - 주석, OCR, 웹캠 오버레이를 지원하는 오픈 소스 스크린샷 및 화면 녹화 도구입니다. [![Open-Source Software][OSS Icon]](https://github.com/lzhgus/Capso) ![Freeware][Freeware Icon]
 * [Gifox](https://gifox.app) - GIF 녹화 및 공유.

--- a/README-zh.md
+++ b/README-zh.md
@@ -529,6 +529,7 @@ Awesome Mac
 ### 屏幕录制
 
 * [BetterCapture](https://jsattler.github.io/BetterCapture/) - 免费开源的专业屏幕录制工具。[![Open-Source Software][OSS Icon]](https://github.com/jsattler/BetterCapture) ![Freeware][Freeware Icon]
+* [Cadre](https://cadre.cam/) - 面向 Apple 芯片 Mac 的屏幕录制与时间线视频编辑工具，支持电影级缩放、本地字幕和 MCP 智能体控制。
 * [GifCapture](https://github.com/onmyway133/GifCapture) - 开源 macOS 截屏生成 Gif 工具。[![Open-Source Software][OSS Icon]](https://github.com/onmyway133/GifCapture) ![Freeware][Freeware Icon]
 * [Gifox](https://gifox.app) - 专业的高颜值 GIF 录制应用。
 * [GIF Brewery](https://gfycat.com/gifbrewery) - GIF Brewery gives everyone the power to create stunning GIFs from video files. [![App Store][app-store Icon]](https://apps.apple.com/cn/app/gif-brewery-by-gfycat/id1081413713?platform=mac) ![Freeware][Freeware Icon]

--- a/README.md
+++ b/README.md
@@ -744,6 +744,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 ### Screen Recording
 
 * [BetterCapture](https://jsattler.github.io/BetterCapture/) - Free and open source screen recorder with professional encoding support. [![Open-Source Software][OSS Icon]](https://github.com/jsattler/BetterCapture) ![Freeware][Freeware Icon]
+* [Cadre](https://cadre.cam/) - Screen recorder and timeline video editor for Apple Silicon Macs, with cinematic zooms, on-device captions, and MCP agent control.
 * [Capty](https://capty.app/) - Screen capture and recording tool with built-in editing and annotations.
 * [Capso](https://github.com/lzhgus/Capso) - Open-source screenshot and screen recording tool with annotations, OCR, and webcam overlays. [![Open-Source Software][OSS Icon]](https://github.com/lzhgus/Capso) ![Freeware][Freeware Icon]
 * [Gifox](https://gifox.app) - Gif Recording and Sharing.


### PR DESCRIPTION
## What

Adds [Cadre](https://cadre.cam/) to the Screen Recording section in the English, Chinese, Japanese, and Korean lists, in alphabetical order.

Cadre is a screen recorder and timeline video editor for Apple Silicon Macs with cinematic zooms, on-device captions, and local MCP agent control. Recording, editing, and preview are free; Pro is required for export. The downloadable app is Developer ID signed and Apple-notarized.

No open-source or freeware badge is applied.

## Disclosure

I am the creator of Cadre. The four concise descriptions were prepared with AI assistance and checked against the live product and each language list.