### PR TITLE
Add crterm to Terminal Apps

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -636,6 +636,7 @@ Awesome Mac
 * [alacritty](https://github.com/jwilm/alacritty) - クロスプラットフォームでGPUアクセラレーションに対応したターミナルエミュレーター。 [![Open-Source Software][OSS Icon]](https://github.com/jwilm/alacritty) ![Freeware][Freeware Icon]
 * [Awal Terminal](https://github.com/AwalTerminal/Awal-terminal) - 複数プロバイダープロファイルと音声入力に対応したAIネイティブのターミナルエミュレーター。 [![Open-Source Software][OSS Icon]](https://github.com/AwalTerminal/Awal-terminal) ![Freeware][Freeware Icon]
 * [Command Book](https://commandbookapp.com) - 長時間実行されるターミナルコマンド用のターミナルコンパニオン（フリーミアム）。
+* [crterm](https://crterm.ai) - 高度なセッションナビゲーションとGPUアクセラレーション対応のレトロプリセットを備えた、美しくこだわりのあるターミナルエミュレーター。 [![Open-Source Software][OSS Icon]](https://github.com/mbcltd/CRTerminal) ![Freeware][Freeware Icon]
 * [electerm](https://electerm.github.io/electerm/) - ターミナル、SSH、SFTPクライアント。 [![Open-Source Software][OSS Icon]](https://github.com/electerm/electerm) ![Freeware][Freeware Icon]
 * [Ghostty](https://github.com/ghostty-org/ghostty) - 高速なGPUアクセラレーション対応ターミナルエミュレーター。 [![Open-Source Software][OSS Icon]](https://github.com/ghostty-org/ghostty) ![Freeware][Freeware Icon]
 * [hyper](https://hyper.is) - Web技術で構築されたターミナル。 [![Open-Source Software][OSS Icon]](https://github.com/zeit/hyper) ![Freeware][Freeware Icon]

--- a/README-ko.md
+++ b/README-ko.md
@@ -532,6 +532,7 @@ Awesome Mac
 
 * [Alacritty](https://github.com/jwilm/alacritty) - GPU 가속을 지원하는 크로스 플랫폼 터미널 에뮬레이터. [![Open-Source Software][OSS Icon]](https://github.com/jwilm/alacritty) ![Freeware][Freeware Icon]
 * [Awal Terminal](https://github.com/AwalTerminal/Awal-terminal) - 다중 제공자 프로필과 음성 입력을 지원하는 AI 네이티브 터미널 에뮬레이터. [![Open-Source Software][OSS Icon]](https://github.com/AwalTerminal/Awal-terminal) ![Freeware][Freeware Icon]
+* [crterm](https://crterm.ai) - 고급 세션 내비게이션과 GPU 가속 레트로 프리셋을 갖춘 아름답고 개성 있는 터미널 에뮬레이터. [![Open-Source Software][OSS Icon]](https://github.com/mbcltd/CRTerminal) ![Freeware][Freeware Icon]
 * [electerm](https://electerm.github.io/electerm/) - 터미널, SSH, SFTP 클라이언트. [![Open-Source Software][OSS Icon]](https://github.com/electerm/electerm) ![Freeware][Freeware Icon]
 * [Ghostty](https://github.com/ghostty-org/ghostty) - 빠른 GPU 가속 터미널 에뮬레이터. [![Open-Source Software][OSS Icon]](https://github.com/ghostty-org/ghostty) ![Freeware][Freeware Icon]
 * [Hyper](https://hyper.is) - 웹 기술로 빌드된 터미널. [![Open-Source Software][OSS Icon]](https://github.com/zeit/hyper) ![Freeware][Freeware Icon]

--- a/README-zh.md
+++ b/README-zh.md
@@ -418,6 +418,7 @@ Awesome Mac
 
 * [alacritty](https://github.com/jwilm/alacritty) - A cross-platform, GPU-accelerated terminal emulator. [![Open-Source Software][OSS Icon]](https://github.com/jwilm/alacritty) ![Freeware][Freeware Icon]
 * [Awal Terminal](https://github.com/AwalTerminal/Awal-terminal) - 支持多提供商配置和语音输入的 AI 原生终端模拟器。 [![Open-Source Software][OSS Icon]](https://github.com/AwalTerminal/Awal-terminal) ![Freeware][Freeware Icon]
+* [crterm](https://crterm.ai) - 美观而有主见的终端模拟器，提供高级会话导航和 GPU 加速的复古预设。 [![Open-Source Software][OSS Icon]](https://github.com/mbcltd/CRTerminal) ![Freeware][Freeware Icon]
 * [electerm](https://electerm.github.io/electerm/) - 终端、SSH 和 SFTP 客户端。 [![Open-Source Software][OSS Icon]](https://github.com/electerm/electerm) ![Freeware][Freeware Icon]
 * [Ghostty](https://github.com/ghostty-org/ghostty) - 快速的 GPU 加速终端模拟器。 [![Open-Source Software][OSS Icon]](https://github.com/ghostty-org/ghostty) ![Freeware][Freeware Icon]
 * [hyper](https://hyper.is) - 基于 Web 技术的终端，直接替代自带的 Terminal。[![Open-Source Software][OSS Icon]](https://github.com/zeit/hyper) ![Freeware][Freeware Icon]

--- a/README.md
+++ b/README.md
@@ -635,6 +635,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [alacritty](https://github.com/jwilm/alacritty) - A cross-platform, GPU-accelerated terminal emulator. [![Open-Source Software][OSS Icon]](https://github.com/jwilm/alacritty) ![Freeware][Freeware Icon]
 * [Awal Terminal](https://github.com/AwalTerminal/Awal-terminal) - AI-native terminal emulator with multi-provider profiles and voice input. [![Open-Source Software][OSS Icon]](https://github.com/AwalTerminal/Awal-terminal) ![Freeware][Freeware Icon]
 * [Command Book](https://commandbookapp.com) - A terminal companion for long-running terminal commands (freemium)
+* [crterm](https://crterm.ai) - Beautifully opinionated terminal emulator, with advanced session navigation and GPU-accelerated retro presets. [![Open-Source Software][OSS Icon]](https://github.com/mbcltd/CRTerminal) ![Freeware][Freeware Icon]
 * [electerm](https://electerm.github.io/electerm/) - Terminal, SSH, and SFTP client. [![Open-Source Software][OSS Icon]](https://github.com/electerm/electerm) ![Freeware][Freeware Icon]
 * [Ghostty](https://github.com/ghostty-org/ghostty) - Fast GPU-accelerated terminal emulator. [![Open-Source Software][OSS Icon]](https://github.com/ghostty-org/ghostty) ![Freeware][Freeware Icon]
 * [hyper](https://hyper.is) - A terminal built on web technologies. [![Open-Source Software][OSS Icon]](https://github.com/zeit/hyper) ![Freeware][Freeware Icon]


### PR DESCRIPTION
### Types of Changes

**What types of changes does your PR introduce?** Put an x in all boxes that apply

- [x] New addition to list
- [ ] Fixing bug in existing item in list
- [ ] Removing item from list
- [ ] Changing structure (organization) of list

### Proposed Changes

Adds [crterm](https://github.com/mbcltd/CRTerminal) to the **Terminal Apps** section:

> [crterm](https://github.com/mbcltd/CRTerminal) - Beautifully opinionated terminal emulator, with advanced session navigation and GPU-accelerated retro presets.

Why it should be added: crterm is a free, open-source (Apache 2.0), native macOS terminal emulator with Metal GPU-accelerated rendering, distinctive session navigation (⌘K palette across all sessions, searchable command history, split panes, tear-off windows), and retro CRT presets modelled on historic monitors — a niche not covered by the existing entries. It ships as a signed/notarised DMG with auto-updates and is actively developed.

The entry is added in alphabetical order to all four language READMEs (`README.md`, `README-zh.md`, `README-ja.md`, `README-ko.md`), following the `awesome-mac-maintainer` curation rules for placement, one-sentence descriptions, and icon formatting.

### PR Checklist

- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important
- [x] I have added necessary documentation (if appropriate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)