### PR TITLE
Add LeafyApp to Education (ja/ko/zh)

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1119,6 +1119,7 @@ Awesome Mac
 
 ## 教育
 
+* [LeafyApp](https://leafyapp.uk/) - ⌥A で画面上のどんな単語も、PDF や画像の中の文字まで調べ、検索できるローカルの単語帳に保存。 ![Freeware][Freeware Icon]
 * [Wokabulary](https://wokabulary.com/) - 個人の外国語語彙を収集、練習、整理。 [![App Store][app-store Icon]](https://apps.apple.com/app/apple-store/id1667619825?platform=mac)
 
 ## ファイナンス

--- a/README-ko.md
+++ b/README-ko.md
@@ -850,6 +850,7 @@ Awesome Mac
 
 ## 교육
 
+* [LeafyApp](https://leafyapp.uk/) - ⌥A로 화면의 모든 단어를 PDF와 이미지 속 글자까지 찾아보고, 검색 가능한 로컬 단어장에 저장. ![Freeware][Freeware Icon]
 * [Wokabulary](https://wokabulary.com/) - 개별 외국어 어휘를 수집, 연습 및 정리. [![App Store][app-store Icon]](https://apps.apple.com/app/apple-store/id1667619825?platform=mac)
 
 ## 금융

--- a/README-zh.md
+++ b/README-zh.md
@@ -156,6 +156,7 @@ Awesome Mac
 - [输入法](#输入法)
 - [浏览器](#浏览器)
 - [翻译工具](#翻译工具)
+- [教育](#教育)
 - [安全工具](#安全工具)
 - [科学上网](#科学上网)
 - [其它实用工具](#其它实用工具)
@@ -1066,6 +1067,10 @@ Awesome Mac
 * [Translatium](https://translatium.app) - 支持 100 多种语言文字与图片翻译的应用。 [![Open-Source Software][OSS Icon]](https://github.com/webcatalog/translatium-desktop) [![App Store][app-store Icon]](https://apps.apple.com/us/app/translatium/id1547052291?platform=mac)
 * [辞海词典](http://cidian.dict.cn/mac.html) - 学单词、背单词、辞海词典。![Freeware][Freeware Icon]
 * [有道翻译](http://cidian.youdao.com/multi.html) - 有道词典桌面版。![Freeware][Freeware Icon]
+
+## 教育
+
+* [LeafyApp](https://leafyapp.uk/) - 按 ⌥A 查屏幕上任意单词，PDF 和图片里的字也能查，并存进可搜索的本地生词库。 ![Freeware][Freeware Icon]
 
 ## 金融
 


### PR DESCRIPTION
The entry was merged in #2251 but only landed in README.md, so the ja/ko/zh lists are missing it. This adds it to all three.

- README-ja.md, README-ko.md: added to the existing Education section, before Wokabulary.
- README-zh.md: that file has no Education section yet, so this adds 教育 between 翻译工具 and 金融, matching the English order, plus the table of contents entry.

Disclosure: I'm the developer. Renaming the English entry to LeafyApp is #2648; these three use the new name already.