### PR TITLE
Add Persona to Note-taking

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Boostnote](https://boostnote.io/) - Note-taking app made for programmers. [![Open-Source Software][OSS Icon]](https://github.com/BoostIO/Boostnote)
 * [Craft](https://www.craft.do/) - Notetaking and writing made beautiful. [![App Store][app-store Icon]](https://apps.apple.com/se/app/craft-docs-and-notes-editor/id1487937127?platform=mac)
 * [Dnote](https://www.getdnote.com/) - A simple command line notebook with multi-device sync and a web interface. [![Open-Source Software][OSS Icon]](https://github.com/dnote/dnote) ![Freeware][Freeware Icon]
+* [Persona](https://github.com/jayamitkatariya/personacli) - Local-first personal workspace: notes and tasks as plain Markdown with an AI chat grounded in your own files. [![Open-Source Software][OSS Icon]](https://github.com/jayamitkatariya/personacli)
 * [Email Me](https://emailmeapp.net/) - Email yourself and much more with just one tap, native on macOS, iOS and WatchOS. [![App Store][app-store Icon]](https://apps.apple.com/us/app/email-me-notes-in-one-tap/id1090744587?platform=mac)
 * [Evernote](https://evernote.com/) - Infamous note-taking app, available on many platforms. ![Freeware][Freeware Icon]
 * [FSNotes](https://fsnot.es/) - File System Notes is a modern notes manager, native on macOS and iOS. [![Open-Source Software][OSS Icon]](https://github.com/glushchenko/fsnotes) [![App Store][app-store Icon]](https://apps.apple.com/gb/app/fsnotes/id1277179284?platform=mac)


### PR DESCRIPTION
Adds [Persona](https://github.com/jayamitkatariya/personacli) to **Note-taking**.

Persona is a local-first personal workspace for macOS (Apple Silicon): notes and tasks stored as plain Markdown files on disk, with an AI chat grounded in those files. Works with Ollama or any OpenAI-compatible API. MIT, free.