### PR TITLE
Sync Education section to zh/ja/ko READMEs

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1126,6 +1126,7 @@ Awesome Mac
 
 ## 教育
 
+* [Leafy](https://leafyapp.uk/) - ⌥A で PDF や画像を含む画面上の任意の単語を調べ、検索可能なローカル単語帳に保存。 ![Freeware][Freeware Icon]
 * [Wokabulary](https://wokabulary.com/) - 個人の外国語語彙を収集、練習、整理。 [![App Store][app-store Icon]](https://apps.apple.com/app/apple-store/id1667619825?platform=mac)
 
 ## ファイナンス

--- a/README-ko.md
+++ b/README-ko.md
@@ -857,6 +857,7 @@ Awesome Mac
 
 ## 교육
 
+* [Leafy](https://leafyapp.uk/) - ⌥A로 PDF와 이미지를 포함한 화면의 모든 단어를 찾아보고 검색 가능한 로컬 단어장에 저장. ![Freeware][Freeware Icon]
 * [Wokabulary](https://wokabulary.com/) - 개별 외국어 어휘를 수집, 연습 및 정리. [![App Store][app-store Icon]](https://apps.apple.com/app/apple-store/id1667619825?platform=mac)
 
 ## 금융

--- a/README-zh.md
+++ b/README-zh.md
@@ -156,6 +156,7 @@ Awesome Mac
 - [输入法](#输入法)
 - [浏览器](#浏览器)
 - [翻译工具](#翻译工具)
+- [教育](#教育)
 - [安全工具](#安全工具)
 - [科学上网](#科学上网)
 - [其它实用工具](#其它实用工具)
@@ -1071,6 +1072,11 @@ Awesome Mac
 * [Translatium](https://translatium.app) - 支持 100 多种语言文字与图片翻译的应用。 [![Open-Source Software][OSS Icon]](https://github.com/webcatalog/translatium-desktop) [![App Store][app-store Icon]](https://apps.apple.com/us/app/translatium/id1547052291?platform=mac)
 * [辞海词典](http://cidian.dict.cn/mac.html) - 学单词、背单词、辞海词典。![Freeware][Freeware Icon]
 * [有道翻译](http://cidian.youdao.com/multi.html) - 有道词典桌面版。![Freeware][Freeware Icon]
+
+## 教育
+
+* [Leafy](https://leafyapp.uk/) - 用 ⌥A 查询屏幕上的任意单词，支持 PDF 和图片，并保存到可搜索的本地词库。 ![Freeware][Freeware Icon]
+* [Wokabulary](https://wokabulary.com/) - 收集、练习和整理个人外语词汇。 [![App Store][app-store Icon]](https://apps.apple.com/app/apple-store/id1667619825?platform=mac)
 
 ## 金融
 


### PR DESCRIPTION
The English README has an `Education` section with Leafy and Wokabulary, but the translations are out of sync:

- `README-ja.md` / `README-ko.md` have the section, but Leafy is missing.
- `README-zh.md` has no Education section at all (it jumps from 翻译工具 to 金融), so both entries are missing.

This PR adds Leafy to the Japanese and Korean sections, and adds the Education section plus its TOC entry to the Chinese README, keeping alphabetical order and the same one-sentence style as the English entries.

Disclosure: I'm the author of Leafy. It was already accepted into `README.md`; this only mirrors the existing entry into the other languages.