### PR TITLE
Add MrEditor to Text Editors

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -205,6 +205,7 @@ Awesome Mac
 * [LiteEdit](https://arietan.github.io/lite-edit/) - 1MB以下の軽量ネイティブコードエディタ、シンタックスハイライトとファイルツリーを搭載。 [![Open-Source Software][OSS Icon]](https://github.com/arietan/lite-edit) ![Freeware][Freeware Icon]
 * [MacVim](https://github.com/macvim-dev/macvim) - macOS用のテキストエディタVim。 [![Open-Source Software][OSS Icon]](https://github.com/macvim-dev/macvim) ![Freeware][Freeware Icon]
 * [micro](https://micro-editor.github.io) - モダンで直感的なターミナルベースのテキストエディタ。 [![Open-Source Software][OSS Icon]](https://github.com/ory/editor) ![Freeware][Freeware Icon]
+* [MrEditor](https://mr-tabata.github.io/MrEditor/) - 巨大なテキストファイル向けのネイティブ macOS エディタ。10GB のログをそのまま開いて編集できる。 [![Open-Source Software][OSS Icon]](https://github.com/MR-TABATA/MrEditor) ![Freeware][Freeware Icon]
 * [Neovim](https://github.com/neovim/neovim) - 拡張性と使いやすさに重点を置いたVimフォーク。 [![Open-Source Software][OSS Icon]](https://github.com/neovim/neovim) ![Freeware][Freeware Icon]
 * [Nova](https://nova.app/) - Panic製の美しく、高速で、柔軟なネイティブMacコードエディタ。
 * [Plain Text Editor](https://sindresorhus.com/plain-text-editor) - シンプルで集中できるメモ帳。 ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id1572202501?platform=mac)

--- a/README-ko.md
+++ b/README-ko.md
@@ -181,6 +181,7 @@ Awesome Mac
 * [Aurora Editor](https://auroraeditor.com/) - macOS용 경량 코드 편집기 (IDE). [![Open-Source Software][OSS Icon]](https://github.com/AuroraEditor/AuroraEditor)
 * [Bootstrap Studio](https://bootstrapstudio.io/) - Bootstrap 프레임워크를 사용하여 반응형 웹사이트를 제작할 수 있는 강력한 데스크톱 앱.
 * [LiteEdit](https://arietan.github.io/lite-edit/) - 1MB 미만의 경량 네이티브 코드 편집기, 구문 강조와 파일 트리 제공. [![Open-Source Software][OSS Icon]](https://github.com/arietan/lite-edit) ![Freeware][Freeware Icon]
+* [MrEditor](https://mr-tabata.github.io/MrEditor/) - 대용량 텍스트 파일을 위한 네이티브 macOS 편집기, 10GB 로그도 열어서 바로 편집 가능. [![Open-Source Software][OSS Icon]](https://github.com/MR-TABATA/MrEditor) ![Freeware][Freeware Icon]
 * [Nova](https://nova.app/) - Panic에서 만든 아름답고 빠르고 유연한 네이티브 Mac 코드 편집기.
 * [Plain Text Editor](https://sindresorhus.com/plain-text-editor) - 단순하고 집중을 방해하지 않는 메모장. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id1572202501?platform=mac)
 * [Sublime Text](http://www.sublimetext.com/3) - 빠른 인터페이스와 플러그인 생태계를 갖춘 텍스트 편집기. [![Awesome List][awesome-list Icon]](https://github.com/dreikanter/sublime-bookmarks#readme)

--- a/README-zh.md
+++ b/README-zh.md
@@ -224,6 +224,7 @@ Awesome Mac
 * [LiteEdit](https://arietan.github.io/lite-edit/) - 轻量级原生代码编辑器，仅1MB大小，支持语法高亮和文件树。 [![Open-Source Software][OSS Icon]](https://github.com/arietan/lite-edit) ![Freeware][Freeware Icon]
 * [MacVim](https://github.com/macvim-dev/macvim) - Vim for macOS. [![Open-Source Software][OSS Icon]](https://github.com/macvim-dev/macvim) ![Freeware][Freeware Icon]
 * [micro](https://micro-editor.github.io) - 一个现代直观的基于终端的文本编辑器。 [![Open-Source Software][OSS Icon]](https://github.com/ory/editor) ![Freeware][Freeware Icon]
+* [MrEditor](https://mr-tabata.github.io/MrEditor/) - 面向超大文本文件的原生 macOS 编辑器，可直接打开并就地编辑 10 GB 的日志。 [![Open-Source Software][OSS Icon]](https://github.com/MR-TABATA/MrEditor) ![Freeware][Freeware Icon]
 * [NetBeans IDE](https://netbeans.org/) - 免费、开源的 IDE，主要用于 Java 开发，可支持多种语言和框架。 [![Open-Source Software][OSS Icon]](https://github.com/apache/netbeans) ![Freeware][Freeware Icon]
 * [Qt](https://www1.qt.io/cn/) - 跨平台 C++ 图形用户界面应用程序开发框架。
 * [TextMate](https://macromates.com) - 文本编辑器软件，与 BBedit 一起并称苹果机上的 emacs 和 vim。[![Open-Source Software][OSS Icon]](https://github.com/textmate/textmate) ![Freeware][Freeware Icon]

--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [LiteEdit](https://arietan.github.io/lite-edit/) - Fast, native macOS code editor under 1 MB — Swift and AppKit, no Electron. [![Open-Source Software][OSS Icon]](https://github.com/arietan/lite-edit) ![Freeware][Freeware Icon]
 * [MacVim](https://github.com/macvim-dev/macvim) - the text editor Vim - for macOS. [![Open-Source Software][OSS Icon]](https://github.com/macvim-dev/macvim) ![Freeware][Freeware Icon]
 * [micro](https://micro-editor.github.io) - Modern and intuitive terminal-based text editor. [![Open-Source Software][OSS Icon]](https://github.com/ory/editor) ![Freeware][Freeware Icon]
+* [MrEditor](https://mr-tabata.github.io/MrEditor/) - Native macOS editor for very large text files — opens and edits a 10 GB log in place. [![Open-Source Software][OSS Icon]](https://github.com/MR-TABATA/MrEditor) ![Freeware][Freeware Icon]
 * [Neovim](https://github.com/neovim/neovim) - Vim-fork focused on extensibility and usability. [![Open-Source Software][OSS Icon]](https://github.com/neovim/neovim) ![Freeware][Freeware Icon]
 * [Nova](https://nova.app/) - The beautiful, fast, flexible, native Mac code editor from Panic.
 * [Plain Text Editor](https://sindresorhus.com/plain-text-editor) - Simple distraction-free notepad. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id1572202501?platform=mac)


### PR DESCRIPTION
Adds **MrEditor** to Text Editors, in all four language files (`README.md`, `README-zh.md`, `README-ja.md`, `README-ko.md`), in alphabetical position.

MrEditor is a Mac-native (AppKit, no Electron) text editor for files other editors refuse to open. Editors built on `NSTextView` keep the whole document in `NSTextStorage`, so they fall over at gigabyte scale. MrEditor mmaps the file, keeps a sparse line index, draws only visible lines with Core Text, and represents edits as a piece table — so inserting a character at line 1 of a 10 GB file does not rewrite 10 GB.

Measured on the shipping build:

| | |
|---|---|
| 10.00 GB / 86,420,337-line log | starts displaying in ~80 ms, `vmmap` reports 0 bytes dirty |
| 1.18 GiB / 5,816,535-row CSV | opens in 51 ms using 78 MB |
| Jump to last line | 0.1 ms |
| Full background line index | ~10 s, never blocks the view |

Nothing currently in the section handles multi-gigabyte files; the closest tools (klogg, lnav) are read-only log viewers and are not Mac-native. MrEditor also edits and saves in place, with full-file search, regex, filtered view (live grep), `tail -f` follow, and structured view for CSV/TSV and NDJSON.

MIT, free, universal (Apple Silicon + Intel), signed with an Apple Developer ID and notarized, so it opens with a plain double-click. macOS 13+. Currently v1.14.0; 1.0 shipped 2026-07-11.

One thing worth stating plainly: the ~80 ms is time to first paint. The full line index of a 10 GB file takes about 10 seconds — it builds in the background and never blocks the view, but the exact line count settles only once it finishes. While indexing, `ps` RSS climbs to several GB; that is reclaimable file-backed page cache, not resident app memory (`vmmap` reports 0 dirty bytes; the app's own footprint stays around 130 MB), but it does look alarming in Activity Monitor.

I am the author. This supersedes issue #2292, which I opened before realising additions land through pull requests.

- [x] I have checked for other similar entries
- [x] The entry is in alphabetical order
- [x] All four language files are updated
