### PR TITLE
Add UpSit to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1477,6 +1477,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Trace](https://trace.techulus.xyz) - Open-source spotlight alternative and shortcut toolkit. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/arjunkomath/trace)
 * [Trello](https://trello.com) - A collaboration tool that organizes your projects into Kanban boards.![Freeware][Freeware Icon][![App Store][app-store Icon]](https://apps.apple.com/app/trello/id1278508951?ls=1&platform=mac)
 * [Ukelele](https://scripts.sil.org/ukelele) - Unicode Keyboard Layout Editor.
+* [UpSit](https://www.upsit.online) - Tracks sitting posture from the webcam using an on-device ML model and nudges you when you slouch, with nothing ever uploaded. [![Open-Source Software][OSS Icon]](https://github.com/aykhanstoic/superposture)
 * [Velja](https://sindresorhus.com/velja) - Browser picker that lets you open links in a specific browser or a desktop app.  [![App Store][app-store Icon]](https://apps.apple.com/app/id1607635845?platform=mac)
 * [Wox](https://wox-launcher.github.io/Wox/) - Open-source cross-platform launcher with fast local search and plugin extensibility. [![Open-Source Software][OSS Icon]](https://github.com/Wox-launcher/Wox) ![Freeware][Freeware Icon]
 * [xScope](https://xscopeapp.com/) - Toolset for measuring, inspecting, and testing on-screen layouts and graphics.


### PR DESCRIPTION
Adds [UpSit](https://www.upsit.online) ([source](https://github.com/aykhanstoic/superposture)) next to Table Habit and Time Out, in the same spirit — it tracks sitting posture via the webcam using an on-device ML model and nudges you when you slouch. Nothing ever leaves the device (no cloud backend for the core feature). Open source (MIT).