### PR TITLE
Add PR Cockpit

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,6 +555,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [GitUp](https://gitup.co/) - A simple & powerful Git client。[![Open-Source Software][OSS Icon]](https://github.com/git-up/GitUp) ![Freeware][Freeware Icon]
 * [GitX-dev](https://rowanj.github.io/gitx/) -  Fork of [Pieter's](https://github.com/pieter/gitx) nice git GUI for OS X. Includes branch/tag sidebar and various fixes. [![Open-Source Software][OSS Icon]](https://github.com/rowanj/gitx) ![Freeware][Freeware Icon]
 * [Hub](https://hub.github.com/) - Command-line wrapper for Git that makes you better at GitHub. [![Open-Source Software][OSS Icon]](https://github.com/github/hub) ![Freeware][Freeware Icon]
+* [PR Cockpit](https://prcockpit.com/) - An extremely fast GitHub for reviewing pull requests: PRs open in about 20 ms, keyboard-first, with a CLI for coding agents. [![Open-Source Software][OSS Icon]](https://github.com/theolundqvist/pr-cockpit) ![Freeware][Freeware Icon]
 * [RelaGit](https://rela.dev/) - The elegant solution to graphical version control. Built by developers, for developers. [![Open-Source Software][OSS Icon]](https://github.com/relagit/relagit) ![Freeware][Freeware Icon]
 * [SmartGit](https://www.syntevo.com/smartgit/) - Git client with support.
 * [SourceTree](https://www.sourcetreeapp.com/) - Free Git & Mercurial client for Windows or Mac. ![Freeware][Freeware Icon]


### PR DESCRIPTION
PR Cockpit is an extremely fast GitHub for reviewing pull requests on macOS and Linux: a PR opens in about 20 ms, against 1.4 s for github.com on the same repository (p50, [docs/BENCHMARKS.md](https://github.com/theolundqvist/pr-cockpit/blob/main/docs/BENCHMARKS.md)).

It belongs in Developer Tools > Version Control next to the other Git and GitHub GUIs such as GitHub Desktop, Fork and RelaGit, and it is open source and free, so I attached the OSS and Freeware icons in the existing style.

Repo: https://github.com/theolundqvist/pr-cockpit (MIT) — Site: https://prcockpit.com
