### PR TITLE
Add PinboardShot to Screenshot Tools

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -736,6 +736,7 @@ Awesome Mac
 * [Flameshot](https://github.com/flameshot-org/flameshot) - 強力でありながらシンプルなスクリーンショットソフトウェア。 ![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]
 * [Lightshot](https://app.prntscr.com/) - カスタマイズ可能なスクリーンショットを撮る最速の方法。 ![Freeware][Freeware Icon]
 * [macshot](https://github.com/sw33tlie/macshot) - 画面録画、スクロールキャプチャ、OCRに対応したスクリーンショット注釈ツール。 [![Open-Source Software][OSS Icon]](https://github.com/sw33tlie/macshot) ![Freeware][Freeware Icon]
+* [PinboardShot](https://pinboardshot.agentclub.dev) - macOS ネイティブでローカルファーストなスクリーンショット、注釈、スクロールキャプチャ、ローカル OCR 履歴、画面ピン留めツール。 [![Open-Source Software][OSS Icon]](https://github.com/agent-club/PinboardShot)
 * [Scap](https://wangchujiang.com/scap/) - ぼかし、モザイク、透かしに対応したスクリーンショット注釈・キャンバスツール。 [![App Store][app-store Icon]](https://apps.apple.com/app/Scap/6758053530?platform=mac)
 * [Shottr](https://shottr.cc/) - スクロールキャプチャ、OCR、マークアップ機能を備えたスクリーンキャプチャアプリケーション。
 * [Skitch](https://evernote.com/skitch/) - 強力な注釈機能を備えたスクリーンキャプチャアプリケーション。 ![Freeware][Freeware Icon]

--- a/README-ko.md
+++ b/README-ko.md
@@ -593,6 +593,7 @@ Awesome Mac
 * [CleanShot X](https://cleanshot.com/) - Mac 화면 캡처를 위한 최고의 방법.
 * [CloudApp](https://www.getcloudapp.com/) - 빠른 화면 캡처 및 공유. ![Freeware][Freeware Icon]
 * [macshot](https://github.com/sw33tlie/macshot) - 화면 녹화, 스크롤 캡처, OCR을 지원하는 스크린샷 주석 도구. [![Open-Source Software][OSS Icon]](https://github.com/sw33tlie/macshot) ![Freeware][Freeware Icon]
+* [PinboardShot](https://pinboardshot.agentclub.dev) - macOS용 네이티브 로컬 우선 스크린샷, 주석, 스크롤 캡처, 로컬 OCR 기록 및 화면 고정 도구. [![Open-Source Software][OSS Icon]](https://github.com/agent-club/PinboardShot)
 * [Scap](https://wangchujiang.com/scap/) - 블러, 모자이크, 워터마크를 지원하는 스크린샷 주석 및 캔버스 도구. [![App Store][app-store Icon]](https://apps.apple.com/app/Scap/6758053530?platform=mac)
 * [Shottr](https://shottr.cc/) - 스크롤 캡처, OCR 등 기능을 갖춘 캡처 앱.
 * [Snapzy](https://snapzy.app/) - 스크린샷, 화면 녹화, 주석, 동영상 편집을 지원하는 무료 오픈 소스 네이티브 macOS 앱입니다. [![Open-Source Software][OSS Icon]](https://github.com/duongductrong/Snapzy) ![Freeware][Freeware Icon] ![Native App][Native Icon]

--- a/README-zh.md
+++ b/README-zh.md
@@ -517,6 +517,7 @@ Awesome Mac
 * [CleanShot X](https://cleanshot.com/) - 像专业人士一样捕捉你的 Mac 屏幕。
 * [iShot](https://www.better365.cn/) - 完全免费、功能全面的截图工具，支持贴图、滚动截图、延时截图等。 [![App Store][app-store Icon]](https://apps.apple.com/cn/app/ishot-%E6%88%AA%E5%9B%BE-%E9%95%BF%E6%88%AA%E5%9B%BE-%E6%A0%87%E6%B3%A8%E5%B7%A5%E5%85%B7/id1485844094?platform=mac) ![Freeware][Freeware Icon]
 * [macshot](https://github.com/sw33tlie/macshot) - 支持录屏、滚动截图和 OCR 的截图标注工具。 [![Open-Source Software][OSS Icon]](https://github.com/sw33tlie/macshot) ![Freeware][Freeware Icon]
+* [PinboardShot](https://pinboardshot.agentclub.dev) - macOS 原生、本地优先的截图、标注、滚动截图、本地 OCR 历史与屏幕贴图工具。 [![Open-Source Software][OSS Icon]](https://github.com/agent-club/PinboardShot)
 * [Scap](https://wangchujiang.com/scap/) - 支持模糊、马赛克和水印的截图标注与画布工具。[![App Store][app-store Icon]](https://apps.apple.com/app/Scap/6758053530?platform=mac)
 * [Capty](https://capty.app/) - 内置编辑和标注功能的录屏与截图工具。
 * [Capso](https://github.com/lzhgus/Capso) - 支持标注、OCR 和摄像头画中画的开源截图与录屏工具。 [![Open-Source Software][OSS Icon]](https://github.com/lzhgus/Capso) ![Freeware][Freeware Icon]

--- a/README.md
+++ b/README.md
@@ -735,6 +735,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Flameshot](https://github.com/flameshot-org/flameshot) - Powerful yet simple to use screenshot software. ![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]
 * [Lightshot](https://app.prntscr.com/) - The fastest way to take a customizable screenshot. ![Freeware][Freeware Icon]
 * [macshot](https://github.com/sw33tlie/macshot) - Screenshot and annotation tool with screen recording, scrolling capture, and OCR. [![Open-Source Software][OSS Icon]](https://github.com/sw33tlie/macshot) ![Freeware][Freeware Icon]
+* [PinboardShot](https://pinboardshot.agentclub.dev) - Native, local-first macOS screenshot, annotation, scrolling capture, local OCR history, and screen pinboard tool. [![Open-Source Software][OSS Icon]](https://github.com/agent-club/PinboardShot)
 * [Scap](https://wangchujiang.com/scap/) - Screenshot annotation and canvas tool with blur, mosaic, and watermark features. [![App Store][app-store Icon]](https://apps.apple.com/app/Scap/6758053530?platform=mac)
 * [Shottr](https://shottr.cc/) - Screen capture application with features like Scrolling capture, OCR and markup.
 * [Skitch](https://evernote.com/skitch/) - Screen capture application with a powerful annotation capabilities. ![Freeware][Freeware Icon]


### PR DESCRIPTION
### Types of Changes

- [x] New addition to list
- [ ] Fixing bug in existing item in list
- [ ] Removing item from list
- [ ] Changing structure (organization) of list

### Proposed Changes

Add PinboardShot to Screenshot Tools in the English, Simplified Chinese, Japanese, and Korean lists.

PinboardShot is a native, local-first macOS screenshot, annotation, scrolling capture, local OCR history, and screen pinboard tool. It is open source under the MIT License. The entry is useful for people looking for an account-free, open-source Mac screenshot workflow with local OCR history and persistent visual references.

Website: https://pinboardshot.agentclub.dev
Source: https://github.com/agent-club/PinboardShot

Checks completed:

- No existing PinboardShot entry or open/closed issue/PR was found.
- The entry is placed alphabetically between macshot and Scap.
- The wording and format are synchronized across all four language lists.

### PR Checklist

- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important
- [x] I have added necessary documentation (if appropriate)

### Further Comments

This contribution was prepared with AI assistance. Product facts, duplicate searches, ordering, and the final four-file diff were checked against the public website, repository, and current master branch.