### PR TITLE
Add Markdown Buddy to Markdown Tools

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -237,6 +237,7 @@ Awesome Mac
 * [Imark](https://github.com/migsilva89/imark) - コメントをHTMLコメントとしてドキュメント自体に保存するオープンソースのMarkdownビューア。 [![Open-Source Software][OSS Icon]](https://github.com/migsilva89/imark) ![Freeware][Freeware Icon]
 * [LightPaper](https://getlightpaper.com/) - Mac用のシンプルで美しく、かつ強力なテキストエディタ。
 * [MacDown](https://macdown.uranusjr.com/) - ライブプレビューおよびHTML/PDF出力に対応した、macOS向けのオープンソースMarkdownエディタ。 [![Open-Source Software][OSS Icon]](https://github.com/MacDownApp/macdown) ![Freeware][Freeware Icon]
+* [Markdown Buddy](https://markdownbuddy.inawa.app/) - Finder でのレンダリング済みクイックルック表示と Xcode ソースエディタ拡張に対応した、ネイティブの Markdown エディタ。 [![App Store][app-store Icon]](https://apps.apple.com/app/id6759007372?platform=mac) ![Native App][Native Icon]
 * [Marked 2](http://marked2app.com/) - すべてのライターのための洗練された強力なツールセットを備えたMarkdownプレビュー。
 * [MarkText](https://github.com/marktext/marktext) - macOS、Windows、Linuxで動作する次世代Markdownエディタ。 [![Open-Source Software][OSS Icon]](https://github.com/marktext/marktext) ![Freeware][Freeware Icon]
 * [MarkViewer](https://markviewer.com) - macOS向けのMarkdownビューア兼エディタ、AI支援編集機能付き。 ![Freeware][Freeware Icon]

--- a/README-ko.md
+++ b/README-ko.md
@@ -211,6 +211,7 @@ Awesome Mac
 * [Imark](https://github.com/migsilva89/imark) - 주석을 HTML 주석 형태로 문서 안에 직접 저장하는 오픈 소스 마크다운 뷰어. [![Open-Source Software][OSS Icon]](https://github.com/migsilva89/imark) ![Freeware][Freeware Icon]
 * [LightPaper](https://getlightpaper.com/) - 단순하고 아름다우면서도 강력한 Mac용 텍스트 편집기.
 * [MacDown](https://macdown.uranusjr.com/) - 실시간 미리보기와 HTML/PDF 내보내기를 지원하는 macOS용 오픈 소스 마크다운 편집기. [![Open-Source Software][OSS Icon]](https://github.com/MacDownApp/macdown) ![Freeware][Freeware Icon]
+* [Markdown Buddy](https://markdownbuddy.inawa.app/) - Finder에서 렌더링된 훑어보기 미리보기와 Xcode 소스 편집기 확장을 제공하는 네이티브 마크다운 편집기. [![App Store][app-store Icon]](https://apps.apple.com/app/id6759007372?platform=mac) ![Native App][Native Icon]
 * [Marked 2](http://marked2app.com/) - 작가들을 위한 우아하고 강력한 도구 세트를 갖춘 마크다운 미리보기.
 * [MarkText](https://github.com/marktext/marktext) - 차세대 마크다운 편집기. [![Open-Source Software][OSS Icon]](https://github.com/marktext/marktext) ![Freeware][Freeware Icon]
 * [MarkViewer](https://markviewer.com) - macOS용 마크다운 뷰어 겸 에디터, AI 보조 편집 지원. ![Freeware][Freeware Icon]

--- a/README-zh.md
+++ b/README-zh.md
@@ -860,6 +860,7 @@ Awesome Mac
 * [Joplin](https://joplinapp.org/) - 跨平台开源记事本，支持 Markdown 和待办事项管理。 [![Open-Source Software][OSS Icon]](https://github.com/laurent22/joplin) ![Freeware][Freeware Icon]
 * [LightPaper](https://getlightpaper.com/) - 简单的 Markdown 文本编辑器。
 * [MacDown](https://macdown.uranusjr.com/) - macOS 开源 Markdown 编辑器，支持实时预览以及导出为 HTML 或 PDF。 [![Open-Source Software][OSS Icon]](https://github.com/MacDownApp/macdown) ![Freeware][Freeware Icon]
+* [Markdown Buddy](https://markdownbuddy.inawa.app/) - 原生 Markdown 编辑器，为访达提供渲染后的快速查看预览，并附带 Xcode 源代码编辑器扩展。 [![App Store][app-store Icon]](https://apps.apple.com/app/id6759007372?platform=mac) ![Native App][Native Icon]
 * [Marked 2](http://marked2app.com/) - Markdown 文本预览编辑，为所有作家提供一套优雅而强大的工具。
 * [MarkText](https://marktext.app/) - 简单而优雅的 Markdown 编辑器，专注于速度和可用性。 [![Open-Source Software][OSS Icon]](https://github.com/marktext/marktext) ![Freeware][Freeware Icon]
 * [MarkViewer](https://markviewer.com) - 适用于 macOS 的 Markdown 查看器和编辑器，支持 AI 辅助编辑。 ![Freeware][Freeware Icon]

--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Imark](https://github.com/migsilva89/imark) - Open-source Markdown reader that stores your comments inside the document itself as HTML comments. [![Open-Source Software][OSS Icon]](https://github.com/migsilva89/imark) ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [LightPaper](https://getlightpaper.com/) - Simple, beautiful, yet powerful text editor for your Mac.
 * [MacDown](https://macdown.uranusjr.com/) - Open source Markdown editor for macOS with live preview and HTML/PDF export. [![Open-Source Software][OSS Icon]](https://github.com/MacDownApp/macdown) ![Freeware][Freeware Icon]
+* [Markdown Buddy](https://markdownbuddy.inawa.app/) - Native Markdown editor that adds rendered Quick Look previews in the Finder and an Xcode source editor extension. [![App Store][app-store Icon]](https://apps.apple.com/app/id6759007372?platform=mac) ![Native App][Native Icon]
 * [Marked 2](https://marked2app.com/) - This is the Markdown preview with an elegant and powerful set of tools for all writers.
 * [MarkText](https://github.com/marktext/marktext) - Next generation markdown editor, running on platforms of MacOS Windows and Linux. [![Open-Source Software][OSS Icon]](https://github.com/marktext/marktext) ![Freeware][Freeware Icon]
 * [MarkViewer](https://markviewer.com) - Markdown viewer and editor for macOS with AI-assisted editing. ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adding Markdown Buddy to the Markdown Tools section. I am the developer.

**What makes it different from the editors already listed:** it extends Markdown rendering outside the app itself. A Quick Look extension renders `.md` files in the Finder instead of showing raw text, and an Xcode source editor extension opens the file you are editing as rendered output. Both share the app's renderer and work once the app has been launched.

Also: workspace browsing with cross-file search and a link graph, Mermaid and KaTeX, native AppKit, 4.8 MB, sandboxed.

**Details of the entry:**

- Added to all four READMEs (`README.md`, `README-zh.md`, `README-ja.md`, `README-ko.md`), with the description translated in each. The app itself ships in those languages, so I wrote them rather than leaving English in the localized files. Corrections welcome, especially on the Korean.
- Placed alphabetically between MacDown and Marked 2.
- Badges: App Store and Native App. No Freeware badge, it is a paid app (0.99 EUR, one off, no subscription or IAP), and no OSS badge.
- App Store link uses the storefront-less form so it resolves to the visitor's country, same as the Pixley Reader entry.

Happy to adjust the wording or drop the localized versions if you would rather handle those yourself.
