### PR TITLE
Add JumpKit to Productivity section

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1432,6 +1432,7 @@ Awesome Mac
 * [Hyperkey](https://hyperkey.app/) - Caps LockなどをHyperキーに変換するツール。 ![Freeware][Freeware Icon]
 * [iCMD](https://icmd.app) - グローバルなあいまいメニュー検索とVim風ナビゲーションを提供するツール。
 * [Journey Navigation](https://gowithjourney.com) - 天気や交通情報付きでルートを計画できるナビゲーションツール。 [![App Store][app-store Icon]](https://apps.apple.com/us/app/journey-navigation/id1662059644?platform=mac)
+* [JumpKit](https://jumpkit.app) - Webリンク、ローカルフォルダ、共有チームリソースをワンクリックで起動できるランチャー。ローカルAIアシスタントでMicrosoft Office作業を自動化可能。
 * [Karabiner](https://pqrs.org/osx/karabiner/) - OS X用の強力で安定したキーボードカスタマイザー。 [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/tekezo/Karabiner)
 * [Keyboard Cowboy](https://github.com/zenangst/KeyboardCowboy) - macOSに欠けていたキーボードショートカットユーティリティ。 [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/zenangst/KeyboardCowboy)
 * [Keyboard Maestro](http://www.keyboardmaestro.com) - トリガーとマクロで繰り返し作業を自動化するツール。

--- a/README-ko.md
+++ b/README-ko.md
@@ -1036,6 +1036,7 @@ Awesome Mac
 * [Hyperkey](https://hyperkey.app/) - Caps Lock이나 다른 보조 키를 Hyper 키로 바꾸는 도구. ![Freeware][Freeware Icon]
 * [iCMD](https://icmd.app) - 전역 퍼지 메뉴 검색과 Vim 스타일 탐색을 제공하는 도구.
 * [Journey Navigation](https://gowithjourney.com) - 날씨와 교통 정보를 함께 보여주는 경로 계획 도구. [![App Store][app-store Icon]](https://apps.apple.com/us/app/journey-navigation/id1662059644?platform=mac)
+* [JumpKit](https://jumpkit.app) - 웹 링크, 로컬 폴더, 팀 공유 리소스를 원클릭으로 실행하는 런처. 로컬 AI 어시스턴트가 Microsoft Office 작업을 자동화할 수 있습니다.
 * [Keyboard Maestro](http://www.keyboardmaestro.com) - 트리거와 매크로로 반복 작업을 자동화하는 도구.
 * [Magic Switch](https://magic-switch.com/) - 여러 Mac 사이에서 Magic Keyboard, Mouse, Trackpad를 전환하는 도구.
 * [Metrune](https://treafree.github.io/Metrune/ko/) - 작업, AI 코딩, GitHub 활동, 기기 이벤트, 배지, 리포트를 MacBook 노치에 모으는 로컬 우선 집중 작업 공간. ![Freeware][Freeware Icon]

--- a/README-zh.md
+++ b/README-zh.md
@@ -1181,6 +1181,7 @@ Awesome Mac
 * [iCMD](https://icmd.app) - 提供全局模糊菜单搜索和 Vim 风格导航。
 * [iStat pro](https://bjango.com/mac/istatmenus/) - Mac OS 电脑硬件信息检测软件。
 * [Itsycal](https://www.mowglii.com/itsycal/) - 一款简洁实用的开源日历工具。[![Open-Source Software][OSS Icon]](https://github.com/sfsam/itsycal) ![Freeware][Freeware Icon]
+* [JumpKit](https://jumpkit.app) - 一键启动网页链接、本地文件夹和团队共享资源的启动器，可选本地 AI 助手自动完成 Microsoft Office 办公任务。
 * [Karabiner](https://pqrs.org/osx/karabiner/) - 一个强大的和稳定的 OS X 的键盘定制。[![Open-Source Software][OSS Icon]](https://github.com/tekezo/Karabiner) ![Freeware][Freeware Icon]
 * [Keyboard Maestro](http://www.keyboardmaestro.com) - 用触发器和宏自动执行重复操作。
 * [Keytty](http://keytty.com) - 让你通过键盘使用鼠标。

--- a/README.md
+++ b/README.md
@@ -1431,6 +1431,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Hungrymark](https://zhengying.github.io/hungrymark) - Bookmark files, folders, and links for quick menu bar access. [![App Store][app-store Icon]](https://apps.apple.com/us/app/hungrymark/id1482778901?platform=mac)
 * [Hyperkey](https://hyperkey.app/) - Turn Caps Lock or another modifier into a Hyper key. ![Freeware][Freeware Icon]
 * [iCMD](https://icmd.app) - Global fuzzy menu search with Vim-style navigation.
+* [JumpKit](https://jumpkit.app) - One-click launcher for web links, local folders, and shared team resources, with an optional local AI assistant that automates Microsoft Office tasks.
 * [Karabiner](https://pqrs.org/osx/karabiner/) - Powerful and stable keyboard customizer for OS X. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/tekezo/Karabiner)
 * [Keyboard Cowboy](https://github.com/zenangst/KeyboardCowboy) - The missing keyboard shortcut utility for macOS. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/zenangst/KeyboardCowboy)
 * [Keyboard Maestro](https://www.keyboardmaestro.com) - Automate repetitive tasks with triggers and macros.


### PR DESCRIPTION
## What
Add [JumpKit](https://jumpkit.app) to the **Productivity** section (alphabetical: between iCMD/Journey Navigation and Karabiner/Keyboard Maestro) across README.md, README-zh.md, README-ja.md, README-ko.md.

## Why
JumpKit is a native macOS launcher (Apple Silicon, free download) for organizing and launching web links, local folders, and shared team resources with one click — plus an optional fully-local AI assistant that automates Microsoft Office tasks. No cloud lock-in; data stays on the machine. Fits alongside existing launchers/productivity tools like Raycast, Alfred, and Freeter.

## Checklist
- [x] Not a duplicate
- [x] Alphabetical placement in relevant category
- [x] One-sentence description per entry
- [x] Synced across all 4 language READMEs (en/zh/ja/ko)
- [x] No trailing whitespace