### PR TITLE
Add Day Monitor to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1407,6 +1407,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Choosy](https://www.choosyosx.com) - UI, URL API and a browser extension set for managing rules where and how to open links.
 * [CurrentKey](https://currentkey.com) - Add custom names and icons to Spaces and track app usage time. [![App Store][app-store Icon]](https://apps.apple.com/us/app/currentkey/id1456226992?mt=12)
 * [CursorSense](https://www.plentycom.jp/en/cursorsense/index.html) - Mouse & trackpad driver that lets you tweak the acceleration curve and more.
+* [Day Monitor](https://defiabell.github.io/day-monitor/) - Automatic AI time tracker in your menu bar: periodic screenshots analyzed by Claude, local-only data, daily timeline and AI report. [![Open-Source Software][OSS Icon]](https://github.com/Defiabell/day-monitor) ![Freeware][Freeware Icon]
 * [Day Progress](https://sindresorhus.com/day-progress) - Time remaining today in your menu bar. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id6450280202?platform=mac)
 * [Dropzone](https://aptonic.com) - Create a popup grid of customizable actions. Scriptable in Ruby & Python.
 * [escrcpy](https://github.com/viarotel-org/escrcpy) -📱 Graphical Scrcpy to display and control Android devices, powered by Electron.[![Open-Source Software][OSS Icon]](https://github.com/viarotel-org/escrcpy) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds **Day Monitor** to the Productivity section (alphabetical position, after CursorSense).

- Automatic AI time tracker living in the macOS menu bar: takes a screenshot every ~20s, has Claude classify the activity, and builds a daily timeline / category breakdown / AI-written report.
- Open source (MIT), Tauri 2 (Rust + React): https://github.com/Defiabell/day-monitor
- Privacy: screenshots are never stored — only a one-line text description in a local SQLite DB; no telemetry.
- Prebuilt releases available (Apple Silicon): https://github.com/Defiabell/day-monitor/releases
- Live demo of the dashboard (sample data): https://defiabell.github.io/day-monitor/

Entry follows the existing format with OSS + Freeware icons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)