### PR TITLE
Add TorrentMilk to Download Management Tools

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1030,6 +1030,7 @@ Awesome Mac
 * [qBittorrent](https://www.qbittorrent.org/) - µTorrentに代わるオープンソースソフトウェアを提供するプロジェクト。 [![Open-Source Software][OSS Icon]](https://github.com/qbittorrent/qBittorrent) ![Freeware][Freeware Icon]
 * [Shuttle](https://fiplab.com/apps/download-shuttle-for-mac) - あらゆるリンクに対応する簡単なダウンロードマネージャー。
 * [Swads](https://swads.app/) - Synology Download Stationクライアント。モダンでネイティブ、直感的に再設計。
+* [TorrentMilk](https://getapps.cafe/app/torrentmilk) - ダウンロード完了を待たずに再生できるストリーミング対応トレントクライアント。 ![Freeware][Freeware Icon]
 * [Transmission](https://www.transmissionbt.com/) - 高速で簡単、無料のBitTorrentクライアント。 [![Open-Source Software][OSS Icon]](https://github.com/transmission/transmission) ![Freeware][Freeware Icon]
 * [XGetter](https://xgetter.com/) - 主要サイトから動画や音声を保存できるメディアダウンローダー。 ![Freeware][Freeware Icon]
 * [You-Get](https://you-get.org/) - Webからメディアコンテンツ（ビデオ、オーディオ、画像）をダウンロードするための小さなコマンドラインユーティリティ。 [![Open-Source Software][OSS Icon]](https://github.com/soimort/you-get) ![Freeware][Freeware Icon]

--- a/README-ko.md
+++ b/README-ko.md
@@ -797,6 +797,7 @@ Awesome Mac
 * [Motrix](https://motrix.app/) - HTTP, FTP, BitTorrent, Magnet 등을 지원하는 모든 기능을 갖춘 다운로드 관리자. [![Open-Source Software][OSS Icon]](https://github.com/agalwood/Motrix) ![Freeware][Freeware Icon]
 * [Neat Download Manager](https://www.neatdownloadmanager.com/) - 최적화된 전송 엔진을 갖춘 경량 다운로드 관리자. ![Freeware][Freeware Icon]
 * [qBittorrent](https://www.qbittorrent.org/) - 인기 있는 비트토렌트 클라이언트. [![Open-Source Software][OSS Icon]](https://github.com/qbittorrent/qBittorrent) ![Freeware][Freeware Icon]
+* [TorrentMilk](https://getapps.cafe/app/torrentmilk) - 다운로드가 끝나기를 기다리지 않고 바로 재생하는 스트리밍 토렌트 클라이언트. ![Freeware][Freeware Icon]
 * [Transmission](https://www.transmissionbt.com/) - 빠르고 쉽고 무료인 비트토렌트 클라이언트. [![Open-Source Software][OSS Icon]](https://github.com/transmission/transmission) ![Freeware][Freeware Icon]
 * [XGetter](https://xgetter.com/) - 주요 웹사이트에서 동영상과 오디오를 내려받는 미디어 다운로드 도구. ![Freeware][Freeware Icon]
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -981,6 +981,7 @@ Awesome Mac
 * [Neat Download Manager](https://www.neatdownloadmanager.com/) - 具备优化传输引擎的轻量下载管理器。![Freeware][Freeware Icon]
 * [qBittorrent](https://www.qbittorrent.org/) - 一个替代 μTorrent 的开源软件。 [![Open-Source Software][OSS Icon]](https://github.com/qbittorrent/qBittorrent) ![Freeware][Freeware Icon]
 * [Swads](https://swads.app/) - 群晖 Download Station 客户端，现代、原生、凭直觉再设计。
+* [TorrentMilk](https://getapps.cafe/app/torrentmilk) - 边下边播的流式 BT 客户端，无需等待下载完成即可观看。![Freeware][Freeware Icon]
 * [Transmission](https://www.transmissionbt.com/) - 免费的 BitTorrent 客户端 [![Open-Source Software][OSS Icon]](https://github.com/transmission/transmission) ![Freeware][Freeware Icon]
 * [XGetter](https://xgetter.com/) - 用于从主流网站下载音视频的媒体下载器。 ![Freeware][Freeware Icon]
 * [You-Get](https://you-get.org/) - 网络富媒体命令行下载工具。[![Open-Source Software][OSS Icon]](https://github.com/soimort/you-get) ![Freeware][Freeware Icon]

--- a/README.md
+++ b/README.md
@@ -1031,6 +1031,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [qBittorrent](https://www.qbittorrent.org/) - A project aims to provide an open-source software alternative to µTorrent. [![Open-Source Software][OSS Icon]](https://github.com/qbittorrent/qBittorrent) ![Freeware][Freeware Icon]
 * [Shuttle](https://fiplab.com/apps/download-shuttle-for-mac) - Easy Download Manager for any links.
 * [Swads](https://swads.app/) - Synology Download Station Client, modern, native, and intuitively redesign.
+* [TorrentMilk](https://getapps.cafe/app/torrentmilk) - Streaming torrent client that plays video as soon as the first bytes arrive. ![Freeware][Freeware Icon]
 * [Transmission](https://www.transmissionbt.com/) - Fast, easy, free BitTorrent Client. [![Open-Source Software][OSS Icon]](https://github.com/transmission/transmission) ![Freeware][Freeware Icon]
 * [XGetter](https://xgetter.com/) - Media downloader for video and audio from major websites. ![Freeware][Freeware Icon]
 * [You-Get](https://you-get.org/) - Tiny command-line utility to download media contents (videos, audios, images) from the web. [![Open-Source Software][OSS Icon]](https://github.com/soimort/you-get) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds **[TorrentMilk](https://getapps.cafe/app/torrentmilk)** under **Download Management Tools**.

Streaming torrent client for macOS — drop in a magnet link and playback starts as soon as the first bytes land, no waiting for the download to finish. Library view with video cards, MP4/WebM/MKV/AVI support, subtitle management, continue-watching and custom collections.

- Free, no account or subscription required to use. Marked `![Freeware][Freeware Icon]`.
- Not open source, so no OSS icon.
- Placed next to the other BitTorrent clients in this section (qBittorrent, Transmission, Motrix).
- Entry synced across `README.md`, `README-zh.md`, `README-ja.md` and `README-ko.md`, in alphabetical position in each file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
