### PR TITLE
Add DockDuck to Finder Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1550,6 +1550,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [SwiftyMenu](https://apps.apple.com/us/app/swiftymenu/id1567748223?platform=mac) - Finder extension for opening selected files or folders with custom app shortcuts.
 * [TotalFinder](https://totalfinder.binaryage.com/) - Chrome-styled Finder substitute.
 * [XtraFinder](https://www.trankynam.com/xtrafinder/) - Adds tabs and cut to Mac Finder. ![Freeware][Freeware Icon]
+* [DockDuck](https://dockduck.app) - Native dual-pane Finder replacement with remote servers, batch rename, and archive support.
 
 ### Quality of Life Improvements
 

--- a/README.md
+++ b/README.md
@@ -1538,6 +1538,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 
 * [Command X](https://sindresorhus.com/command-x) - Cut and paste files in Finder. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id1666327168?platform=mac)
 * [Default Folder X](https://www.stclairsoft.com/DefaultFolderX/index.html) - Quick access to your files and folders in every app.
+* [DockDuck](https://dockduck.app) - Native dual-pane Finder replacement with remote servers, batch rename, and archive support.
 * [FileMinutes](https://www.fileminutes.com/) - Find files and take actions, all in one.
 * [FinderFix](https://synappser.github.io/apps/finderfix/) - Finally, a lasting solution for Finder windows size and position. ![Freeware][Freeware Icon].
 * [SaneClick](https://saneclick.com) - Finder extension that adds right-click actions for file tasks, conversion, and developer tools. [![Open-Source Software][OSS Icon]](https://github.com/sane-apps/SaneClick) ![Freeware][Freeware Icon]
@@ -1550,7 +1551,6 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [SwiftyMenu](https://apps.apple.com/us/app/swiftymenu/id1567748223?platform=mac) - Finder extension for opening selected files or folders with custom app shortcuts.
 * [TotalFinder](https://totalfinder.binaryage.com/) - Chrome-styled Finder substitute.
 * [XtraFinder](https://www.trankynam.com/xtrafinder/) - Adds tabs and cut to Mac Finder. ![Freeware][Freeware Icon]
-* [DockDuck](https://dockduck.app) - Native dual-pane Finder replacement with remote servers, batch rename, and archive support.
 
 ### Quality of Life Improvements
 


### PR DESCRIPTION
NOTE: A similar PR may already be submitted! Please search among the Pull request before creating one.

### Types of Changes

**What types of changes does your PR introduce?** Put an x in all boxes that apply

- [ x ] New addition to list
- [ ] Fixing bug in existing item in list
- [ ] Removing item from list
- [ ] Changing structure (organization) of list

### Proposed Changes

Adds [DockDuck](https://dockduck.app) to the **Finder Tools** section, in
alphabetical order after Default Folder X.

DockDuck is a fully native dual-pane Finder replacement (Swift/AppKit, no Electron, no third-party dependencies) with remote servers (SFTP/SMB/WebDAV/FTP), batch rename, archive support, and a Shelf drop-stack. It complements the existing entries: unlike the Finder *extensions* in this section, it is a full replacement in the spirit of ForkLift or Path Finder, actively developed (v1.0.6, Aug 2026).

No OSS/Freeware/App Store icons added: it is paid, closed source, and distributed outside the Mac App Store, per the repo conventions.

### PR Checklist

- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important
- [x] I have added necessary documentation (if appropriate)

### Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
