### PR TITLE
Add LibreMerge to Developer Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [JsonStudio](https://jsonstudio.js.org/) - Local-first JSON workspace for formatting, editing, diffing, converting, validating, and extracting JSON from logs. [![Open-Source Software][OSS Icon]](https://github.com/sundegan/JsonStudio) ![Freeware][Freeware Icon]
 * [Kaleidoscope](https://www.kaleidoscopeapp.com/) - Compare text, images, and folders.
 * [Koala](https://koala-app.com) - GUI application for Less, Sass, Compass and CoffeeScript compilation. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/oklai/koala/)
+* [LibreMerge](https://github.com/iagodpassos/libremerge) - Diff and merge tool for files, folders and CSV tables, bringing the WinMerge engine to macOS with a native Qt interface. [![Open-Source Software][OSS Icon]](https://github.com/iagodpassos/libremerge) ![Freeware][Freeware Icon]
 * [Loca Studio](https://www.cunningo.com/locastudio/index.html) - Analyze, review, and edit app translations. [![App Store][app-store Icon]](https://apps.apple.com/app/id1465684707?platform=mac)
 * [LINQPad](https://www.linqpad.net/) - .NET scratchpad for running code, queries, and database exploration. ![Freeware][Freeware Icon]
 * [Loupe](https://github.com/smughead/Loupe) - Accessibility inspector that generates AI-agent-ready output. [![Open-Source Software][OSS Icon]](https://github.com/smughead/Loupe) ![Freeware][Freeware Icon]


### PR DESCRIPTION
**[LibreMerge](https://github.com/iagodpassos/libremerge)** is a free, open-source (GPL-3.0) diff and merge tool: side-by-side file compare/merge (2 and 3-way), folder comparison, CSV/TSV table comparison with cell-level diffs, syntax highlighting for 47 languages, light/dark themes. It brings WinMerge's battle-tested comparison engine (369 upstream tests passing) to macOS with a native Qt 6 interface — universal binary (Intel + Apple Silicon), macOS 12+.

- Website/repo: https://github.com/iagodpassos/libremerge
- Install: dmg from releases or `brew install --cask iagodpassos/tap/libremerge`
- Placed alphabetically in Developer Utilities, following the entry format (OSS + Freeware icons).