### PR TITLE
Add Tidy to File Organization Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1341,7 +1341,8 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Rapidmg](https://rapidmg.branchseer.com/) 1-Click extracting apps from DMG images to the "Applications" folder. [![App Store][app-store Icon]](https://apps.apple.com/app/rapidmg/id6451349778?platform=mac)
 * [Shuffle](https://shuffleapp.co) - Fast, GPU-rendered file manager and Finder alternative built in Rust. [![Open-Source Software][OSS Icon]](https://github.com/WizenPainter/shuffle) ![Freeware][Freeware Icon]
 * [The Unarchiver](https://theunarchiver.com/) - Unarchive many different kinds of archive files. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/us/app/the-unarchiver/id425424353?platform=mac)
-* [Unarchive One](https://cleanerone.trendmicro.com/unarchiver-one/?utm_source=github&utm_medium=referral&utm_campaign=githubproject) - Archive utility for extracting and compressing many common formats. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/apple-store/id1127253508?pt=444218&ct=GitHub&mt=8&platform=mac)
+* [Tidy](https://tidymacapp.com/) - Menu bar app that reads images and scanned PDFs with on-device OCR and names each file after what is written inside it.
+*  [Unarchive One](https://cleanerone.trendmicro.com/unarchiver-one/?utm_source=github&utm_medium=referral&utm_campaign=githubproject) - Archive utility for extracting and compressing many common formats. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/apple-store/id1127253508?pt=444218&ct=GitHub&mt=8&platform=mac)
 * [Marta](https://marta.sh) - File Manager for macOS written entirely in Swift ![Freeware][Freeware Icon]
 
 ### General Tools


### PR DESCRIPTION
### Types of Changes

**What types of changes does your PR introduce?** Put an x in all boxes that apply

- [x] New addition to list
- [ ] Fixing bug in existing item in list
- [ ] Removing item from list
- [ ] Changing structure (organization) of list

### Proposed Changes

Adds Tidy to File Organization Tools, in alphabetical order between The Unarchiver and Unarchive One.

Tidy is a macOS menu bar app that runs Apple's on-device text recognition over images and scanned PDFs, and names each file from the text it finds, so "Screenshot 2026-08-14 at 14.22.10.png" becomes "invoice-mueller-gmbh.png". It also files Downloads and the Desktop with rules you set. Everything runs locally: no account, no server, nothing uploaded. macOS 14 and later, $9 once.

The category already lists Hazel, so paid file organization tools fit here. No badge added, since the app is neither freeware nor open source nor on the App Store.

I searched the README and the open pull requests before submitting. Tidy is not listed and no other PR adds it.

### PR Checklist

- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important
- [ ] I have added necessary documentation (if appropriate)

### Further Comments

I am the developer of the app, so weigh that accordingly. Happy to add the same entry to README-zh, README-ja and README-ko if you want it in this PR.