### PR TITLE
Add Authier to Password Management

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1523,6 +1523,7 @@ Awesome Mac
 ### パスワード管理
 
 * [1Password](https://1password.com/) - クロスプラットフォームのパスワード管理ツール。
+* [Authier](https://www.authier.pm/) - ブラウザとWeb向けのオープンソースパスワードマネージャーで、まだ開発初期段階にあり、クライアント側で暗号化したデータの同期、TOTP、自動入力に対応しているが、第三者による独立監査は未実施。 [![Open-Source Software][OSS Icon]](https://github.com/authier-pm/authier) ![Freeware][Freeware Icon]
 * [Bitwarden](https://bitwarden.com) - Mac OS、iOS、ブラウザ対応のオープンソースパスワード管理ツール。 [![Open-Source Software][OSS Icon]](https://github.com/bitwarden) ![Freeware][Freeware Icon]
 * [Buttercup](https://buttercup.pw/) - あなたにふさわしいパスワードマネージャー。 ![Freeware][Freeware Icon]
 * [Dashlane](https://www.dashlane.com) - 受賞歴のあるデザインを持つクラウドベースのパスワードマネージャー。

--- a/README-ko.md
+++ b/README-ko.md
@@ -1086,6 +1086,7 @@ Awesome Mac
 ### 비밀번호 관리
 
 * [1Password](https://1password.com/) - 세계에서 가장 인기 있는 비밀번호 관리자.
+* [Authier](https://www.authier.pm/) - 브라우저와 웹에서 사용할 수 있는 초기 개발 단계의 오픈 소스 비밀번호 관리자로, 클라이언트 측에서 암호화한 데이터를 동기화하고 TOTP 및 자동 완성을 지원하지만 아직 독립적인 감사를 받지는 않았습니다. [![Open-Source Software][OSS Icon]](https://github.com/authier-pm/authier) ![Freeware][Freeware Icon]
 * [Bitwarden](https://bitwarden.com/) - 안전한 오픈 소스 비밀번호 관리 솔루션. [![Open-Source Software][OSS Icon]](https://github.com/bitwarden/desktop) ![Freeware][Freeware Icon]
 * [Strongbox](https://strongboxsafe.com/) - KeePass와 Password Safe를 지원하는 비밀번호 관리자. [![Open-Source Software][OSS Icon]](https://github.com/strongbox-password-safe/Strongbox) [![App Store][app-store Icon]](https://apps.apple.com/us/app/strongbox/id1270075435?platform=mac)
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -1456,6 +1456,7 @@ Awesome Mac
 ### 密码管理
 
 * [1password](https://1password.com/) - 跨平台帐号密码管理软件。
+* [Authier](https://www.authier.pm/) - 一款尚处早期阶段、面向浏览器和 Web 的开源密码管理器，支持客户端加密同步、TOTP 和自动填充；尚未经过独立审计。 [![Open-Source Software][OSS Icon]](https://github.com/authier-pm/authier) ![Freeware][Freeware Icon]
 * [Bitwarden](https://bitwarden.com) - 适用于Mac OS，iOS和浏览器的开源密码管理工具。 [![Open-Source Software][OSS Icon]](https://github.com/bitwarden) ![Freeware][Freeware Icon]
 * [Buttercup](https://buttercup.pw/) - 跨平台密码管理器 ![Freeware][Freeware Icon] [![Open-Source Software][OSS Icon]](https://github.com/buttercup/buttercup-desktop)
 * [Dashlane](https://www.dashlane.com) - 基于云的密码管理器，拥有屡获殊荣的设计。

--- a/README.md
+++ b/README.md
@@ -1529,6 +1529,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 ### Password Management
 
 * [1Password](https://1password.com/) - Cross-platform password management tool.
+* [Authier](https://www.authier.pm/) - Early-stage open-source password manager for browsers and the web with client-side encrypted sync, TOTP, and autofill; not independently audited. [![Open-Source Software][OSS Icon]](https://github.com/authier-pm/authier) ![Freeware][Freeware Icon]
 * [Bitwarden](https://bitwarden.com) - Open source password management tool for Mac OS, iOS and browsers. [![Open-Source Software][OSS Icon]](https://github.com/bitwarden) ![Freeware][Freeware Icon]
 * [Buttercup](https://buttercup.pw/) - The Password Manager You Deserve ![Freeware][Freeware Icon]
 * [Dashlane](https://www.dashlane.com) - Cloud-based password manager with award-winning design.


### PR DESCRIPTION
## Summary

- Add Authier to Password Management in the English, Chinese, Japanese, and Korean catalogues.
- Link the canonical homepage and AGPL-3.0-or-later source repository, with the freeware marker for Authier's non-expiring free tier.
- Describe Authier accurately as an early-stage browser/web password manager and state that it has not been independently audited.

## Validation

- `npm install`
- `npm run build`
- `npm run create:ast`
- `npm run feed` (detected one new Authier entry in each language from a disposable committed checkout)
- `git diff --check`
- Confirmed generated HTML contains a direct `https://www.authier.pm/` anchor in all four language pages.

## Disclosure

I am an Authier maintainer. This contribution was prepared with AI assistance and manually reviewed for factual accuracy, translation quality, repository style, and generated output.
