### PR TITLE
Add SubnetDesk to Remote Login Software

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1641,6 +1641,7 @@ Awesome Mac
 * [RealVNC](https://www.realvnc.com) - デスクトップとモバイルのリモートアクセスのためのオリジナルかつ最高のソフトウェア。
 * [RoyalTSX](https://www.royalapps.com/ts/mac/features) - 複数プロトコルの接続をまとめて管理できるリモート接続クライアント。 ![Freeware][Freeware Icon]
 * [RustDesk](https://rustdesk.com/) - もう一つのリモートデスクトップソフトウェア。 [![Open-Source Software][OSS Icon]](https://github.com/rustdesk/rustdesk) ![Freeware][Freeware Icon]
+* [SubnetDesk](https://github.com/zibo-chen/SubnetDesk) - LAN/VPN専用のリモートデスクトップ。公開ランデブーやリレーサービスを使わず、IPアドレスまたはホスト名で直接接続。 [![Open-Source Software][OSS Icon]](https://github.com/zibo-chen/SubnetDesk) ![Freeware][Freeware Icon]
 * [Steam Link](https://apps.apple.com/us/app/steam-link/id1246969117?platform=mac) - Steam Linkアプリを使えば、すべてのコンピューターでSteamゲームをプレイ可能。 ![Freeware][Freeware Icon]
 * [Sunshine](https://github.com/LizardByte/Sunshine) - Moonlight用のセルフホスト型ゲームストリームホスト。 [![Open-Source Software][OSS Icon]](https://github.com/LizardByte/Sunshine) ![Freeware][Freeware Icon]
 * [TeamViewer](https://www.teamviewer.com/en) - リモートサポートと画面共有のためのツール。 ![Freeware][Freeware Icon]

--- a/README-ko.md
+++ b/README-ko.md
@@ -1106,6 +1106,7 @@ Awesome Mac
 * [Parsec](https://parsec.app/) - 저지연 원격 데스크톱 및 게임 스트리밍 도구.
 * [RoyalTSX](https://www.royalapps.com/ts/mac/features) - 여러 프로토콜을 한곳에서 관리하는 원격 접속 클라이언트. ![Freeware][Freeware Icon]
 * [RustDesk](https://rustdesk.com/) - 오픈 소스 원격 데스크톱 솔루션. [![Open-Source Software][OSS Icon]](https://github.com/rustdesk/rustdesk) ![Freeware][Freeware Icon]
+* [SubnetDesk](https://github.com/zibo-chen/SubnetDesk) - 공용 랑데부나 릴레이 서비스 없이 IP 주소 또는 호스트 이름으로 직접 연결하는 LAN/VPN 전용 원격 데스크톱. [![Open-Source Software][OSS Icon]](https://github.com/zibo-chen/SubnetDesk) ![Freeware][Freeware Icon]
 * [TeamViewer](https://www.teamviewer.com/) - 원격 지원과 화면 공유를 위한 도구. ![Freeware][Freeware Icon]
 
 ## QuickLook 플러그인

--- a/README-zh.md
+++ b/README-zh.md
@@ -1511,6 +1511,7 @@ Awesome Mac
 * [RealVNC](https://www.realvnc.com) 是一款免费的远程控制跨多平台的程序。 ![Freeware][Freeware Icon]
 * [RoyalTSX](https://www.royalapps.com/ts/mac/features) - 管理多种协议远程连接的客户端。 ![Freeware][Freeware Icon]
 * [RustDesk](https://rustdesk.com/) - 一个开源的远程桌面应用程序，为自托管而设计。[![Open-Source Software][OSS Icon]](https://github.com/rustdesk/rustdesk) ![Freeware][Freeware Icon]
+* [SubnetDesk](https://github.com/zibo-chen/SubnetDesk) - 局域网与 VPN 专用的远程桌面，通过 IP 或主机名直连，无需公网信令或中继服务。[![Open-Source Software][OSS Icon]](https://github.com/zibo-chen/SubnetDesk) ![Freeware][Freeware Icon]
 * [Steam Link](https://apps.apple.com/cn/app/steam-link/id1246969117?platform=mac) - 通过局域网或互联网将您的 Steam 游戏串流到 Mac 上。[![App Store][app-store Icon]](https://apps.apple.com/cn/app/steam-link/id1246969117?platform=mac) ![Freeware][Freeware Icon]
 * [Sunshine](https://github.com/LizardByte/Sunshine) - 自托管的游戏串流，用于 Moonlight。[![Open-Source Software][OSS Icon]](https://github.com/LizardByte/Sunshine) ![Freeware][Freeware Icon]
 * [TeamViewer](https://www.teamviewer.com) - 用于远程协助和屏幕共享的工具。![Freeware][Freeware Icon]

--- a/README.md
+++ b/README.md
@@ -1642,6 +1642,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [RealVNC](https://www.realvnc.com) - The original and best software for remote access across desktop and mobile.
 * [RoyalTSX](https://www.royalapps.com/ts/mac/features) - Remote connection manager for multiple protocols. ![Freeware][Freeware Icon]
 * [RustDesk](https://rustdesk.com/) - Yet another remote desktop software. [![Open-Source Software][OSS Icon]](https://github.com/rustdesk/rustdesk) ![Freeware][Freeware Icon]
+* [SubnetDesk](https://github.com/zibo-chen/SubnetDesk) - LAN/VPN-only remote desktop that connects directly by IP or hostname without public rendezvous or relay services. [![Open-Source Software][OSS Icon]](https://github.com/zibo-chen/SubnetDesk) ![Freeware][Freeware Icon]
 * [Steam Link](https://apps.apple.com/us/app/steam-link/id1246969117?platform=mac) - The Steam Link app allows you to play your Steam games across all your computers. ![Freeware][Freeware Icon]
 * [Sunshine](https://github.com/LizardByte/Sunshine) - Self-hosted game stream host for Moonlight. [![Open-Source Software][OSS Icon]](https://github.com/LizardByte/Sunshine) ![Freeware][Freeware Icon]
 * [TeamViewer](https://www.teamviewer.com/en) - Remote support and screen sharing tool. ![Freeware][Freeware Icon]


### PR DESCRIPTION
### Types of Changes

- [x] New addition to list
- [ ] Fixing bug in existing item in list
- [ ] Removing item from list
- [ ] Changing structure (organization) of list

### Proposed Changes

Adds SubnetDesk to Remote Login Software in the English, Chinese, Japanese, and Korean lists. It is an AGPL-3.0 remote desktop app for devices already reachable over a LAN or VPN, with direct IP/hostname connections and no public rendezvous or relay service.

### PR Checklist

- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important
- [x] I have added necessary documentation (if appropriate)

### Further Comments

The entry is placed alphabetically after RustDesk and uses the existing OSS and Freeware icon style.