### PR TITLE
Add MacDupl to General Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1362,6 +1362,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Lungo](https://sindresorhus.com/lungo) - Prevent your Mac from going to sleep. [![App Store][app-store Icon]](https://apps.apple.com/us/app/lungo/id1263070803?platform=mac)
 * [LaunchNext](https://github.com/RoversX/LaunchNext) - Classic Launchpad experience, relive old macOS. [![Open-Source Software][OSS Icon]](https://github.com/RoversX/LaunchNext) ![Freeware][Freeware Icon]
 * [lo-rain](https://lo.cafe/lo-rain) - Create a customizable rain over your desktop and apps, with splash over the dock.
+* [MacDupl](https://macdupl.app) - Clone any installed Mac app into an isolated instance with its own login, data, and Dock icon.
 * [Memo](https://memo-app.net/) - Simple and elegant app. Unlock memos even more quickly using Touch ID. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id1212409035?platform=mac)
 * [Nifro](https://github.com/PathGao/Nifro) - Turn websites into configurable desktop wallpapers, with separate views for each display. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/PathGao/Nifro)
 * [Numi](https://numi.io/) - Beautiful calculator app for Mac. ![Freeware][Freeware Icon]


### PR DESCRIPTION
MacDupl clones installed Mac apps into genuinely isolated instances — new bundle identity, own data directory, own Dock icon — so you can run two signed-in copies of the same app (work/personal Slack, Discord, Chrome, etc.) at once. macOS 13+, Apple Silicon & Intel. Free with one instance after a 7-day trial, $19 one-time for unlimited.

Added under General Tools, alphabetically. Happy to move it if there's a better-fitting category.