### PR TITLE
Add Tr4wl to Finder Tools

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1551,6 +1551,7 @@ Awesome Mac
 * [RClick](https://github.com/wflixu/RClick) - macOS Finderのコンテキストメニューに新しい機能を追加。 [![Open-Source Software][OSS Icon]](https://github.com/wflixu/RClick) ![Freeware][Freeware Icon]
 * [SwiftyMenu](https://apps.apple.com/us/app/swiftymenu/id1567748223?platform=mac) - 選択したファイルやフォルダを指定アプリですばやく開く Finder 拡張。
 * [TotalFinder](http://totalfinder.binaryage.com/) - Chrome風のFinder代替。
+* [Tr4wl](https://tr4wl.com/) - Spotlight がインデックスしないファイルまで名前で検索するツール。ドットファイル、キャッシュ、ビルド成果物、アプリバンドルの中身に対応。 ![Native App][Native Icon]
 * [XtraFinder](https://www.trankynam.com/xtrafinder/) - Mac Finderにタブ機能と切り取り機能を追加。 ![Freeware][Freeware Icon]
 
 ### 生活の質の向上

--- a/README-ko.md
+++ b/README-ko.md
@@ -991,6 +991,7 @@ Awesome Mac
 * [Keka](https://www.keka.io/) - 다양한 포맷을 지원하는 오픈 소스 압축/해제 도구. [![Open-Source Software][OSS Icon]](https://github.com/aonez/Keka) ![Freeware][Freeware Icon]
 * [The Unarchiver](https://theunarchiver.com/) - 모든 스타일의 압축 파일을 해제. ![Freeware][Freeware Icon]
 * [Unarchive One](https://cleanerone.trendmicro.com/unarchiver-one/?utm_source=github&utm_medium=referral&utm_campaign=githubproject) - 다양한 일반 압축 포맷을 압축하고 해제하는 도구. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/apple-store/id1127253508?pt=444218&ct=GitHub&mt=8&platform=mac)
+* [Tr4wl](https://tr4wl.com/) - Spotlight가 색인하지 않는 파일까지 이름으로 찾는 검색 도구. 점 파일, 캐시, 빌드 산출물, 앱 번들 내부를 포함한다. ![Native App][Native Icon]
 
 ### 시스템 도구
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -1485,6 +1485,7 @@ Awesome Mac
 * [Shuffle](https://shuffleapp.co) - 使用 Rust 构建的 GPU 渲染高速文件管理器，Finder 的替代品。 [![Open-Source Software][OSS Icon]](https://github.com/WizenPainter/shuffle) ![Freeware][Freeware Icon]
 * [SwiftyMenu](https://apps.apple.com/us/app/swiftymenu/id1567748223?platform=mac) - 用常用应用快速打开所选文件或文件夹的 Finder 扩展。
 * [TotalFinder](http://totalfinder.binaryage.com/) - 强大的 Finder 替代者，界面风格像 Chrome。
+* [Tr4wl](https://tr4wl.com/) - 按文件名搜索 Spotlight 未索引的文件，包括点文件、缓存、构建产物和应用程序包内部。 ![Native App][Native Icon]
 * [XtraFinder](https://www.trankynam.com/xtrafinder/) - 给 Finder 添加有用的新特性。![Freeware][Freeware Icon]
 
 ## 游戏软件

--- a/README.md
+++ b/README.md
@@ -1556,6 +1556,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [RClick](https://github.com/wflixu/RClick) - Add new functionality to the macOS Finder context menu.  [![Open-Source Software][OSS Icon]](https://github.com/wflixu/RClick) ![Freeware][Freeware Icon]
 * [SwiftyMenu](https://apps.apple.com/us/app/swiftymenu/id1567748223?platform=mac) - Finder extension for opening selected files or folders with custom app shortcuts.
 * [TotalFinder](https://totalfinder.binaryage.com/) - Chrome-styled Finder substitute.
+* [Tr4wl](https://tr4wl.com/) - Filename search for the files Spotlight does not index, including dotfiles, caches, build output, and the contents of app bundles. ![Native App][Native Icon]
 * [XtraFinder](https://www.trankynam.com/xtrafinder/) - Adds tabs and cut to Mac Finder. ![Freeware][Freeware Icon]
 
 ### Quality of Life Improvements


### PR DESCRIPTION
### Types of Changes

**What types of changes does your PR introduce?** Put an `x` in all boxes that apply

- [x] New addition to list
- [ ] Fixing bug in existing item in list
- [ ] Removing item from list
- [ ] Changing structure (organization) of list

---

Tr4wl is a native macOS app that searches by filename in the places Spotlight leaves out: dotfiles, caches, build output, gaps in `~/Library` and app containers, and inside `.app` bundles. It builds its own in-memory index by walking the filesystem directly, and keeps it current with FSEvents.

- Website: https://tr4wl.com/
- macOS 14 (Sonoma) or later, Apple silicon
- Signed and notarized with a Developer ID, distributed outside the App Store
- Paid (one-time purchase, 14-day trial), so no Freeware or Open Source badge

Note on `README-ko.md`: the Korean translation has no `Finder Tools` section, and the entries that live there in English (SaneClick, SwiftyMenu, Shuffle) are under `파일 정리 도구`, so I added it there instead. Happy to move any of these if you would prefer a different section.