### PR TITLE
Add Mossy to Productivity

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1444,6 +1444,7 @@ Awesome Mac
 * [Metrune](https://treafree.github.io/Metrune/ja/) - タスク、AIコーディング、GitHubアクティビティ、デバイスイベント、バッジ、レポートをMacBookのノッチに集約するローカルファーストの集中ワークスペース。 ![Freeware][Freeware Icon]
 * [MindMac](https://mindmac.app/) - 複数のAIサービスを一つで使えるチャットクライアント。
 * [Mos](https://mos.caldis.me/) - Macでスムーズスクロールを提供し、マウスのスクロール方向を反転できるシンプルなツール。 [![Open-Source Software][OSS Icon]](https://github.com/Caldis/Mos) ![Freeware][Freeware Icon]
+* [Mossy](https://heymossy.com) - 座り続けるとしおれていくデスクトップの植物。一度設定した目標に沿った休憩を提案し、画面を遮ることはありません。 ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [MacPacker](https://macpacker.app) - アーカイブファイルのプレビューと展開をサポートするアーカイブマネージャー。 [![Open-Source Software][OSS Icon]](https://github.com/sarensw/macpacker) ![Freeware][Freeware Icon]
 * [Magic Switch](https://magic-switch.com/) - 複数のMac間でMagic Keyboard、Mouse、Trackpadを切り替えるツール。
 * [nnScreenshots](https://www.nearnorthsoftware.com/software/screenshots.php) - 定期スクリーンショットで一日の作業を振り返れるツール。

--- a/README-ko.md
+++ b/README-ko.md
@@ -1038,6 +1038,7 @@ Awesome Mac
 * [Magic Switch](https://magic-switch.com/) - 여러 Mac 사이에서 Magic Keyboard, Mouse, Trackpad를 전환하는 도구.
 * [Metrune](https://treafree.github.io/Metrune/ko/) - 작업, AI 코딩, GitHub 활동, 기기 이벤트, 배지, 리포트를 MacBook 노치에 모으는 로컬 우선 집중 작업 공간. ![Freeware][Freeware Icon]
 * [MindMac](https://mindmac.app/) - 여러 AI 서비스를 한곳에서 쓰는 채팅 클라이언트.
+* [Mossy](https://heymossy.com) - 오래 앉아 있으면 시들어가는 데스크톱 식물로, 한 번 설정한 목표에 맞춘 휴식을 제안하며 화면을 가리지 않습니다. ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [nnScreenshots](https://www.nearnorthsoftware.com/software/screenshots.php) - 주기적 스크린샷으로 하루 작업을 돌아볼 수 있는 도구.
 * [Qbserve](https://qotoqot.com/qbserve/) - 프로젝트와 생산성 분석을 지원하는 자동 시간 추적 도구.
 * [Raycast](https://www.raycast.com/) - 확장 기능, 스니펫, 노트, AI를 갖춘 런처. ![Freeware][Freeware Icon]

--- a/README-zh.md
+++ b/README-zh.md
@@ -1355,6 +1355,7 @@ Awesome Mac
 * [Textream](https://textream.fka.dev) - 免费提词器，具有实时单词跟踪和语音激活滚动功能。[![Open-Source Software][OSS Icon]](https://github.com/f/textream) ![Freeware][Freeware Icon]
 * [Trace](https://trace.techulus.xyz) - 开源的 Spotlight 替代品和快捷工具套件。 [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/arjunkomath/trace)
 * [ProBoard](https://apps.apple.com/app/id6748314346?platform=mac) - 通过一个面板来帮助你高效管理所有项目信息。[![App Store][app-store Icon]](https://apps.apple.com/app/id6748314346?platform=mac)
+* [Mossy](https://heymossy.com) - 桌面植物，久坐时会逐渐枯萎，并根据你一次设定的目标提供休息建议，全程不遮挡屏幕。 ![Freeware][Freeware Icon] ![Native App][Native Icon]
 
 ### 清理卸载
 

--- a/README.md
+++ b/README.md
@@ -1447,6 +1447,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Metrune](https://treafree.github.io/Metrune/en/) - Local-first focus workspace that brings tasks, AI coding, GitHub activity, device events, badges, and reports into the MacBook notch. ![Freeware][Freeware Icon]
 * [MindMac](https://mindmac.app/) - AI chat client for multiple providers in one place.
 * [Mos](https://mos.caldis.me/) - Simple tool can offer the smooth scrolling and reverse the mouse scrolling direction on your Mac. [![Open-Source Software][OSS Icon]](https://github.com/Caldis/Mos) ![Freeware][Freeware Icon]
+* [Mossy](https://heymossy.com) - Desktop plant that wilts while you sit, then offers a break shaped by a goal you set once, without ever blocking the screen. ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [MacPacker](https://macpacker.app) - Archive manager that supports previewing and extracting archive files [![Open-Source Software][OSS Icon]](https://github.com/sarensw/macpacker) ![Freeware][Freeware Icon]
 * [Magic Switch](https://magic-switch.com/) - Switch Magic Keyboard, Mouse, and Trackpad between multiple Macs.
 * [nnScreenshots](https://www.nearnorthsoftware.com/software/screenshots.php) - Capture periodic screenshots to review your day and fill timesheets.


### PR DESCRIPTION
Adding **Mossy**, a free native macOS app: a small plant that lives on your desktop and wilts while you sit, then offers a break shaped by a goal you set once. It never takes over the screen and skipping a break is a normal way to use it.

- https://heymossy.com
- Swift / AppKit, no dependencies, 1.6 MB, macOS 12+, notarized

**Disclosure:** I am the author. Happy to close this if self-submissions are not welcome here.

**Category:** placed in `Productivity`, next to `Time Out` and `Pomodoro Cycle`, rather than `Menu Bar Tools` where the other break apps (`Eye Timer`, `Repose`, `mysa`) live. Mossy has no `NSStatusBar` item at all: it is a desktop companion, so `Menu Bar Tools` would be inaccurate.

**Sync:** the entry is added to `README.md`, `README-zh.md`, `README-ja.md` and `README-ko.md`, in alphabetical position in each (the `zh` productivity section is append-ordered, so it goes last there).

**Icons:** `Freeware` (free, no account) and `Native App`. No `Open-Source Software` icon: the source is not public.