### PR TITLE
Add Noctis to Proxy and VPN Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1180,6 +1180,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Jumper VPN](https://jumpervpn.com/) - VPN Client for Mac and other platforms, secure, fast VPN proxy.
 * [Lantern](https://getlantern.org) - Free application that delivers fast, reliable and secure access to the open internet. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/getlantern/lantern)
 * [Mullvad VPN](https://mullvad.net) - Privacy-focused VPN service with anonymous accounts and flat-rate access. [![Open-Source Software][OSS Icon]](https://github.com/mullvad/mullvadvpn-app)
+* [Noctis](https://noctis.c0nn3ct.info/) - Browser-only proxy: routes Chrome through VLESS Reality, VMess, Trojan, Shadowsocks, Hysteria2, TUIC or WireGuard using a local sing-box, Xray or mihomo core. ![Freeware][Freeware Icon]
 * [Outline](https://getoutline.org/) - Outline makes it easy to create a VPN server, giving anyone access to the free and open internet. [![Open-Source Software][OSS Icon]](https://github.com/Jigsaw-Code) ![Freeware][Freeware Icon]
 * [RerouteMe](https://nadenco.gumroad.com/l/rerouteme) - An easy one-click macOS Proxy Configuration app. ![Freeware][Freeware Icon]
 * [ShadowsocksX-NG](https://github.com/qiuyuzhou/ShadowsocksX-NG) - Next generation of ShadowsocksX. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/qiuyuzhou/ShadowsocksX-NG)


### PR DESCRIPTION
Noctis routes browser traffic through your own proxy server and leaves the rest of the system alone. A native helper runs a local sing-box, Xray or mihomo core, so the extension speaks VLESS and VLESS Reality, VMess, Trojan, Shadowsocks, Hysteria2, TUIC, WireGuard, AnyTLS and ShadowTLS. Per-host rules decide whether a request takes the proxy or goes direct.

- Site: https://noctis.c0nn3ct.info
- Web Store: https://chromewebstore.google.com/detail/noctis/nmhobajopepdpihahepaddpdifdcenpn
- Helper source, MIT: https://github.com/c0nn3ct-info/noctis
- Free, no account. The helper installs on macOS, Windows and Linux.

The entry carries the Freeware badge only. The helper is MIT, the extension is not, so the OSS badge would overstate it.

Added alphabetically under Proxy and VPN Tools, between Mullvad VPN and Outline. I searched the list for duplicates first.

Disclosure: I wrote Noctis.
