### PR TITLE
Add Coii AudioNotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1011,6 +1011,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 ### Audio Record and Process
 
 * [CapSoftware](https://github.com/CapSoftware/) - An open-source alternative to Loom. Beautiful, shareable screen recording tool. [![Open-Source Software][OSS Icon]](https://github.com/CapSoftware/) ![Freeware][Freeware Icon]
+* [Coii AudioNotes](https://audio.coii.io) - Records meetings, transcribes them, writes the summary, and answers questions about them, entirely on your Mac. No cloud, no account.
 * [GarageBand](https://www.apple.com/mac/garageband/) - Digital audio workstation for recording and music production. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/cn/app/garageband/id682658836?l=zh&ls=1&platform=mac)
 * [Logic Pro X](https://www.apple.com/logic-pro/) - Professional digital audio workstation for music and audio production. [![App Store][app-store Icon]](https://apps.apple.com/cn/app/logic-pro-x/id634148309?l=zh&platform=mac)
 * [Segue](https://segue.npearce.me/) - Broadcast audio playout with crossfade, trim, ramp timers, and pause beds for live radio and podcasts. [![Open-Source Software][OSS Icon]](https://github.com/pearcenuk/Segue) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adding [Coii AudioNotes](https://audio.coii.io) to Audio and Video Tools > Audio Record and Process, next to CapSoftware.

Coii AudioNotes is our own app: it records meetings, transcribes them, writes the summary, and answers questions about them, entirely on the user's Mac. No cloud, no account.

Disclosure: I am one of the developers.
