### PR TITLE
Add DevPeek to Network Analysis

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -513,6 +513,7 @@ Awesome Mac
 ### ネットワーク分析
 
 * [Charles](https://www.charlesproxy.com/) - HTTPおよびHTTPSトラフィックを表示するHTTPプロキシ/モニター。
+* [DevPeek](https://devpeek.ypgao.com/) - モック、パラメータ自動復号、リクエスト再送に対応した HTTP(S) デバッグプロキシ。 ![Freeware][Freeware Icon]
 * [James](https://github.com/james-proxy/james) - httpおよびhttpsでリクエストの確認とマッピングを行うオープンソースのプロキシツール。 [![Open-Source Software][OSS Icon]](https://github.com/james-proxy/james) ![Freeware][Freeware Icon]
 * [Little Snitch](https://www.obdev.at/products/littlesnitch/download.html) - ネットワーク接続を世界地図で可視化するネットワークモニター。
 * [mitmproxy](https://mitmproxy.org/) - ペネトレーションテスターとソフトウェア開発者向けの対話型HTTPインターセプトプロキシ。 [![Open-Source Software][OSS Icon]](https://github.com/mitmproxy/mitmproxy) ![Freeware][Freeware Icon]

--- a/README-ko.md
+++ b/README-ko.md
@@ -463,6 +463,7 @@ Awesome Mac
 ### 네트워크 분석
 
 * [Charles](https://www.charlesproxy.com/) - HTTP 프록시/모니터.
+* [DevPeek](https://devpeek.ypgao.com/) - Mock, 파라미터 자동 복호화, 요청 재전송을 지원하는 HTTP(S) 디버깅 프록시. ![Freeware][Freeware Icon]
 * [Little Snitch](https://www.obdev.at/products/littlesnitch/download.html) - 네트워크 연결 시각화 도구.
 * [mitmproxy](https://mitmproxy.org/) - 인터랙티브 가로채기 HTTP 프록시. [![Open-Source Software][OSS Icon]](https://github.com/mitmproxy/mitmproxy) ![Freeware][Freeware Icon]
 * [Proxyman](https://proxyman.app) - 현대적이고 직관적인 HTTP 디버깅 프록시. ![Freeware][Freeware Icon]

--- a/README-zh.md
+++ b/README-zh.md
@@ -334,6 +334,7 @@ Awesome Mac
 
 * [bruno](https://www.usebruno.com/) - 一款离线优先、快速且兼容 Git 的开源 API 客户端。 ![Freeware][Freeware Icon]
 * [Charles](https://www.charlesproxy.com/) - 一个代理工具，允许你查看所有的 HTTP 和 HTTPS 流量。
+* [DevPeek](https://devpeek.ypgao.com/) - HTTP(S) 抓包调试工具，支持精确 Mock、参数自动加解密与请求重发。 ![Freeware][Freeware Icon]
 * [James](https://github.com/james-proxy/james) - 用于 https 和 http 进行查询映射请求。 [![Open-Source Software][OSS Icon]](https://github.com/james-proxy/james) ![Freeware][Freeware Icon]
 * [mitmproxy](https://mitmproxy.org/) - 一款支持 HTTP(S) 的中间人代理工具，可在终端下运行，可用于抓包 [![Open-Source Software][OSS Icon]](https://github.com/mitmproxy/mitmproxy) ![Freeware][Freeware Icon]
 * [Paw](https://luckymarmot.com/paw) - 先进的 HTTP 客户端。

--- a/README.md
+++ b/README.md
@@ -511,6 +511,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 ### Network Analysis
 
 * [Charles](https://www.charlesproxy.com/) - HTTP proxy/monitor to view HTTP and HTTPS traffic.
+* [DevPeek](https://devpeek.ypgao.com/) - HTTP(S) debugging proxy with mock, automatic parameter decryption, and request replay. ![Freeware][Freeware Icon]
 * [James](https://github.com/james-proxy/james) - Open-source proxy tool for checking and mapping requests with http as well as https. [![Open-Source Software][OSS Icon]](https://github.com/james-proxy/james) ![Freeware][Freeware Icon]
 * [Little Snitch](https://www.obdev.at/products/littlesnitch/download.html) - Network monitor with a world map for visualizing network connections.
 * [mitmproxy](https://mitmproxy.org/) - Interactive intercepting HTTP proxy for penetration testers and software developers. [![Open-Source Software][OSS Icon]](https://github.com/mitmproxy/mitmproxy) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Add [DevPeek](https://devpeek.ypgao.com/) to **Network Analysis** in EN / ZH / JA / KO.

Related issue: https://github.com/jaywcjlove/awesome-mac/issues/2744

DevPeek is a free HTTP(S) debugging proxy (closed-source, official site). It supports traffic capture, precise mock, automatic parameter encrypt/decrypt, WebSocket inspection, and request replay. Fits next to Charles / Proxyman / mitmproxy.

- Link: official website (not a git repo)
- Freeware icon only (not open source)
- Placed alphabetically


Made with [Cursor](https://cursor.com)