### PR TITLE
Add 1bench (Databases)

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -590,6 +590,7 @@ Awesome Mac
 
 ### データベース
 
+* [1bench](https://1bench.dev) - Postgres、Redis、ClickHouse、MongoDB など20種類以上のデータベースに対応したデスクトップクライアント。
 * [Apache Directory Studio](https://directory.apache.org/studio/) - LDAPブラウザおよびActive Directoryクライアント。 [![Open-Source Software][OSS Icon]](https://directory.apache.org/sources.html) ![Freeware][Freeware Icon]
 * [Another Redis Desktop Manager](https://github.com/qishibo/AnotherRedisDesktopManager) - より高速で安定したRedisデスクトップマネージャー。[![Open-Source Software][OSS Icon]](https://directory.apache.org/sources.html)![Freeware][Freeware Icon]
 * [Base 2](http://menial.co.uk/base/) - SQLite 3データベースファイルの作成、設計、編集、ブラウジング用アプリケーション。

--- a/README-ko.md
+++ b/README-ko.md
@@ -515,6 +515,7 @@ Awesome Mac
 
 ### 데이터베이스
 
+* [1bench](https://1bench.dev) - Postgres, Redis, ClickHouse, MongoDB 등 20여 종의 데이터베이스를 지원하는 데스크톱 클라이언트.
 * [Another Redis Desktop Manager](https://github.com/qishibo/AnotherRedisDesktopManager) - 빠르고 안정적인 Redis 데스크톱 관리자. [![Open-Source Software][OSS Icon]](https://github.com/qishibo/AnotherRedisDesktopManager) ![Freeware][Freeware Icon]
 * [Beekeeper Studio](https://www.beekeeperstudio.io) - 매끄러운 SQL 편집기 및 데이터베이스 관리자. [![Open-Source Software][OSS Icon]](https://github.com/beekeeper-studio/beekeeper-studio) ![Freeware][Freeware Icon]
 * [DataGrip](https://www.jetbrains.com/datagrip/) - 많은 데이터베이스를 지원하는 지능형 도구.

--- a/README-zh.md
+++ b/README-zh.md
@@ -381,6 +381,7 @@ Awesome Mac
 
 ### 数据库
 
+* [1bench](https://1bench.dev) - 桌面数据库客户端，支持 Postgres、Redis、ClickHouse、MongoDB 等二十多种数据库。
 * [Another Redis Desktop Manager](https://github.com/qishibo/AnotherRedisDesktopManager) - 一款稳定全新的Redis管理工具。![Open-Source Software][OSS Icon]![Freeware][Freeware Icon]
 * [Bdash](https://github.com/bdash-app/bdash) - SQL 客户端应用程序，支持 MySQL、 PostgreSQL (Redshift)、 BigQuery。[![Open-Source Software][OSS Icon] ](https://github.com/bdash-app/bdash) ![Freeware][Freeware Icon]
 * [Base 2](http://menial.co.uk/base/) - 一个用于管理 SQLite 数据库的软件。

--- a/README.md
+++ b/README.md
@@ -588,6 +588,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 
 ### Databases
 
+* [1bench](https://1bench.dev) - Desktop client for Postgres, Redis, ClickHouse, MongoDB and about two dozen other databases.
 * [Apache Directory Studio](https://directory.apache.org/studio/) - LDAP browser and Active Directory client. [![Open-Source Software][OSS Icon]](https://directory.apache.org/sources.html) ![Freeware][Freeware Icon]
 * [Another Redis Desktop Manager](https://github.com/qishibo/AnotherRedisDesktopManager) - A faster, better and more stable redis desktop manager.[![Open-Source Software][OSS Icon]](https://directory.apache.org/sources.html)![Freeware][Freeware Icon]
 * [Base 2](https://menial.co.uk/base/) - Application for creating, designing, editing and browsing SQLite 3 database files.


### PR DESCRIPTION
Adds 1bench to the Databases section in the four maintained languages.

1bench is a macOS desktop client for Postgres, Redis, ClickHouse, MongoDB and about two dozen other databases. Commercial, with a 7-day trial.