### PR TITLE
Add Lunaver (voice-first book studio) to Writing

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 ### Writing
 
 * [Retrotype](https://retrotype.ink/) - A fun and minimalist writing app that feels like a real typewriter. ![Freeware][Freeware Icon]
+* [Lunaver](https://lunaver.app/) - Voice-first book studio with on-device AI; exports EPUB, print-ready PDF, DOCX, audiobook, DAISY and braille from one manuscript. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id6760931487?platform=mac)
 * [novelWriter](https://github.com/vkbo/novelWriter) - Open-source plain text editor for writing novels with minimal markdown-like syntax. [![OSS][OSS Icon]](https://github.com/vkbo/novelWriter) ![Freeware][Freeware Icon]
 * [Scrivener](https://www.literatureandlatte.com/scrivener/overview/) - The quintessential word processor for writers.
 * [THORN](https://thorn.so) - All you need to power personal writing and website building.


### PR DESCRIPTION
Adds **Lunaver** to the Writing section.

Lunaver is a book studio for the Mac, designed voice-first and fully VoiceOver-accessible — built by a developer who is losing his sight to retinitis pigmentosa and uses it daily. AI drafting runs entirely on-device (Apple Foundation Models + local MLX models); no account required. One manuscript exports to EPUB, print-ready PDF, DOCX, a multi-voice audiobook, DAISY and braille. The core app is free on the Mac App Store, including the braille and audiobook exports.

- Website: https://lunaver.app/
- Mac App Store: https://apps.apple.com/app/id6760931487

Entry follows the existing format (Freeware + App Store icons), inserted alphabetically.