### PR TITLE
Add Vasa

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [QOwnNotes](https://www.qownnotes.org/) - Open-source notepad with markdown support and todo list manager. [![Open-Source Software][OSS Icon]](https://github.com/pbek/QOwnNotes) ![Freeware][Freeware Icon]
 * [Quick Note](https://quicknoteapp.com) - Colorful sticky notes in the Menu bar. [![App Store][app-store Icon]](https://apps.apple.com/in/app/quick-note-in-the-menu/id1472935217?platform=mac)
 * [Quiver](https://happenapps.com/#quiver) - Mix text, code, Markdown, and LaTeX in one note with live preview.
+* [Vasa](https://github.com/timurverevkin/Vasa) - Local-first infinite canvas for notes, images, links, audio, and video. [![Open-Source Software][OSS Icon]](https://github.com/timurverevkin/Vasa) ![Freeware][Freeware Icon]
 * [VNote](https://app.vnote.fun/) - Open-source Markdown note-taking app with a polished editor. [![Open-Source Software][OSS Icon]](https://github.com/vnotex/vnote/) ![Freeware][Freeware Icon]
 * [Zettel](https://github.com/AlexW00/Zettel) - Minimal, distraction-free note-taking app with Markdown and hashtag-based organization. [![Open-Source Software][OSS Icon]](https://github.com/AlexW00/Zettel) [![App Store][app-store Icon]](https://apps.apple.com/app/zettel-quick-notes/id6748525244?platform=mac)
 


### PR DESCRIPTION
Adds Vasa, a local-first infinite canvas app for macOS (notes, images, links, audio, video). Apache 2.0.