### PR TITLE
Rename Leafy to LeafyApp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1120,7 +1120,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 
 ## Education
 
-* [Leafy](https://leafyapp.uk/) - Look up any word on screen with ⌥A, including in PDFs and images, and save it to a searchable local library. ![Freeware][Freeware Icon]
+* [LeafyApp](https://leafyapp.uk/) - Look up any word on screen with ⌥A, including in PDFs and images, and save it to a searchable local library. ![Freeware][Freeware Icon]
 * [Wokabulary](https://wokabulary.com/) - Collect, practice, and organize your individual foreign language vocabulary. [![App Store][app-store Icon]](https://apps.apple.com/app/apple-store/id1667619825?platform=mac)
 
 ## Finance


### PR DESCRIPTION
I'm the developer of the app added in #2251. The app is now branded LeafyApp, so this renames the entry to match. The link is unchanged.