### PR TITLE
Add Planim Time to Productivity

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1454,6 +1454,7 @@ Awesome Mac
 * [PaletteBrain](https://palettebrain.com) - ショートカットキーひとつですべてのMacアプリケーションからChatGPTのパワーにアクセス。
 * [Pie Menu](https://www.pie-menu.com) – アクティブなアプリに合わせてカスタマイズされたラジアルメニューでツールを操作。
 * [Perplexity](https://apps.apple.com/us/app/perplexity-ask-anything/id6714467650?platform=mac) - AIによる検索と発見。
+* [Planim Time](https://time.planim.app/jira) - ワンクリック計測、作業ログの双方向同期、オフラインでも使えるローカル保存に対応した Jira 向けメニューバー時間追跡ツール。 ![Freeware][Freeware Icon]
 * [Pomodoro Cycle](https://github.com/jet8a/pomodoro-cycle-app) - ポモドーロトラッカー。
 * [Qbserve](https://qotoqot.com/qbserve/) - プロジェクト管理や工数集計に対応した自動時間追跡ツール。
 * [Raycast](https://raycast.com?via=ae02) - 拡張機能、スニペット、ノート、AIを備えたランチャー。

--- a/README-ko.md
+++ b/README-ko.md
@@ -1042,6 +1042,7 @@ Awesome Mac
 * [MindMac](https://mindmac.app/) - 여러 AI 서비스를 한곳에서 쓰는 채팅 클라이언트.
 * [nnScreenshots](https://www.nearnorthsoftware.com/software/screenshots.php) - 주기적 스크린샷으로 하루 작업을 돌아볼 수 있는 도구.
 * [OpenClip](https://getopenclip.app) - 선택한 텍스트로 즉각적인 작업을 실행할 수 있는 macOS용 경량 플로팅 액션 바. [![Open-Source Software][OSS Icon]](https://github.com/ganeshmshetty/openclip) ![Freeware][Freeware Icon]
+* [Planim Time](https://time.planim.app/jira) - 원클릭 타이머, 작업 로그 양방향 동기화, 오프라인 로컬 저장을 지원하는 Jira용 메뉴 바 시간 추적 도구. ![Freeware][Freeware Icon]
 * [Qbserve](https://qotoqot.com/qbserve/) - 프로젝트와 생산성 분석을 지원하는 자동 시간 추적 도구.
 * [Raycast](https://www.raycast.com/) - 확장 기능, 스니펫, 노트, AI를 갖춘 런처. ![Freeware][Freeware Icon]
 * [SuperCmd](https://github.com/SuperCmdLabs/SuperCmd) - Raycast 호환 확장, 음성 워크플로, TTS, 메모리, AI 액션을 제공하는 오픈소스 런처. [![Open-Source Software][OSS Icon]](https://github.com/SuperCmdLabs/SuperCmd)

--- a/README-zh.md
+++ b/README-zh.md
@@ -1204,6 +1204,7 @@ Awesome Mac
 * [OmniPlan](https://www.omnigroup.com/omniplan/) - 项目管理软件。
 * [OpenClip](https://getopenclip.app) - 适用于 macOS 的轻量级浮动操作栏，选中文字即可即时执行操作。 [![Open-Source Software][OSS Icon]](https://github.com/ganeshmshetty/openclip) ![Freeware][Freeware Icon]
 * [OpenDisplay](https://opendisplay.app) - 把闲置的 iPhone 或 iPad 变成 Mac 的第二块屏幕，支持 USB 有线与 WiFi 无线连接，以及触控输入。 [![Open-Source Software][OSS Icon]](https://github.com/peetzweg/opendisplay) ![Freeware][Freeware Icon]
+* [Planim Time](https://time.planim.app/jira) - 面向 Jira 的菜单栏时间追踪工具，支持一键计时、工时双向同步和离线本地存储。 ![Freeware][Freeware Icon]
 * [Qbserve](https://qotoqot.com/qbserve/) - 自动追踪时间，并提供项目、工时和效率统计。
 * [Rapidmg](https://rapidmg.branchseer.com/) - 一键解压 DMG 镜像里的 app 至 “应用程序” 目录。[![App Store][app-store Icon]](https://apps.apple.com/app/rapidmg/id6451349778?platform=mac)
 * [rem](https://github.com/jasonjmcghee/rem) - 一款开源软件，可以本地记录并搜索你在 Mac 上查看的所有内容。 [![Open-Source Software][OSS Icon]](https://github.com/jasonjmcghee/rem) ![Freeware][Freeware Icon]

--- a/README.md
+++ b/README.md
@@ -1453,6 +1453,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [PaletteBrain](https://palettebrain.com) - Access the power of ChatGPT across all your Mac applications with the press of a shortcut.
 * [Pie Menu](https://www.pie-menu.com) – Control your tools with a radial menu customized for your active app.
 * [Perplexity](https://apps.apple.com/us/app/perplexity-ask-anything/id6714467650?platform=mac) - Search and discovery with AI.
+* [Planim Time](https://time.planim.app/jira) - Menu bar time tracker for Jira with a one-click timer, two-way worklog sync, and offline-first local storage. ![Freeware][Freeware Icon]
 * [Pomodoro Cycle](https://github.com/jet8a/pomodoro-cycle-app) - Pomodoro tracker
 * [ProBoard](https://apps.apple.com/app/id6748314346?platform=mac) - Use one board to manage all your project information efficiently.[![App Store][app-store Icon]](https://apps.apple.com/app/id6748314346?platform=mac)
 * [Qbserve](https://qotoqot.com/qbserve/) - Automatic time tracking with projects, timesheets, and productivity insights.


### PR DESCRIPTION
### Types of Changes

- [x] New addition to list
- [ ] Fixing bug in existing item in list
- [ ] Removing item from list
- [ ] Changing structure (organization) of list

### Proposed Changes

Adds Planim Time to Productivity, next to Qbserve, RescueTime, Rize and Timing. Those track time automatically; Planim Time is the opposite kind of tracker: you start a timer on a Jira issue from the menu bar, and the entry is pushed to Jira as a regular worklog under your own account. Two-way sync pulls existing worklogs back, and everything is stored locally so it works offline. Tauri 2 with a Rust core, about 9 MB.

The free tier is the whole tracker, with no limits: unlimited timer and worklogs, two-way Jira sync, one-click push, no account or card. Pro adds automation on top (auto-push on stop, calendar view, idle detection, reports). I marked it Freeware in the sense the legend uses ("free to use, or free personal license"), the same way Proxyman, Figma, Trello and Metrune are marked; happy to drop the icon if you'd rather keep it for fully free apps.

The same one-line entry is added to README-zh, README-ja and README-ko, in the section where those files keep Qbserve and Rize.

Closed source, so no OSS icon. I'm the developer.

### PR Checklist

- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important
- [x] I have added necessary documentation (if appropriate)
