### PR TITLE
Add ControllerKeys to Productivity

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1409,6 +1409,7 @@ Awesome Mac
 * [BetterTouchTool](https://folivora.ai/) - トラックパッド、マウス、キーボードのジェスチャーや操作を細かくカスタマイズできるツール。
 * [Cerebro](https://cerebroapp.com/) - 頭脳を持つオープンソースの生産性向上ツール。 [![Open-Source Software][OSS Icon]](https://github.com/cerebroapp/cerebro) ![Freeware][Freeware Icon]
 * [Choosy](https://www.choosyosx.com) - リンクをどこでどのように開くかのルールを管理するUI、URL API、ブラウザ拡張機能のセット。
+* [ControllerKeys](https://kevintang.xyz/apps/controller-keys) - 任意のゲームコントローラーをキーボードやマウスとして使い、ボタンマッピング、マクロ、コード入力、ジャイロマウス、スワイプ入力に対応したツール。
 * [CurrentKey](https://currentkey.com) - Spacesに名前とアイコンを付けて、アプリごとの利用時間を追跡するツール。 [![App Store][app-store Icon]](https://apps.apple.com/us/app/currentkey/id1456226992?mt=12)
 * [CursorSense](https://www.plentycom.jp/en/cursorsense/index.html) - アクセラレーションカーブなどを調整できるマウス＆トラックパッドドライバー。
 * [Day Progress](https://sindresorhus.com/day-progress) - メニューバーに今日の残り時間を表示。 ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id6450280202?platform=mac)

--- a/README-ko.md
+++ b/README-ko.md
@@ -1020,6 +1020,7 @@ Awesome Mac
 * [Better Launchpad](https://github.com/rewhex/better-launchpad) - 빠른 검색을 지원하는 맞춤형 앱 런처.
 * [BetterMouse](https://better-mouse.com) - 서드파티 마우스의 스크롤, 가속, 버튼, 제스처를 조정하는 도구.
 * [BetterTouchTool](https://folivora.ai/) - 트랙패드, 마우스, 키보드의 제스처와 동작을 세밀하게 설정하는 도구.
+* [ControllerKeys](https://kevintang.xyz/apps/controller-keys) - 게임 컨트롤러를 키보드와 마우스로 사용하며 버튼 매핑, 매크로, 코드 입력, 자이로 마우스, 스와이프 입력을 지원하는 도구.
 * [CurrentKey](https://currentkey.com) - Spaces에 사용자 지정 이름과 아이콘을 붙이고 앱 사용 시간을 추적하는 도구. [![App Store][app-store Icon]](https://apps.apple.com/us/app/currentkey/id1456226992?mt=12)
 * [FnKeyboard](https://github.com/kotique123/FnKeyboard) - 메뉴 막대에서 기능 키를 빠르게 호출하는 도구. [![Open-Source Software][OSS Icon]](https://github.com/kotique123/FnKeyboard) ![Freeware][Freeware Icon]
 * [Freeter](https://freeter.io/) - 앱, 링크, 파일을 프로젝트별로 정리하는 작업 공간 도구. [![Open-Source Software][OSS Icon]](https://github.com/FreeterApp/Freeter) ![Freeware][Freeware Icon]

--- a/README-zh.md
+++ b/README-zh.md
@@ -1153,6 +1153,7 @@ Awesome Mac
 * [BetterZip](https://macitbetter.com/) - 压缩解压缩工具支持格式 ZIP、TAR、TGZ、TBZ、TXZ (new)、7-ZIP、RAR
 * [CheatSheet](https://www.mediaatelier.com/CheatSheet/) - CheatSheet 是一款 Mac 上的非常实用的快捷键快速提醒工具。 ![Freeware][Freeware Icon]
 * [Cadran](https://cadranapp.com) - 在Mac桌面壁纸和屏幕保护程序上显示22种可自定义的时钟表盘。
+* [ControllerKeys](https://kevintang.xyz/apps/controller-keys) - 将任意游戏手柄用作键盘和鼠标，支持按键映射、宏、组合键、陀螺仪鼠标和滑动输入。
 * [Deskflow](https://github.com/deskflow/deskflow) - Deskflow 让你在 Windows、macOS 和 Linux 上共享一套鼠标和键盘控制多台电脑。[![Open-Source Software][OSS Icon]](https://github.com/deskflow/deskflow) ![Freeware][Freeware Icon]
 * [Crisp](https://didriksg.github.io/Crisp/) - 在菜单栏管理外接显示器：HiDPI 缩放、DDC 亮度、颜色和预设。 [![Open-Source Software][OSS Icon]](https://github.com/didriksg/Crisp) ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [DisplayBuddy](https://displaybuddy.app) - 直接控制外接显示器的亮度、对比度和输入源。

--- a/README.md
+++ b/README.md
@@ -1412,6 +1412,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [BetterTouchTool](https://folivora.ai/) - Customize gestures, shortcuts, and input actions across trackpads, mice, and keyboards.
 * [Cerebro](https://cerebroapp.com/) - Open-source productivity booster with a brain. [![Open-Source Software][OSS Icon]](https://github.com/cerebroapp/cerebro) ![Freeware][Freeware Icon]
 * [Choosy](https://www.choosyosx.com) - UI, URL API and a browser extension set for managing rules where and how to open links.
+* [ControllerKeys](https://kevintang.xyz/apps/controller-keys) - Use any game controller as a keyboard and mouse, with button mapping, macros, chords, gyro mouse, and swipe typing.
 * [CurrentKey](https://currentkey.com) - Add custom names and icons to Spaces and track app usage time. [![App Store][app-store Icon]](https://apps.apple.com/us/app/currentkey/id1456226992?mt=12)
 * [CursorSense](https://www.plentycom.jp/en/cursorsense/index.html) - Mouse & trackpad driver that lets you tweak the acceleration curve and more.
 * [Day Progress](https://sindresorhus.com/day-progress) - Time remaining today in your menu bar. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id6450280202?platform=mac)


### PR DESCRIPTION
Adds **ControllerKeys** to the Productivity section, alongside other input-customization utilities like Karabiner and BetterTouchTool.

- **What it is:** a native macOS app that turns any game controller (Xbox, PlayStation, Steam, Nintendo, 8BitDo, Siri Remote) into a keyboard and mouse — button mapping, macros, chords, gyro mouse, and swipe typing.
- **Link:** https://kevintang.xyz/apps/controller-keys
- **Disclosure:** I'm the developer. ControllerKeys is a paid app ($19.99) with a free 14-day trial; its source is available under PolyForm Noncommercial (source-available, not open source), so I did not add the open-source icon.
- Added in alphabetical order and synced across `README.md`, `README-zh.md`, `README-ja.md`, and `README-ko.md` per the multilingual sync rule in CONTRIBUTING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)