### PR TITLE
Add Sundown to Quality of Life Improvements

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1557,6 +1557,7 @@ Awesome Mac
 * [Shifty](http://shifty.natethompson.io) - Night Shiftをより細かく制御できるmacOSメニューバーアプリ。 [![Open-Source Software][OSS Icon]](https://github.com/thompsonate/Shifty)
 * [Snap](http://indragie.com/snap) - アプリを素早く起動。非常に簡単なショートカット管理。 ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id418073146?platform=mac)
 * [Shareful](https://sindresorhus.com/shareful) - コピー、保存、開くアクションでシステム共有メニューを強化。 ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id1522267256?platform=mac)
+* [Sundown](https://trysundown.com) - Night Shiftの限界を超えてディスプレイを暖色・減光（最低500K）、日没から日の出のスケジュールで動作。 ![Native App][Native Icon]
 * [Mouse Jiggler for Mac](https://mousejigglermac.com) - マウスムーバーでMacのスリープを防止。 ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id6740313656?platform=mac)
 
 ### システム関連ツール

--- a/README-ja.md
+++ b/README-ja.md
@@ -1557,7 +1557,7 @@ Awesome Mac
 * [Shifty](http://shifty.natethompson.io) - Night Shiftをより細かく制御できるmacOSメニューバーアプリ。 [![Open-Source Software][OSS Icon]](https://github.com/thompsonate/Shifty)
 * [Snap](http://indragie.com/snap) - アプリを素早く起動。非常に簡単なショートカット管理。 ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id418073146?platform=mac)
 * [Shareful](https://sindresorhus.com/shareful) - コピー、保存、開くアクションでシステム共有メニューを強化。 ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id1522267256?platform=mac)
-* [Sundown](https://trysundown.com) - Night Shiftの限界を超えてディスプレイを暖色・減光（最低500K）、日没から日の出のスケジュールで動作。 ![Native App][Native Icon]
+* [Sundown](https://trysundown.com) - Night Shiftの限界を超えてディスプレイを暖色・減光（最低500K）、日没から日の出のスケジュールで動作。
 * [Mouse Jiggler for Mac](https://mousejigglermac.com) - マウスムーバーでMacのスリープを防止。 ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id6740313656?platform=mac)
 
 ### システム関連ツール

--- a/README-ko.md
+++ b/README-ko.md
@@ -986,6 +986,7 @@ Awesome Mac
 * [Crisp](https://didriksg.github.io/Crisp/) - 메뉴 막대에서 외부 디스플레이 관리: HiDPI 스케일링, DDC 밝기, 색상 및 프리셋. [![Open-Source Software][OSS Icon]](https://github.com/didriksg/Crisp) ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [macUSB](https://github.com/Kruszoneq/macUSB) - Apple Silicon Mac용 부팅 가능한 macOS/OS X 설치 프로그램 생성기. [![Open-Source Software][OSS Icon]](https://github.com/Kruszoneq/macUSB) ![Freeware][Freeware Icon]
 * [DisplayBuddy](https://displaybuddy.app) - 외부 디스플레이의 밝기, 대비, 입력 소스를 제어하는 도구.
+* [Sundown](https://trysundown.com) - Night Shift 한계를 넘어 디스플레이를 더 따뜻하고 어둡게(최저 500K), 일몰-일출 스케줄로 조절하는 메뉴 막대 앱. ![Native App][Native Icon]
 * [OpenDisplay](https://opendisplay.app) - 여분의 iPhone이나 iPad를 USB 또는 WiFi로 Mac의 보조 디스플레이로 사용하는 도구 (터치 입력 지원). [![Open-Source Software][OSS Icon]](https://github.com/peetzweg/opendisplay) ![Freeware][Freeware Icon]
 * [Phosphene](https://kagerou.glass/phosphene/) - 어떤 동영상이든 macOS 배경화면으로 사용하세요. 데스크톱과 잠금 화면을 지원하며 시스템 설정에서 직접 선택합니다. [![Open-Source Software][OSS Icon]](https://github.com/kageroumado/phosphene) ![Freeware][Freeware Icon]
 * [WaifuX](https://jipika.github.io/WaifuX) - 배경화면, 동적 배경, 애니메이션 영상을 한곳에서 즐길 수 있는 오픈 소스 ACG 앱입니다. [![Open-Source Software][OSS Icon]](https://github.com/jipika/WaifuX) ![Freeware][Freeware Icon]

--- a/README-ko.md
+++ b/README-ko.md
@@ -986,7 +986,7 @@ Awesome Mac
 * [Crisp](https://didriksg.github.io/Crisp/) - 메뉴 막대에서 외부 디스플레이 관리: HiDPI 스케일링, DDC 밝기, 색상 및 프리셋. [![Open-Source Software][OSS Icon]](https://github.com/didriksg/Crisp) ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [macUSB](https://github.com/Kruszoneq/macUSB) - Apple Silicon Mac용 부팅 가능한 macOS/OS X 설치 프로그램 생성기. [![Open-Source Software][OSS Icon]](https://github.com/Kruszoneq/macUSB) ![Freeware][Freeware Icon]
 * [DisplayBuddy](https://displaybuddy.app) - 외부 디스플레이의 밝기, 대비, 입력 소스를 제어하는 도구.
-* [Sundown](https://trysundown.com) - Night Shift 한계를 넘어 디스플레이를 더 따뜻하고 어둡게(최저 500K), 일몰-일출 스케줄로 조절하는 메뉴 막대 앱. ![Native App][Native Icon]
+* [Sundown](https://trysundown.com) - Night Shift 한계를 넘어 디스플레이를 더 따뜻하고 어둡게(최저 500K), 일몰-일출 스케줄로 조절하는 메뉴 막대 앱.
 * [OpenDisplay](https://opendisplay.app) - 여분의 iPhone이나 iPad를 USB 또는 WiFi로 Mac의 보조 디스플레이로 사용하는 도구 (터치 입력 지원). [![Open-Source Software][OSS Icon]](https://github.com/peetzweg/opendisplay) ![Freeware][Freeware Icon]
 * [Phosphene](https://kagerou.glass/phosphene/) - 어떤 동영상이든 macOS 배경화면으로 사용하세요. 데스크톱과 잠금 화면을 지원하며 시스템 설정에서 직접 선택합니다. [![Open-Source Software][OSS Icon]](https://github.com/kageroumado/phosphene) ![Freeware][Freeware Icon]
 * [WaifuX](https://jipika.github.io/WaifuX) - 배경화면, 동적 배경, 애니메이션 영상을 한곳에서 즐길 수 있는 오픈 소스 ACG 앱입니다. [![Open-Source Software][OSS Icon]](https://github.com/jipika/WaifuX) ![Freeware][Freeware Icon]

--- a/README-zh.md
+++ b/README-zh.md
@@ -1163,6 +1163,7 @@ Awesome Mac
 * [eZip](http://ezip.awehunt.com) - 轻量压缩解压工具，支持 ZIP、RAR、7Z 等常见格式。 ![Freeware][Freeware Icon]
 * [Final2x](https://github.com/Tohrusky/Final2x) - 这是一个强大的工具，允许使用多种模型对图像进行任意大小的超分辨率处理，旨在提高图像的分辨率和质量，使其更加清晰和详细。[![Open-Source Software][OSS Icon]](https://github.com/Tohrusky/Final2x) ![Freeware][Freeware Icon]
 * [f.lux](https://justgetflux.com/) - 自动调整您的电脑屏幕，以匹配亮度。![Freeware][Freeware Icon]
+* [Sundown](https://trysundown.com) - 将 Mac 屏幕调得比夜览（Night Shift）更暖更暗（低至 500K），按日落到日出的时间表自动运行。 ![Native App][Native Icon]
 * [Grayscale Mode](https://github.com/rkbhochalya/grayscale-mode) - 通过菜单栏或快捷键快速切换灰度显示。 [![Open-Source Software][OSS Icon]](https://github.com/rkbhochalya/grayscale-mode) ![Freeware][Freeware Icon]
 * [FnKeyboard](https://github.com/kotique123/FnKeyboard) - 在菜单栏快速调用功能键。 [![Open-Source Software][OSS Icon]](https://github.com/kotique123/FnKeyboard) ![Freeware][Freeware Icon]
 * [Freeter](https://freeter.io/) - 按项目整理应用、链接和文件的工作台。 [![Open-Source Software][OSS Icon]](https://github.com/FreeterApp/Freeter) ![Freeware][Freeware Icon]

--- a/README-zh.md
+++ b/README-zh.md
@@ -1163,7 +1163,7 @@ Awesome Mac
 * [eZip](http://ezip.awehunt.com) - 轻量压缩解压工具，支持 ZIP、RAR、7Z 等常见格式。 ![Freeware][Freeware Icon]
 * [Final2x](https://github.com/Tohrusky/Final2x) - 这是一个强大的工具，允许使用多种模型对图像进行任意大小的超分辨率处理，旨在提高图像的分辨率和质量，使其更加清晰和详细。[![Open-Source Software][OSS Icon]](https://github.com/Tohrusky/Final2x) ![Freeware][Freeware Icon]
 * [f.lux](https://justgetflux.com/) - 自动调整您的电脑屏幕，以匹配亮度。![Freeware][Freeware Icon]
-* [Sundown](https://trysundown.com) - 将 Mac 屏幕调得比夜览（Night Shift）更暖更暗（低至 500K），按日落到日出的时间表自动运行。 ![Native App][Native Icon]
+* [Sundown](https://trysundown.com) - 将 Mac 屏幕调得比夜览（Night Shift）更暖更暗（低至 500K），按日落到日出的时间表自动运行。
 * [Grayscale Mode](https://github.com/rkbhochalya/grayscale-mode) - 通过菜单栏或快捷键快速切换灰度显示。 [![Open-Source Software][OSS Icon]](https://github.com/rkbhochalya/grayscale-mode) ![Freeware][Freeware Icon]
 * [FnKeyboard](https://github.com/kotique123/FnKeyboard) - 在菜单栏快速调用功能键。 [![Open-Source Software][OSS Icon]](https://github.com/kotique123/FnKeyboard) ![Freeware][Freeware Icon]
 * [Freeter](https://freeter.io/) - 按项目整理应用、链接和文件的工作台。 [![Open-Source Software][OSS Icon]](https://github.com/FreeterApp/Freeter) ![Freeware][Freeware Icon]

--- a/README.md
+++ b/README.md
@@ -1562,6 +1562,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Shifty](https://shifty.natethompson.io) - A macOS menu bar app that gives you more control over Night Shift. [![Open-Source Software][OSS Icon]](https://github.com/thompsonate/Shifty)
 * [Snap](https://indragie.com/snap) - Launch an app in a snap. Ridiculously easy shortcut management. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id418073146?platform=mac)
 * [Shareful](https://sindresorhus.com/shareful) - Supercharge the system share menu with copy, save, and open actions. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id1522267256?platform=mac)
+* [Sundown](https://trysundown.com) - Warm and dim the display beyond Night Shift's limits, on a sunset-to-sunrise schedule. ![Native App][Native Icon]
 * [Mouse Jiggler for Mac](https://mousejigglermac.com) - Prevent Mac from sleep with Mac Mouse Mover. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id6740313656?platform=mac)
 
 ### System Related Tools

--- a/README.md
+++ b/README.md
@@ -1562,7 +1562,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Shifty](https://shifty.natethompson.io) - A macOS menu bar app that gives you more control over Night Shift. [![Open-Source Software][OSS Icon]](https://github.com/thompsonate/Shifty)
 * [Snap](https://indragie.com/snap) - Launch an app in a snap. Ridiculously easy shortcut management. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id418073146?platform=mac)
 * [Shareful](https://sindresorhus.com/shareful) - Supercharge the system share menu with copy, save, and open actions. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id1522267256?platform=mac)
-* [Sundown](https://trysundown.com) - Warm and dim the display beyond Night Shift's limits, on a sunset-to-sunrise schedule. ![Native App][Native Icon]
+* [Sundown](https://trysundown.com) - Warm and dim the display beyond Night Shift's limits, on a sunset-to-sunrise schedule.
 * [Mouse Jiggler for Mac](https://mousejigglermac.com) - Prevent Mac from sleep with Mac Mouse Mover. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id6740313656?platform=mac)
 
 ### System Related Tools


### PR DESCRIPTION
Adds **Sundown** to Utilities → Quality of Life Improvements, next to the other display-comfort tools (f.lux, Shifty, Dimly).

**[Sundown](https://trysundown.com)** is a Mac menu-bar app that warms and dims the display beyond what Night Shift allows — Night Shift's warmest setting is roughly 2700K, Sundown goes down to 500K — on a sunset-to-sunrise schedule or manual control. Brightness dimming works via the gamma curve, so the screen can go darker than the backlight floor without added flicker.

- Native Swift, no Electron (~6 MB download) — `![Native App][Native Icon]` added
- Paid app ($4.99/mo · $39/yr · $79 lifetime) with a 7-day free trial, so no Freeware icon
- macOS 14+ (Sonoma or later), Apple Silicon + Intel
- Entry synced across `README.md`, `README-zh.md`, `README-ja.md`, `README-ko.md` per the contributing guidelines

Disclosure: I'm the developer of Sundown. Happy to adjust wording, placement, or icons to fit the list's conventions.
