### PR TITLE
Add SessionWatcher to Menu Bar Tools

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1290,6 +1290,7 @@ Awesome Mac
 * [RewriteBar](https://rewritebar.com/) - AIの支援でテキストを書くのを助けるmacOSメニューバーアプリ。
 * [Second Clock](https://sindresorhus.com/second-clock) - メニューバーに別のタイムゾーンの時計を表示。 ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id6450279539?platform=mac)
 * [Thaw](https://github.com/stonerl/Thaw) - メニューバーアイテムの表示・非表示のための強力なメニューバー管理ツール。 [![Open-Source Software][OSS Icon]](https://github.com/stonerl/Thaw)
+* [SessionWatcher](https://sessionwatcher.com) - Claude Code、Codex、Cursor、Copilot、Gemini CLI など 15 種類の AI コーディングサービスの利用上限、クォータ、使用額、リセット時刻をメニューバーで追跡。 ![Native App][Native Icon]
 * [SketchyBar](https://github.com/FelixKratz/SketchyBar) - 高度にカスタマイズ可能なmacOSステータスバーの代替。 [![Open-Source Software][OSS Icon]](https://github.com/FelixKratz/SketchyBar) ![Freeware][Freeware Icon]
 * [Spaced](https://sindresorhus.com/spaced) - メニューバーアイテムをグループに整理。 ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id1666327168?platform=mac)
 * [Streaker](https://github.com/jamieweavis/streaker) - GitHubコントリビューションストリーク追跡メニューバーアプリ。 [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/jamieweavis/streaker)

--- a/README-ko.md
+++ b/README-ko.md
@@ -938,6 +938,7 @@ Awesome Mac
 * [BeardedSpice](https://github.com/beardedspice/beardedspice) - 미디어 키로 웹 플레이어와 일부 앱의 재생을 제어하는 도구. [![Open-Source Software][OSS Icon]](https://github.com/beardedspice/beardedspice) ![Freeware][Freeware Icon]
 * [DynamicHorizon](https://dynamichorizon.app) - 노치 영역에 미디어 제어, 알림, 시스템 표시를 추가하는 도구.
 * [Hidden Bar](https://github.com/dwarvesf/hidden) - 메뉴 바 아이콘을 숨겨주는 초경량 도구. [![Open-Source Software][OSS Icon]](https://github.com/dwarvesf/hidden) ![Freeware][Freeware Icon]
+* [SessionWatcher](https://sessionwatcher.com) - Claude Code, Codex, Cursor, Copilot, Gemini CLI 등 15개 AI 코딩 서비스의 사용 한도, 할당량, 지출, 초기화 시각을 메뉴 막대에서 추적. ![Native App][Native Icon]
 * [Sharptooth](https://apps.apple.com/app/sharptooth-bluetooth-hotkeys/id6748440814?platform=mac) - 단축키와 자동화로 블루투스 기기를 관리하는 메뉴 막대 도구. [![Freeware][Freeware Icon]](https://apps.apple.com/app/sharptooth-bluetooth-hotkeys/id6748440814?platform=mac)
 * [GoogleDriveSync](https://github.com/saihgupr/GoogleDriveSync) - 원활한 Google Drive 동기화를 위한 메뉴 바 앱. [![Open-Source Software][OSS Icon]](https://github.com/saihgupr/GoogleDriveSync)
 * [Itsytv](https://itsytv.app/) - 메뉴 바에서 Apple TV를 제어. [![Open-Source Software][OSS Icon]](https://github.com/nickustinov/itsytv-macos) ![Freeware][Freeware Icon]

--- a/README-zh.md
+++ b/README-zh.md
@@ -1319,6 +1319,7 @@ Awesome Mac
 * [Today](https://sindresorhus.com/today) - 在菜单栏查看今天日程和日历事件。 ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id6443714928?platform=mac)
 * [TypeCue](https://typecue.app) - 将预先准备好的脚本逐行输入到任意应用，每按一次快捷键输入一行，以真实按键和自然的节奏模拟人工输入，适用于产品演示录制和现场演讲。 [![Open-Source Software][OSS Icon]](https://github.com/alexpolonsky/TypeCue) ![Freeware][Freeware Icon]
 * [FunKey](https://apps.apple.com/us/app/funkey-mechanical-keyboard-app/id6469420677?platform=mac) - 为键盘输入添加机械键盘音效的工具。 [![App Store][app-store Icon]](https://apps.apple.com/us/app/funkey-mechanical-keyboard-app/id6469420677?platform=mac)
+* [SessionWatcher](https://sessionwatcher.com) - 在菜单栏中跟踪 15 个 AI 编程服务的用量上限、配额、花费与重置时间，涵盖 Claude Code、Codex、Cursor、Copilot 和 Gemini CLI。 ![Native App][Native Icon]
 * [SketchyBar](https://github.com/FelixKratz/SketchyBar) - A highly customizable macOS status bar replacement. [![Open-Source Software][OSS Icon]](https://github.com/FelixKratz/SketchyBar) ![Freeware][Freeware Icon]
 * [stats](https://github.com/exelban/stats) - 免费的 Mac 系统监视器，显示在菜单栏中。 [![Open-Source Software][OSS Icon]](https://github.com/exelban/stats) ![Freeware][Freeware Icon]
 * [Vanilla](https://matthewpalmer.net/vanilla/) - 隐藏系统菜单栏。 ![Freeware][Freeware Icon]

--- a/README.md
+++ b/README.md
@@ -1293,6 +1293,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [RewriteBar](https://rewritebar.com/) - A macOS menu bar app that helps you write your text with the assistance of AI.
 * [Second Clock](https://sindresorhus.com/second-clock) - Show a second clock for a different time zone in your menu bar. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id6450279539?platform=mac)
 * [Thaw](https://github.com/stonerl/Thaw) - A powerful menu bar management tool for hiding and showing menu bar items. [![Open-Source Software][OSS Icon]](https://github.com/stonerl/Thaw)
+* [SessionWatcher](https://sessionwatcher.com) - Menu bar tracker for AI coding usage limits, quotas, spend and reset times across 15 providers including Claude Code, Codex, Cursor, Copilot and Gemini CLI. ![Native App][Native Icon]
 * [SketchyBar](https://github.com/FelixKratz/SketchyBar) - A highly customizable macOS status bar replacement. [![Open-Source Software][OSS Icon]](https://github.com/FelixKratz/SketchyBar) ![Freeware][Freeware Icon]
 * [Spaced](https://sindresorhus.com/spaced) - Organize your menu bar items into groups. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id1666327168?platform=mac)
 * [Streaker](https://github.com/jamieweavis/streaker) - GitHub contribution streak tracking menubar app. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/jamieweavis/streaker)


### PR DESCRIPTION
Adds SessionWatcher to Menu Bar Tools, in all four language READMEs.

Disclosure: I am the developer.

**What it is:** a native macOS menu bar app that shows how much AI coding usage
you have left. It reads limits, quotas, spend and reset times for 15 providers
(Claude Code, Codex, Cursor, Copilot, Gemini CLI, Antigravity, opencode, Devin,
Grok, OpenRouter, Z.ai, Kimi, Qwen, DeepSeek, Synthetic) and puts them in the
menu bar.

**Why this section:** Menu Bar Tools already lists cctop, CodexIsland,
MenubarCC, Agent Island and Notchly, which solve the same problem for one or two
providers. This one covers 15 and is native Swift rather than Electron.

**Guideline checklist:**

* Searched first, no existing SessionWatcher entry in any of the four READMEs
* One PR for one suggestion
* Alphabetical placement in each file (before SketchyBar in en/zh/ja, before
  Sharptooth in ko, which has no SketchyBar entry)
* Synced across README.md, README-zh.md, README-ja.md and README-ko.md, with
  the description translated in each
* One sentence per description, matching neighbouring entries
* `![Native App][Native Icon]` only. No Freeware or OSS badge, since it is paid
  and closed source. Bartender and DynamicHorizon in the same section follow
  this pattern.
* No trailing whitespace, no tracking parameters in the URL

macOS 14 or later, Apple Silicon and Intel. There is a 7 day trial without a
credit card if you want to check it before merging.
