### PR TITLE
Add InvoiceFlowAI to Finance

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1129,6 +1129,7 @@ Awesome Mac
 
 ## ファイナンス
 
+* [InvoiceFlowAI](https://github.com/EthanYoQ/Invoice-Downloader) - メールからPDF・OFD・XMLの請求書を収集し、OCR、分類保存、確認可能なExcel集計を行うオープンソースの請求書整理ツール。 [![Open-Source Software][OSS Icon]](https://github.com/EthanYoQ/Invoice-Downloader) ![Freeware][Freeware Icon]
 * [Pulse](https://www.pulseticker.app/) - 米国株・香港株・中国株、暗号資産、指数、ETF、ポートフォリオ損益を表示するネイティブのメニューバー相場ツール。 [![Open-Source Software][OSS Icon]](https://github.com/fatwang2/Pulse) ![Freeware][Freeware Icon]
 * [SubManager](https://submanager.app) - 更新通知に対応したサブスクリプション管理ツール。 [![App Store][app-store Icon]](https://apps.apple.com/app/submanager-subscription-list/id1632853914?platform=mac)
 * [SubList](https://apps.apple.com/app/sublist-subscription-list/id6757860829?platform=mac) - リマインダー、分析、iCloud同期でサブスクリプション、更新、支出を1か所で追跡。

--- a/README-ko.md
+++ b/README-ko.md
@@ -860,6 +860,7 @@ Awesome Mac
 
 ## 금융
 
+* [InvoiceFlowAI](https://github.com/EthanYoQ/Invoice-Downloader) - 이메일에서 PDF, OFD, XML 전자 인보이스를 수집하고 OCR, 분류 보관, 검토 가능한 Excel 요약을 제공하는 오픈 소스 인보이스 정리 도구. [![Open-Source Software][OSS Icon]](https://github.com/EthanYoQ/Invoice-Downloader) ![Freeware][Freeware Icon]
 * [Pulse](https://www.pulseticker.app/) - 미국·홍콩·중국 주식, 암호화폐, 지수, ETF 및 포트폴리오 손익을 보여주는 네이티브 메뉴 막대 시세 도구. [![Open-Source Software][OSS Icon]](https://github.com/fatwang2/Pulse) ![Freeware][Freeware Icon]
 * [SubManager](https://submanager.app/) - 갱신 알림을 제공하는 구독 관리 도구. [![App Store][app-store Icon]](https://apps.apple.com/app/submanager-subscription-list/id1632853914?platform=mac)
 * [SubList](https://apps.apple.com/app/sublist-subscription-list/id6757860829?platform=mac) - 알림, 분석 및 iCloud 동기화를 통해 한 곳에서 구독, 갱신 및 지출을 추적.

--- a/README-zh.md
+++ b/README-zh.md
@@ -1075,6 +1075,7 @@ Awesome Mac
 
 ## 金融
 
+* [InvoiceFlowAI](https://github.com/EthanYoQ/Invoice-Downloader) - 开源电子发票整理工具，从邮箱收集 PDF、OFD、XML 发票，OCR 后分类归档并生成可复核的 Excel 汇总。 [![Open-Source Software][OSS Icon]](https://github.com/EthanYoQ/Invoice-Downloader) ![Freeware][Freeware Icon]
 * [Pulse](https://www.pulseticker.app/) - 原生菜单栏行情工具，支持美股、港股、A 股、加密货币、指数、ETF 和持仓盈亏。 [![Open-Source Software][OSS Icon]](https://github.com/fatwang2/Pulse) ![Freeware][Freeware Icon]
 * [SubManager](https://submanager.app) - 带续费提醒的订阅管理工具。 [![App Store][app-store Icon]](https://apps.apple.com/app/submanager-subscription-list/id1632853914?platform=mac)
 

--- a/README.md
+++ b/README.md
@@ -1131,6 +1131,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 
 ## Finance
 
+* [InvoiceFlowAI](https://github.com/EthanYoQ/Invoice-Downloader) - Open-source invoice organizer that collects PDF, OFD, and XML invoices from email, applies OCR, archives them by category, and exports a reviewable Excel summary. [![Open-Source Software][OSS Icon]](https://github.com/EthanYoQ/Invoice-Downloader) ![Freeware][Freeware Icon]
 * [Pulse](https://www.pulseticker.app/) - Native menu bar market tracker for US, Hong Kong and China stocks, crypto, indices, ETFs and portfolio P&L. [![Open-Source Software][OSS Icon]](https://github.com/fatwang2/Pulse) ![Freeware][Freeware Icon]
 * [SubManager](https://submanager.app) - Subscription tracker with renewal reminders. [![App Store][app-store Icon]](https://apps.apple.com/app/submanager-subscription-list/id1632853914?platform=mac)
 * [SubList](https://apps.apple.com/app/sublist-subscription-list/id6757860829?platform=mac) - Track subscriptions, renewals, and spending in one place with reminders, analytics, and iCloud sync.


### PR DESCRIPTION
Adds an open-source macOS tool for collecting and organizing electronic invoices, with concise descriptions in the four maintained languages. This replaces the earlier submission that closed when its source fork was removed.