### PR TITLE
Add Focuh

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1388,6 +1388,7 @@ Awesome Mac
 * [2Do](http://www.2doapp.com/) - 優れたTodoアプリ。
 * [Day-O 2](http://www.shauninman.com/archive/2016/10/20/day_o_2_mac_menu_bar_clock) - カレンダー内蔵のメニューバー時計の代替アプリ。 ![Freeware][Freeware Icon]
 * [Fantastical](https://flexibits.com/fantastical) - 手放せなくなるカレンダーアプリ。
+* [Focuh](https://www.focuh.com) - ADHD向けの無料ToDoリストと週間プランナー。システム全体のウェブサイトブロック付き。 ![Freeware][Freeware Icon]
 * [Focus](https://meaningful-things.com/focus) - ポモドーロベースの美しいタイムマネージャー。 [![App Store][app-store Icon]](https://apps.apple.com/us/app/focus-productivity-timer/id777233759?platform=mac)
 * [Focused Work: Focus Timer](https://focusedwork.app) - シンプルで柔軟なフォーカスタイマー。 [![App Store][app-store Icon]](https://apps.apple.com/us/app/focused-work-focus-timer/id1523968394?uo=4&platform=mac)
 * [Lunatask](https://lunatask.app) - 暗号化されたオールインワンのToDoリスト、習慣・気分トラッカー、ジャーナリング＆メモアプリ。 ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/us/app/lunatask-a-better-to-do-list/id1583719331?platform=mac)

--- a/README-ko.md
+++ b/README-ko.md
@@ -1015,6 +1015,7 @@ Awesome Mac
 
 ### 할 일 목록 (To-Do Lists)
 
+* [Focuh](https://www.focuh.com) - ADHD를 위한 무료 할 일 목록과 주간 플래너. 시스템 전반 웹사이트 차단 포함. ![Freeware][Freeware Icon]
 * [Nozbe](https://nozbe.com) - 개인과 팀을 위한 GTD 작업 관리자. [![App Store][app-store Icon]](https://apps.apple.com/pl/app/nozbe-tasks-projects-team/id508957583?platform=mac)
 * [Super Productivity](https://super-productivity.com) - 타임박싱과 시간 추적을 갖춘 작업 관리자. [![Open-Source Software][OSS Icon]](https://github.com/johannesjo/super-productivity) ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/cn/app/super-productivity/id1482572463?platform=mac)
 * [Things](https://culturedcode.com/things/) - 수상 경력이 있는 작업 관리자.

--- a/README-zh.md
+++ b/README-zh.md
@@ -1332,6 +1332,7 @@ Awesome Mac
 * [2Do](http://www.2doapp.com/) - 比较好的 TODO 应用程序。
 * [Day-O 2](http://www.shauninman.com/archive/2016/10/20/day_o_2_mac_menu_bar_clock) - 菜单日历更换内置日历。![Freeware][Freeware Icon]
 * [Fantastical](https://flexibits.com/fantastical) - 日历应用程序，你将管理好生活。
+* [Focuh](https://www.focuh.com) - 免费的 ADHD 待办与周计划工具，支持系统级网站屏蔽。 ![Freeware][Freeware Icon]
 * [Focus](https://masterbuilders.io) - 一个漂亮的番茄工作法为基础的时间管理工具。 [![App Store][app-store Icon]](https://apps.apple.com/cn/app/focus-productivity-timer/id777233759?platform=mac)
 * [Microsoft To-Do](https://www.microsoft.com/en-us/microsoft-365/microsoft-to-do-list-app) - 任务管理工具微软出品。 ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/cn/app/microsoft-to-do/id1274495053?platform=mac)
 * [Nozbe](https://nozbe.com) - 面向个人与团队的 GTD 任务管理器。[![App Store][app-store Icon]](https://apps.apple.com/cn/app/nozbe-tasks-projects-team/id508957583?platform=mac)

--- a/README.md
+++ b/README.md
@@ -1389,6 +1389,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 
 * [2Do](https://www.2doapp.com/) - Nice todo app.
 * [Fantastical](https://flexibits.com/fantastical) - The calendar app you won't be able to live without.
+* [Focuh](https://www.focuh.com) - Free ADHD todo list and week planner with system-wide website blocking. ![Freeware][Freeware Icon]
 * [Focus](https://meaningful-things.com/focus) - Beautiful pomodoro-based time manager. [![App Store][app-store Icon]](https://apps.apple.com/us/app/focus-productivity-timer/id777233759?platform=mac)
 * [Focused Work: Focus Timer](https://focusedwork.app) - A simple, flexible Focus Timer. [![App Store][app-store Icon]](https://apps.apple.com/us/app/focused-work-focus-timer/id1523968394?uo=4&platform=mac)
 * [Lunatask](https://lunatask.app) - An all-in-one encrypted to-do list, habit and mood tracker, journaling and notes app. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/us/app/lunatask-a-better-to-do-list/id1583719331?platform=mac)


### PR DESCRIPTION
NOTE: A similar PR may already be submitted! Please search among the Pull request before creating one.

### Types of Changes

**What types of changes does your PR introduce?** Put an x in all boxes that apply

- [x] New addition to list
- [ ] Fixing bug in existing item in list
- [ ] Removing item from list
- [ ] Changing structure (organization) of list

### Proposed Changes

Add [Focuh](https://www.focuh.com) under To-Do Lists in `README.md`, `README-zh.md`, `README-ja.md`, and `README-ko.md`, in alphabetical order.

Focuh is a free macOS ADHD todo list and week planner (Today / week / loops / goals) with system-wide website blocking during a focus session. Native Mac app (signed/notarized Apple Silicon + Intel DMGs) plus a web app. 100% free, no premium tier.

It belongs next to Things / Todoist / Lunatask rather than the generic Productivity launchers: the core product is a dated todo + week board.

### PR Checklist

- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important
- [x] I have added necessary documentation (if appropriate)

### Further Comments

Freeware only (not App Store, not open source). Description is one sentence in each language. No Chrome-extension listing.