### PR TITLE
Add Quill: open-source macOS voice typing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1069,6 +1069,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [OpenTypeless](https://github.com/tover0314-w/opentypeless) - Open-source AI voice input that types polished text into any app. [![Open-Source Software][OSS Icon]](https://github.com/tover0314-w/opentypeless) ![Freeware][Freeware Icon]
 * [Ottex](https://ottex.ai) - AI dictation tool that formats text for the app or site you are using.
 * [Presspeech](https://github.com/rcourtman/presspeech) - Native push-to-talk local dictation app for Apple Silicon Macs using Parakeet TDT v3 (CoreML/ANE). [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/rcourtman/presspeech)
+* [Quill](https://quillvoice.xyz) - System-wide voice typing that inserts polished text at your cursor using your own Gemini key. [![Open-Source Software][OSS Icon]](https://github.com/skundu42/quill) ![Freeware][Freeware Icon]
 * [ShengJi](https://github.com/maddylaneeee/ShengJi) - Open-source local transcription and subtitle editor for microphones, media files, and Mac audio. [![Open-Source Software][OSS Icon]](https://github.com/maddylaneeee/ShengJi) ![Freeware][Freeware Icon]
 * [Spokenly](https://spokenly.app/) - Voice-to-text with 100+ languages, offline mode, and AI-powered formatting.
 * [Tambourine](https://tambourinevoice.com/) - Open-source, customizable AI voice dictation that works in any app. [![Open-Source Software][OSS Icon]](https://github.com/kstonekuan/tambourine-voice/) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adding Quill to the Voice-to-Text section.

Quill is a native macOS voice-typing app (macOS 14+, Apache 2.0). Hold a shortcut in any text field, speak, and polished text appears at your cursor. It uses your own Gemini API key, keeps no recordings or transcript history, and has no backend.

Self-submission. Happy to adjust wording or placement if preferred.

- Repo: https://github.com/skundu42/quill
- Site: https://quillvoice.xyz