### PR TITLE
Add SnipperApp 3 to Developer Utilities

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -461,6 +461,7 @@ Awesome Mac
 * [SCM Breeze](https://github.com/scmbreeze/scm_breeze) - gitとの対話を強化するシェルスクリプトセット（bashおよびzsh用）。 ![Freeware][Freeware Icon] [![Open-Source Software][OSS Icon]](https://github.com/scmbreeze/scm_breeze)
 * [SecureCRT](https://www.vandyke.com/products/securecrt/) - SSH、Telnet、その他のプロトコルをサポートするターミナルエミュレーション。
 * [Site Sucker](https://ricks-apps.com/osx/sitesucker/) - ウェブサイトを自動的にダウンロードするツール。 [![App Store][app-store Icon]](https://apps.apple.com/in/app/sitesucker/id442168834?platform=mac)
+* [SnipperApp 3](https://snipperapp.com) - iCloud/Gist 同期と AI アシスタント向け MCP サーバーを内蔵したネイティブのコードスニペット管理ツール。 [![App Store][app-store Icon]](https://apps.apple.com/us/app/snipperapp-3-code-snippets/id6757330954?mt=12)
 * [SnippetsLab](https://www.renfei.org/snippets-lab/) - 使いやすいコードスニペット管理ツール。
 * [Solarized](http://ethanschoonover.com/solarized) - クリーンで美しいカラーテーマ。iTerm、JetBrains製品、Vimなどとの相性が良い。
 * [SSH Keys Manager](https://github.com/Stmol/ssh-keys-manager-macos-app) - ローカルSSHキーとGitアイデンティティを管理するためのネイティブmacOSアプリ。 [![Open-Source Software][OSS Icon]](https://github.com/Stmol/ssh-keys-manager-macos-app) ![Freeware][Freeware Icon] ![Native App][Native Icon]

--- a/README-ko.md
+++ b/README-ko.md
@@ -426,6 +426,7 @@ Awesome Mac
 * [Runjs](https://runjs.app/) - JavaScript 플레이그라운드. ![Freeware][Freeware Icon]
 * [SCM Breeze](https://github.com/scmbreeze/scm_breeze) - Git 인터랙션 강화 쉘 스크립트. ![Freeware][Freeware Icon] [![Open-Source Software][OSS Icon]](https://github.com/scmbreeze/scm_breeze)
 * [SaneHosts](https://sanehosts.com) - hosts 기반 광고 및 추적기 차단 도구. [![Open-Source Software][OSS Icon]](https://github.com/sane-apps/SaneHosts)
+* [SnipperApp 3](https://snipperapp.com) - iCloud/Gist 동기화와 AI 어시스턴트용 MCP 서버를 내장한 네이티브 코드 스니펫 관리자. [![App Store][app-store Icon]](https://apps.apple.com/us/app/snipperapp-3-code-snippets/id6757330954?mt=12)
 * [SnippetsLab](https://www.renfei.org/snippets-lab/) - 코드 스니펫 관리자.
 * [SSH Keys Manager](https://github.com/Stmol/ssh-keys-manager-macos-app) - 로컬 SSH 키와 Git 신원을 관리하는 네이티브 macOS 앱입니다. [![Open-Source Software][OSS Icon]](https://github.com/Stmol/ssh-keys-manager-macos-app) ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [Starcat](https://starcat.ink/) - 저장한 저장소를 검색 가능한 AI 지원 지식 베이스로 전환하는 네이티브 로컬 우선 GitHub Stars 관리 도구. [![Open-Source Software][OSS Icon]](https://github.com/starcat-app/Starcat) ![Freeware][Freeware Icon] ![Native App][Native Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/starcat-for-github/id6788809803?mt=12)

--- a/README-zh.md
+++ b/README-zh.md
@@ -289,6 +289,7 @@ Awesome Mac
 * [SwitchHosts](https://oldj.github.io/SwitchHosts/) - 一个管理、切换多个 hosts 方案的工具。[![Open-Source Software][OSS Icon]](https://github.com/oldj/SwitchHosts) ![Freeware][Freeware Icon]
 * [SCM Breeze](https://github.com/scmbreeze/scm_breeze) - 用于增强与git交互的shell脚本集(用于bash和zsh)。![Freeware][Freeware Icon] [![Open-Source Software][OSS Icon]](https://github.com/scmbreeze/scm_breeze)
 * [SecureCRT](https://www.vandyke.com/products/securecrt/) - 一款支持 SSH、Telnet 等多种协议的终端仿真程序。
+* [SnipperApp 3](https://snipperapp.com) - 原生代码片段管理器，支持 iCloud/Gist 同步，内置供 AI 助手使用的 MCP 服务器。[![App Store][app-store Icon]](https://apps.apple.com/us/app/snipperapp-3-code-snippets/id6757330954?mt=12)
 * [SnippetsLab](https://www.renfei.org/snippets-lab/) - 管理和组织你的代码片段。
 * [SSH Keys Manager](https://github.com/Stmol/ssh-keys-manager-macos-app) - 用于管理本地 SSH 密钥和 Git 身份的原生 macOS 应用。 [![Open-Source Software][OSS Icon]](https://github.com/Stmol/ssh-keys-manager-macos-app) ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [Starcat](https://starcat.ink/) - 原生、本地优先的 GitHub Stars 管理器，将收藏的仓库转化为可搜索、AI 辅助的知识库。 [![Open-Source Software][OSS Icon]](https://github.com/starcat-app/Starcat) ![Freeware][Freeware Icon] ![Native App][Native Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/starcat-for-github/id6788809803?mt=12)

--- a/README.md
+++ b/README.md
@@ -460,6 +460,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [SCM Breeze](https://github.com/scmbreeze/scm_breeze) - Set of shell scripts (for bash and zsh) that enhance your interaction with git. ![Freeware][Freeware Icon] [![Open-Source Software][OSS Icon]](https://github.com/scmbreeze/scm_breeze)
 * [SecureCRT](https://www.vandyke.com/products/securecrt/) - Terminal emulation which supports SSH, Telnet or other protocols.
 * [Site Sucker](https://ricks-apps.com/osx/sitesucker/) - Automatically downloads websites. [![App Store][app-store Icon]](https://apps.apple.com/in/app/sitesucker/id442168834?platform=mac)
+* [SnipperApp 3](https://snipperapp.com) - Native code snippet manager with iCloud/Gist sync and a built-in MCP server for AI assistants. [![App Store][app-store Icon]](https://apps.apple.com/us/app/snipperapp-3-code-snippets/id6757330954?mt=12)
 * [SnippetsLab](https://www.renfei.org/snippets-lab/) - Easy-to-use code snippets manager.
 * [Solarized](https://ethanschoonover.com/solarized) - Clean and beautiful color theme. Works well with iTerm, JetBrains products, Vim etc.
 * [SSH Keys Manager](https://github.com/Stmol/ssh-keys-manager-macos-app) - Native macOS app for managing local SSH keys and Git identities. [![Open-Source Software][OSS Icon]](https://github.com/Stmol/ssh-keys-manager-macos-app) ![Freeware][Freeware Icon] ![Native App][Native Icon]


### PR DESCRIPTION

Adds SnipperApp 3 to Developer Utilities, alphabetically before SnippetsLab, in all four READMEs (en/zh/ja/ko).

- Native macOS code snippet manager (Swift 6 / SwiftUI), macOS 15+.
- Folders, tags, workspaces; full-text search; ⌘K command palette; menubar app; iCloud and two-way GitHub Gist sync; a bundled MCP server so Claude Code, Cursor and Windsurf can search and save snippets.
- Mac App Store, free 7-day trial, then $29.99 one-time. https://snipperapp.com

I'm the developer.


Adds SnipperApp 3 under Developers, alphabetically before SnippetsLab.

Native Swift/SwiftUI app, not Electron. Its main purpose is managing code snippets (folders, tags, workspaces, search, command palette, menubar, iCloud and GitHub Gist sync); it also ships an MCP server so AI assistants can read a user's library. Commercial with a free 7-day trial on the Mac App Store (not via a bundle): https://apps.apple.com/us/app/snipperapp-3-code-snippets/id6757330954?mt=12. No referral parameters in the link. I'm the developer.