### PR TITLE
Add mead to Package Managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1661,6 +1661,7 @@ If you come across websites offering pirated software or cracks, please post [HE
 * [Homebrew](https://brew.sh/) - The missing package manager for macOS. ![Freeware][Freeware Icon] [![Open-Source Software][OSS Icon]](https://github.com/Homebrew/brew/)
 * [MacPorts](https://www.macports.org/) - Package manager for installing and maintaining open-source software. ![Freeware][Freeware Icon] [![Open-Source Software][OSS Icon]](https://github.com/macports/)
 * [MacUpdate Desktop](https://www.macupdate.com/) - Simplifies finding, buying and installing apps for your Mac.
+* [mead](https://getmead.app) - Native Homebrew GUI for macOS, built with Go and Wails. [![Open-Source Software][OSS Icon]](https://github.com/DaKiLloTh/mead)
 
 ## Mac App Download Sites
 


### PR DESCRIPTION
mead is a free, open-source native Homebrew GUI for macOS (Go + Wails), in the same category as Applite and Cork already listed here: browse/search/install/update formulae and casks, manage taps and services, CVE scanning, no terminal needed.

- App: https://github.com/DaKiLloTh/mead
- Site: https://getmead.app

It's currently pre-alpha, understand if it's not a fit until it's more established, happy to resubmit later if so.