### PR TITLE
Add Cyanote to Note-taking

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Bear Writer](https://www.bear-writer.com/) - Beautiful, flexible writing app for crafting notes and prose. [![App Store][app-store Icon]](https://apps.apple.com/us/app/bear-beautiful-writing-app/id1091189122?ls=1&platform=mac)
 * [Boostnote](https://boostnote.io/) - Note-taking app made for programmers. [![Open-Source Software][OSS Icon]](https://github.com/BoostIO/Boostnote)
 * [Craft](https://www.craft.do/) - Notetaking and writing made beautiful. [![App Store][app-store Icon]](https://apps.apple.com/se/app/craft-docs-and-notes-editor/id1487937127?platform=mac)
+* [Cyanote](https://cyanote.app) - All-in-one local-first app for notes, to-dos, calendar, habits and clipboard history. ![Native App][Native Icon]
 * [Dnote](https://www.getdnote.com/) - A simple command line notebook with multi-device sync and a web interface. [![Open-Source Software][OSS Icon]](https://github.com/dnote/dnote) ![Freeware][Freeware Icon]
 * [Email Me](https://emailmeapp.net/) - Email yourself and much more with just one tap, native on macOS, iOS and WatchOS. [![App Store][app-store Icon]](https://apps.apple.com/us/app/email-me-notes-in-one-tap/id1090744587?platform=mac)
 * [Evernote](https://evernote.com/) - Infamous note-taking app, available on many platforms. ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds Cyanote to the Note-taking section, alphabetically between Craft and Dnote.

Cyanote is a native (Rust/Tauri) all-in-one macOS app combining notes, to-dos, a kanban board, a calendar, habit tracking, routines, and a system-wide clipboard manager. It's a one-time $4.99 purchase (no subscription), local-first with no account and no sync — everything is stored in a single SQLite database on the user's own Mac.

- Website: https://cyanote.app
- Signed and notarized by Apple, macOS 12+ (Apple Silicon and Intel, universal)