### PR TITLE
Add Earkeep

### DIFF
--- a/README.md
+++ b/README.md
@@ -1074,6 +1074,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Voxt](https://github.com/hehehai/voxt) - Hold-to-talk voice input tool with AI transcription rules per app and URL, and built-in translation. [![Open-Source Software][OSS Icon]](https://github.com/hehehai/voxt) ![Freeware][Freeware Icon]
 * [Whispering](https://epicenter.md/whispering/) - Multi-provider speech-to-text with AI transformations and keyboard shortcuts. [![Open-Source Software][OSS Icon]](https://github.com/EpicenterHQ/epicenter/tree/main/apps/whispering) ![Freeware][Freeware Icon]
 * [Willow Voice](https://willowvoice.com/) - AI dictation with automatic editing, style-matching, and noise optimization.
+* [Earkeep](https://earkeep.com) - Ambient meeting transcriber with always-on mic and system audio, local whisper.cpp transcription.
 
 ## Browsers
 


### PR DESCRIPTION
Add [Earkeep](https://earkeep.com) — ambient meeting transcriber with always-on mic and system audio, local whisper.cpp transcription.

Add to **Voice-to-Text** section. Earkeep is a macOS desktop app built with Tauri 2, uses local whisper.cpp for on-device transcription, and supports always-on mic + system audio capture with retroactive meeting definition via timeline.