### PR TITLE
Add reminal to Remote Login Software

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1626,6 +1626,7 @@ Awesome Mac
 * [Moonlight](https://github.com/moonlight-stream/moonlight-qt) - PC（Windows、Mac、Linux、Steam Link）向けGameStreamクライアント。 [![Open-Source Software][OSS Icon]](https://github.com/moonlight-stream/moonlight-qt) ![Freeware][Freeware Icon]
 * [Parsec](https://parsec.app) - 低遅延のリモートデスクトップ兼ゲームストリーミングツール。
 * [RealVNC](https://www.realvnc.com) - デスクトップとモバイルのリモートアクセスのためのオリジナルかつ最高のソフトウェア。
+* [reminal](https://reminal.app) - すべてのウィンドウとターミナルを任意のブラウザにストリーミングし、蓋を閉じてもMacを稼働させ続ける。 [![Open-Source Software][OSS Icon]](https://github.com/harshalgajjar/Reminal) ![Freeware][Freeware Icon]
 * [RoyalTSX](https://www.royalapps.com/ts/mac/features) - 複数プロトコルの接続をまとめて管理できるリモート接続クライアント。 ![Freeware][Freeware Icon]
 * [RustDesk](https://rustdesk.com/) - もう一つのリモートデスクトップソフトウェア。 [![Open-Source Software][OSS Icon]](https://github.com/rustdesk/rustdesk) ![Freeware][Freeware Icon]
 * [Steam Link](https://apps.apple.com/us/app/steam-link/id1246969117?platform=mac) - Steam Linkアプリを使えば、すべてのコンピューターでSteamゲームをプレイ可能。 ![Freeware][Freeware Icon]

--- a/README-ko.md
+++ b/README-ko.md
@@ -1090,6 +1090,7 @@ Awesome Mac
 * [AnyDesk](https://anydesk.com/) - 빠르고 안전한 원격 데스크톱 소프트웨어. ![Freeware][Freeware Icon]
 * [MoonProxy](https://github.com/MoonProxyHQ/moonproxy-desktop) - FRP의 GUI 클라이언트. 클릭 한 번으로 로컬 서비스를 인터넷에 공개. [![Open-Source Software][OSS Icon]](https://github.com/MoonProxyHQ/moonproxy-desktop) ![Freeware][Freeware Icon]
 * [Parsec](https://parsec.app/) - 저지연 원격 데스크톱 및 게임 스트리밍 도구.
+* [reminal](https://reminal.app) - 모든 창과 터미널을 브라우저로 스트리밍하고, 덮개를 닫아도 Mac을 계속 실행. [![Open-Source Software][OSS Icon]](https://github.com/harshalgajjar/Reminal) ![Freeware][Freeware Icon]
 * [RoyalTSX](https://www.royalapps.com/ts/mac/features) - 여러 프로토콜을 한곳에서 관리하는 원격 접속 클라이언트. ![Freeware][Freeware Icon]
 * [RustDesk](https://rustdesk.com/) - 오픈 소스 원격 데스크톱 솔루션. [![Open-Source Software][OSS Icon]](https://github.com/rustdesk/rustdesk) ![Freeware][Freeware Icon]
 * [TeamViewer](https://www.teamviewer.com/) - 원격 지원과 화면 공유를 위한 도구. ![Freeware][Freeware Icon]

--- a/README-zh.md
+++ b/README-zh.md
@@ -1498,6 +1498,7 @@ Awesome Mac
 * [Moonlight](https://github.com/moonlight-stream/moonlight-qt) - 高画质且低延时的游戏串流 [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/moonlight-stream/moonlight-qt)
 * [Parsec](https://parsec.app/) - 低延迟远程桌面与游戏串流工具。
 * [RealVNC](https://www.realvnc.com) 是一款免费的远程控制跨多平台的程序。 ![Freeware][Freeware Icon]
+* [reminal](https://reminal.app) - 将每个窗口和终端实时串流到任意浏览器，合盖后 Mac 依然保持运行。[![Open-Source Software][OSS Icon]](https://github.com/harshalgajjar/Reminal) ![Freeware][Freeware Icon]
 * [RoyalTSX](https://www.royalapps.com/ts/mac/features) - 管理多种协议远程连接的客户端。 ![Freeware][Freeware Icon]
 * [RustDesk](https://rustdesk.com/) - 一个开源的远程桌面应用程序，为自托管而设计。[![Open-Source Software][OSS Icon]](https://github.com/rustdesk/rustdesk) ![Freeware][Freeware Icon]
 * [Steam Link](https://apps.apple.com/cn/app/steam-link/id1246969117?platform=mac) - 通过局域网或互联网将您的 Steam 游戏串流到 Mac 上。[![App Store][app-store Icon]](https://apps.apple.com/cn/app/steam-link/id1246969117?platform=mac) ![Freeware][Freeware Icon]

--- a/README.md
+++ b/README.md
@@ -1632,6 +1632,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Moonlight](https://github.com/moonlight-stream/moonlight-qt) - GameStream client for PCs (Windows, Mac, Linux, and Steam Link). [![Open-Source Software][OSS Icon]](https://github.com/moonlight-stream/moonlight-qt) ![Freeware][Freeware Icon]
 * [Parsec](https://parsec.app) - Low-latency remote desktop and game streaming tool.
 * [RealVNC](https://www.realvnc.com) - The original and best software for remote access across desktop and mobile.
+* [reminal](https://reminal.app) - Streams every window and terminal to any browser, keeping the Mac awake with the lid closed. [![Open-Source Software][OSS Icon]](https://github.com/harshalgajjar/Reminal) ![Freeware][Freeware Icon]
 * [RoyalTSX](https://www.royalapps.com/ts/mac/features) - Remote connection manager for multiple protocols. ![Freeware][Freeware Icon]
 * [RustDesk](https://rustdesk.com/) - Yet another remote desktop software. [![Open-Source Software][OSS Icon]](https://github.com/rustdesk/rustdesk) ![Freeware][Freeware Icon]
 * [Steam Link](https://apps.apple.com/us/app/steam-link/id1246969117?platform=mac) - The Steam Link app allows you to play your Steam games across all your computers. ![Freeware][Freeware Icon]


### PR DESCRIPTION
## What is this app?

[reminal](https://reminal.app) streams every window, desktop and terminal on a Mac into any browser, with input — and its closed-lid mode keeps the Mac awake and rendering headlessly (it disables clamshell sleep and creates a virtual display in software, replacing the dummy-HDMI-plug trick).

- Open source (AGPL-3.0): https://github.com/harshalgajjar/Reminal
- Free; nothing to install on the viewing device, no account
- End-to-end encrypted, outbound-only (no open ports), relay is self-hostable

## Checklist

- Added under **Remote Login Software** in alphabetical order (after RealVNC, before RoyalTSX)
- Synced across README.md, README-zh.md, README-ja.md and README-ko.md per the contributing guidelines
- One-sentence description, AP title casing, no trailing whitespace
- Searched previous suggestions — not a duplicate

Disclosure: I am the author of reminal. This PR was prepared with AI assistance, following the repository's AI-assisted contribution guidelines.