### PR TITLE
Add FlicKey to Input Methods list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1051,6 +1051,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 
 ## Input Methods
 
+* [FlicKey](https://flickey.site) - Keeps your keyboard layout per app, per website and per chat, and fixes wrong-layout typing. ![Native][Native Icon]
 * [Kawa](https://github.com/utatti/kawa) - Better input source switcher for OS X. [![Open-Source Software][OSS Icon]](https://github.com/utatti/kawa) ![Freeware][Freeware Icon]
 * [LangSwitcher](https://github.com/reg2005/langSwitcher) - Keyboard layout converter for mistyped text. [![Open-Source Software][OSS Icon]](https://github.com/reg2005/langSwitcher) ![Freeware][Freeware Icon]
 * [Rocket](https://matthewpalmer.net/rocket/) - Makes typing emoji faster and easier using Slack-style shortcuts. ![Freeware][Freeware Icon]


### PR DESCRIPTION
### Types of Changes

**What types of changes does your PR introduce?** Put an x in all boxes that apply

- [x] New addition to list
- [ ] Fixing bug in existing item in list
- [ ] Removing item from list
- [ ] Changing structure (organization) of list

### Proposed Changes

Adds FlicKey to the Input Methods section, placed alphabetically before Kawa.

1. FlicKey is a macOS menu bar app that keeps a keyboard layout per app, per website and per chat conversation, and arms it the moment you focus that window. It also converts text typed in the wrong layout. The section already lists LangSwitcher and InputSourcePro, which cover conversion and per-app switching separately, so this fits the existing category rather than needing a new one.

2. Tagged `![Native][Native Icon]` only. The source is public at https://github.com/alfital2/FlicKey, but the license restricts commercial redistribution, so the OSS badge would not be accurate here. It is also not freeware: 30 day trial, then a one-time unlock.

3. Native Swift, 4.8 MB, notarized by Apple, macOS Ventura and later.

I searched the open pull requests for FlicKey before opening this and found none.

### PR Checklist

- [ ] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important
- [x] I have added necessary documentation (if appropriate)

### Further Comments

Single line addition, no structural changes. Happy to adjust the wording, the badge or the placement if you would rather it sit elsewhere in the section.
