### PR TITLE
Add Super ADB Manager (System Related Tools)

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1610,6 +1610,7 @@ Awesome Mac
 * [Sleepr](https://sleepr.app/) - macOSにスリープタイマーを復活。 [![App Store][app-store Icon]](https://apps.apple.com/us/app/sleepr-app/id6465683427?platform=mac)
 * [Sloth](https://sveinbjorn.org/sloth/) - 実行中のすべてのプロセスが使用している開いているファイル、ディレクトリ、ソケット、パイプ、デバイスを表示。 [![Open-Source Software][OSS Icon]](https://github.com/sveinbjornt/Sloth/) ![Freeware][Freeware Icon]
 * [SteerMouse](https://plentycom.jp/en/steermouse/) - マウスのボタン、ホイール、カーソル速度を細かく調整するツール。
+* [Super ADB Manager](https://adb.apiprime.com) - adb を通じて Android デバイスを管理するネイティブ macOS アプリ。scrcpy による画面ミラーリング、アプリ/APK とファイル管理、ワイヤレス ADB、logcat を内蔵。 ![Freeware][Freeware Icon]
 * [SwiftQuit](https://github.com/onebadidea/swiftquit/) - ウィンドウを閉じた際にmacOSアプリを自動的に終了する機能を有効化。 [![Open-Source Software][OSS Icon]](https://github.com/onebadidea/swiftquit) ![Freeware][Freeware Icon]
 * [SwiftMTP](https://github.com/Neighbor-Z/SwiftMTP) - MacとAndroidデバイス間でファイルの閲覧と転送を行うためのオープンソースMTP管理ツール。 [![Open-Source Software][OSS Icon]](https://github.com/Neighbor-Z/SwiftMTP) ![Freeware][Freeware Icon]
 * [Core Tunnel](https://codinn.com/tunnel/) - SSH接続を管理するアプリケーション。 [![App Store][app-store Icon]](https://apps.apple.com/us/app/core-tunnel/id1354318707?platform=mac)

--- a/README-ko.md
+++ b/README-ko.md
@@ -1010,6 +1010,7 @@ Awesome Mac
 * [SiliconScope](https://siliconscope.calidalab.ai) - 免授权的 Apple Silicon 系统监控工具（菜单栏 + 仪表盘），支持 ANE、媒体引擎、内存带宽追踪以及 E/P 核性能分解。 [![Open-Source Software][OSS Icon]](https://github.com/kennss/SiliconScope) ![Freeware][Freeware Icon]
 * [Sleepless](https://github.com/Aboudjem/Sleepless) - 덮개를 닫아도 절전을 막고 자동 종료 타이머와 배터리 하한 보호를 제공하는 도구. [![Open-Source Software][OSS Icon]](https://github.com/Aboudjem/Sleepless)
 * [SteerMouse](https://plentycom.jp/en/steermouse/) - 마우스 버튼, 휠, 커서 속도를 세밀하게 조정하는 도구.
+* [Super ADB Manager](https://adb.apiprime.com) - adb를 통해 Android 기기를 관리하는 네이티브 macOS 앱. scrcpy 화면 미러링, 앱/APK 및 파일 관리, 무선 ADB, logcat을 내장. ![Freeware][Freeware Icon]
 
 ### 할 일 목록 (To-Do Lists)
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -1411,6 +1411,7 @@ Awesome Mac
 * [SiliconScope](https://siliconscope.calidalab.ai) - 免授权的 Apple Silicon 系统监控工具（菜单栏 + 仪表盘），支持 ANE、媒体引擎、内存带宽追踪以及 E/P 核性能分解。 [![Open-Source Software][OSS Icon]](https://github.com/kennss/SiliconScope) ![Freeware][Freeware Icon]
 * [Sleepless](https://github.com/Aboudjem/Sleepless) - 合盖后也能保持唤醒，支持自动关闭计时和最低电量保护。 [![Open-Source Software][OSS Icon]](https://github.com/Aboudjem/Sleepless)
 * [SteerMouse](https://plentycom.jp/en/steermouse/) - 自定义鼠标按键、滚轮和指针速度的工具。
+* [Super ADB Manager](https://adb.apiprime.com) - 用于通过 adb 管理 Android 设备的原生 macOS 应用，内置 scrcpy 投屏、应用/APK 与文件管理、无线 ADB 和 logcat。 ![Freeware][Freeware Icon]
 * [Paragon NTFS](https://www.paragon-software.com/home/ntfs-mac/) - 在 Mac OS X 中完全读写、修改、访问 Windows NTFS 硬盘、U 盘等外接设备的文件。
 * [Raycast](https://raycast.com) - 集启动、扩展、片段、笔记和 AI 于一体的命令工具。
 * [SuperCmd](https://github.com/SuperCmdLabs/SuperCmd) - 开源启动器，支持 Raycast 兼容扩展、语音工作流、文本转语音、记忆与 AI 动作。 [![Open-Source Software][OSS Icon]](https://github.com/SuperCmdLabs/SuperCmd)

--- a/README.md
+++ b/README.md
@@ -1615,6 +1615,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Sleepr](https://sleepr.app/) - Sleepr brings back sleep timer on macOS. [![App Store][app-store Icon]](https://apps.apple.com/us/app/sleepr-app/id6465683427?platform=mac)
 * [Sloth](https://sveinbjorn.org/sloth/) - Shows all open files, directories, sockets, pipes and devices in use by all running processes. [![Open-Source Software][OSS Icon]](https://github.com/sveinbjornt/Sloth/) ![Freeware][Freeware Icon]
 * [SteerMouse](https://plentycom.jp/en/steermouse/) - Customize mouse buttons, wheel behavior, and cursor speed.
+* [Super ADB Manager](https://adb.apiprime.com) - Native macOS app to manage Android devices over adb, with embedded scrcpy screen mirroring, app/APK and file management, wireless ADB, and logcat. ![Freeware][Freeware Icon]
 * [SwiftQuit](https://github.com/onebadidea/swiftquit/) - Enables automatic quitting of macOS apps when closing their windows. [![Open-Source Software][OSS Icon]](https://github.com/onebadidea/swiftquit) ![Freeware][Freeware Icon]
 * [SwiftMTP](https://github.com/Neighbor-Z/SwiftMTP) - Open-source MTP device manager for browsing and transferring files between Mac and Android devices. [![Open-Source Software][OSS Icon]](https://github.com/Neighbor-Z/SwiftMTP) ![Freeware][Freeware Icon]
 * [Core Tunnel](https://codinn.com/tunnel/) - Application for managing SSH connections. [![App Store][app-store Icon]](https://apps.apple.com/us/app/core-tunnel/id1354318707?platform=mac)


### PR DESCRIPTION
Adds **Super ADB Manager** to **System Related Tools**, alphabetically after SteerMouse, in all four READMEs (`README.md`, `README-zh.md`, `README-ja.md`, `README-ko.md`).

**What it is:** a free, native macOS (SwiftUI, Apple Silicon) app to manage Android devices over `adb`, with a `scrcpy` server bundled inside — screen mirroring, app/APK and /sdcard file management, wireless ADB, and logcat. It sits naturally next to the existing HandShaker and SwiftMTP entries.

**Disclosure:** I'm the developer. It's free and closed-source freeware, so it carries only the `![Freeware][Freeware Icon]` badge (no Open Source / App Store badges) — same as the neighboring HandShaker entry.

Guidelines followed: not a duplicate, alphabetical order in the category, one-sentence descriptions, title-cased name, four-file sync, no trailing whitespace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)