### PR TITLE
Add Boldaram to Clipboard Tools

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1197,6 +1197,7 @@ Awesome Mac
 
 ### クリップボードツール
 
+* [Boldaram](https://boldaram.beside-co.com/) - コピーしたものをリスがくわえて預かってくれるクリップボードマネージャー。
 * [Buffer](https://samirpatil2000.github.io/products/buffer/) - 画像OCRとブックマークに対応した軽量なネイティブクリップボードマネージャー。 [![Open-Source Software][OSS Icon]](https://github.com/samirpatil2000/Buffer) ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [CleanClip](https://cleanclip.cc) - macOS史上最もクリーンなクリップボードマネージャー！ ![Freeware][Freeware Icon]
 * [Clipboard](https://getclipboard.app/) - すべてのプラットフォーム対応の使いやすいターミナルクリップボードマネージャー。 [![Open-Source Software][OSS Icon]](https://github.com/Slackadays/Clipboard) ![Freeware][Freeware Icon]

--- a/README-ko.md
+++ b/README-ko.md
@@ -905,6 +905,7 @@ Awesome Mac
 
 ### 클립보드 도구
 
+* [Boldaram](https://boldaram.beside-co.com/) - 복사한 걸 다람쥐가 물고 있어주는 클립보드 관리자.
 * [Buffer](https://samirpatil2000.github.io/products/buffer/) - 이미지 OCR과 북마크를 지원하는 가벼운 네이티브 클립보드 관리자입니다. [![Open-Source Software][OSS Icon]](https://github.com/samirpatil2000/Buffer) ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [Clippy](https://github.com/yarasaa/Clippy) - 콘텐츠 인식 미리보기, AI 변환, 내장 스크린샷 편집기, 파일 변환기를 갖춘 스마트 클립보드 관리자. [![Open-Source Software][OSS Icon]](https://github.com/yarasaa/Clippy) ![Freeware][Freeware Icon]
 * [ClipHistory](https://github.com/weiykong/ClipHistory) - 단축키 즉시 팝업, 검색, 고정, 텍스트/이미지 기록을 지원하는 가벼운 네이티브 클립보드 관리자. [![Open-Source Software][OSS Icon]](https://github.com/weiykong/ClipHistory) ![Freeware][Freeware Icon]

--- a/README-zh.md
+++ b/README-zh.md
@@ -1235,6 +1235,7 @@ Awesome Mac
 
 ### 剪贴板工具
 
+* [Boldaram](https://boldaram.beside-co.com/) - 复制的内容由一只松鼠帮你叼着的剪贴板管理工具。
 * [Buffer](https://samirpatil2000.github.io/products/buffer/) - 轻量的原生剪贴板管理工具，支持图片 OCR 和书签。 [![Open-Source Software][OSS Icon]](https://github.com/samirpatil2000/Buffer) ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [CleanClip](https://cleanclip.cc) - 最简洁的剪贴板管理器。 ![Freeware][Freeware Icon]
 * [ClipMenu](http://www.clipmenu.com) - 一个剪贴板操作的管理器。[![Open-Source Software][OSS Icon]](https://github.com/naotaka/ClipMenu) ![Freeware][Freeware Icon]

--- a/README.md
+++ b/README.md
@@ -1200,6 +1200,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 
 ### Clipboard Tools
 
+* [Boldaram](https://boldaram.beside-co.com/) - Clipboard manager where a squirrel holds onto what you copy.
 * [Buffer](https://samirpatil2000.github.io/products/buffer/) - Lightweight native clipboard manager with bookmarks and OCR for images. [![Open-Source Software][OSS Icon]](https://github.com/samirpatil2000/Buffer) ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [CleanClip](https://cleanclip.cc) - The cleanest Clipboard Manager on macOS, ever! ![Freeware][Freeware Icon]
 * [Clipboard](https://getclipboard.app/) - Easy-to-use terminal clipboard manager for all platforms. [![Open-Source Software][OSS Icon]](https://github.com/Slackadays/Clipboard) ![Freeware][Freeware Icon]


### PR DESCRIPTION
### Types of Changes

- [x] New addition to list
- [ ] Fixing bug in existing item in list
- [ ] Removing item from list
- [ ] Changing structure (organization) of list

### Proposed Changes

Adds **Boldaram** (https://boldaram.beside-co.com/) to the Clipboard Tools section.

1. It is a clipboard manager for macOS with a distinct take: a squirrel character visually holds onto what you copied, instead of the usual list UI. Localized in English, Korean, and Japanese.
2. Added in alphabetical order (between Buffer and CleanClip), synced across `README.md`, `README-ko.md`, `README-zh.md`, and `README-ja.md` per the contributing guidelines. One-sentence description, no icons (paid app, not open source, not on the Mac App Store).

Disclosure: I am the developer of this app.

### PR Checklist

- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important
- [ ] I have added necessary documentation (if appropriate)

### Further Comments

None. A single-entry addition following the existing format of the section.