### PR TITLE
Add TouchNow to Remote Login Software

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1642,6 +1642,7 @@ Awesome Mac
 * [Steam Link](https://apps.apple.com/us/app/steam-link/id1246969117?platform=mac) - Steam Linkアプリを使えば、すべてのコンピューターでSteamゲームをプレイ可能。 ![Freeware][Freeware Icon]
 * [Sunshine](https://github.com/LizardByte/Sunshine) - Moonlight用のセルフホスト型ゲームストリームホスト。 [![Open-Source Software][OSS Icon]](https://github.com/LizardByte/Sunshine) ![Freeware][Freeware Icon]
 * [TeamViewer](https://www.teamviewer.com/en) - リモートサポートと画面共有のためのツール。 ![Freeware][Freeware Icon]
+* [TouchNow](https://touchmac.app/ja/) - iPhone や iPad から Mac をタッチ操作、画面上のコントローラーで Mac のゲームも遊べる。同じ Wi-Fi 内なら無料。 ![Freeware][Freeware Icon]
 * [Windows App](https://apps.apple.com/us/app/windows-app/id1295203466?platform=mac) - リモートPCまたは管理者が利用可能にした仮想アプリやデスクトップに接続。 ![Freeware][Freeware Icon]
 
 ## クイックルックプラグイン

--- a/README-ko.md
+++ b/README-ko.md
@@ -1104,6 +1104,7 @@ Awesome Mac
 * [RoyalTSX](https://www.royalapps.com/ts/mac/features) - 여러 프로토콜을 한곳에서 관리하는 원격 접속 클라이언트. ![Freeware][Freeware Icon]
 * [RustDesk](https://rustdesk.com/) - 오픈 소스 원격 데스크톱 솔루션. [![Open-Source Software][OSS Icon]](https://github.com/rustdesk/rustdesk) ![Freeware][Freeware Icon]
 * [TeamViewer](https://www.teamviewer.com/) - 원격 지원과 화면 공유를 위한 도구. ![Freeware][Freeware Icon]
+* [TouchNow](https://touchmac.app/en/) - iPhone이나 iPad에서 터치로 Mac을 제어하거나 화면 컨트롤러로 Mac 게임을 즐기는 도구. 같은 Wi-Fi에서는 무료. ![Freeware][Freeware Icon]
 
 ## QuickLook 플러그인
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -1514,6 +1514,7 @@ Awesome Mac
 * [Steam Link](https://apps.apple.com/cn/app/steam-link/id1246969117?platform=mac) - 通过局域网或互联网将您的 Steam 游戏串流到 Mac 上。[![App Store][app-store Icon]](https://apps.apple.com/cn/app/steam-link/id1246969117?platform=mac) ![Freeware][Freeware Icon]
 * [Sunshine](https://github.com/LizardByte/Sunshine) - 自托管的游戏串流，用于 Moonlight。[![Open-Source Software][OSS Icon]](https://github.com/LizardByte/Sunshine) ![Freeware][Freeware Icon]
 * [TeamViewer](https://www.teamviewer.com) - 用于远程协助和屏幕共享的工具。![Freeware][Freeware Icon]
+* [TouchNow](https://touchmac.app/zh-hans/) - 用 iPhone 或 iPad 触控操作 Mac，也可以用屏幕上的手柄玩 Mac 游戏。局域网内免费。![Freeware][Freeware Icon]
 * [Windows App](https://apps.apple.com/cn/app/windows-app/id1295203466?platform=mac) - 微软官方的远程桌面连接工具 [![App Store][app-store Icon]](https://apps.apple.com/cn/app/windows-app/id1295203466?platform=mac) [![Freeware][Freeware Icon]](https://go.microsoft.com/fwlink/?linkid=868963)
 
 ## QuickLook插件

--- a/README.md
+++ b/README.md
@@ -1648,6 +1648,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Steam Link](https://apps.apple.com/us/app/steam-link/id1246969117?platform=mac) - The Steam Link app allows you to play your Steam games across all your computers. ![Freeware][Freeware Icon]
 * [Sunshine](https://github.com/LizardByte/Sunshine) - Self-hosted game stream host for Moonlight. [![Open-Source Software][OSS Icon]](https://github.com/LizardByte/Sunshine) ![Freeware][Freeware Icon]
 * [TeamViewer](https://www.teamviewer.com/en) - Remote support and screen sharing tool. ![Freeware][Freeware Icon]
+* [TouchNow](https://touchmac.app/en/) - Control your Mac from an iPhone or iPad by touch, or play Mac games on it with an on-screen controller. Free on your own Wi-Fi. ![Freeware][Freeware Icon]
 * [Windows App](https://apps.apple.com/us/app/windows-app/id1295203466?platform=mac) - Connect to a remote PC or virtual apps and desktops made available by your admin. ![Freeware][Freeware Icon]
 
 ## QuickLook Plugins


### PR DESCRIPTION
TouchNow streams a Mac's screen to an iPhone or iPad and lets you control it by touch, or play Mac games with an on-screen controller that maps to keyboard input. Free on the local network, no account needed. The Mac side is a free download from touchmac.app.

Added to all four READMEs in alphabetical order under Remote Login Software.