### PR TITLE
Add SUPERNOVA to Audio and Video Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -992,6 +992,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [SpotMenu](https://github.com/kmikiy/SpotMenu) - Spotify and iTunes in your menu bar. [![Open-Source Software][OSS Icon]](https://github.com/kmikiy/SpotMenu) ![Freeware][Freeware Icon]
 * [Stremio](https://www.stremio.com/) - Media center for movies, TV, live channels, and streaming sources. ![Freeware][Freeware Icon]
 * [Stringed 2](https://apps.apple.com/us/app/stringed-2/id698710517) - Music practice software designed to help users learn how to play their favorite songs.
+* [SUPERNOVA](https://ovniaudio.com/supernova) - Audio-reactive visual synth that turns an image or a video into GPU particles moving with the Mac's system audio, no audio driver needed; also a VST3/AU plugin. [![Open-Source Software][OSS Icon]](https://github.com/ovniaudio/ovni)
 * [Synfig Studio](https://synfig.org) - Synfig Studio is free, open-source 2D animation software. [![Open-Source Software][OSS Icon]](https://github.com/synfig/synfig) ![Freeware][Freeware Icon]
 * [trax](https://github.com/nbonamy/trax) - Music library manager with audio conversion and tag editing. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/nbonamy/trax)
 * [Tiny Player](https://www.catnapgames.com/tiny-player-for-mac/) - As the name suggests, a tiny player. ![Freeware][Freeware Icon]


### PR DESCRIPTION
OVNI Audio is a one-person label of free, open-source spatial audio plug-ins, plus SUPERNOVA, an audio-reactive visual synth that turns an image or a video into GPU particles driven by the sound — https://ovniaudio.com

Everything is AGPLv3 and the source is public (https://github.com/ovniaudio/ovni, https://github.com/ovniaudio/orbita). Same model as Ardour: the code is free forever, the ready-made installers are free to download until November 23, 2026 and paid after that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
