### PR TITLE
Add Anthora to photo and media tools in four languages

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -774,6 +774,7 @@ Awesome Mac
 ### その他のツール
 
 * [Amazing AI](https://sindresorhus.com/amazing-ai) - Stable Diffusionを使用してテキストから画像を生成。 ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id1660147028?platform=mac)
+* [Anthora](https://goodburrow.com/anthora/) - フォルダやマウント済みドライブ内の写真と動画を閲覧・検索し、重複を確認できるローカルライブラリ。
 * [APNGb](https://github.com/mancunianetz/APNGb) - PNG画像のアセンブラー/ディスアセンブラーアプリ。 [![Open-Source Software][OSS Icon]](https://github.com/mancunianetz/APNGb) ![Freeware][Freeware Icon]
 * [Aspect](https://aspect.bildhuus.com) - ピアツーピア同期を備えた写真整理アプリ。 ![Freeware][Freeware Icon]
 * [Assetizr](https://assetizr.com) - Webおよびモバイルアプリケーション向けの画像リサイズと最適化。 ![Freeware][Freeware Icon]

--- a/README-ko.md
+++ b/README-ko.md
@@ -623,6 +623,7 @@ Awesome Mac
 ### 기타 도구
 
 * [Amazing AI](https://sindresorhus.com/amazing-ai) - Stable Diffusion을 사용한 텍스트-이미지 생성. ![Freeware][Freeware Icon]
+* [Anthora](https://goodburrow.com/anthora/) - 폴더와 마운트된 드라이브의 사진과 동영상을 탐색하고 검색하며 중복 파일을 검토하는 로컬 라이브러리.
 * [Assetizr](https://assetizr.com) - 이미지 크기 조정 및 최적화. ![Freeware][Freeware Icon]
 * [BlurScreen App](https://www.blurscreen.app) - 녹화나 화면 공유 중 민감한 화면 내용을 즉시 흐리게 처리하는 도구.
 * [Diffusion Bee](https://diffusionbee.com/) - Stable Diffusion AI 아트 생성 도구. [![Open-Source Software][OSS Icon]](https://github.com/divamgupta/diffusionbee-stable-diffusion-ui/) ![Freeware][Freeware Icon]

--- a/README-zh.md
+++ b/README-zh.md
@@ -555,6 +555,7 @@ Awesome Mac
 
 ### 其它工具
 
+* [Anthora](https://goodburrow.com/anthora/) - 用于浏览、搜索文件夹和已挂载驱动器中的照片与视频并检查重复文件的本地媒体库。
 * [APNGb](https://github.com/mancunianetz/APNGb) - 编辑 png 图片格式的软件。 [![Open-Source Software][OSS Icon]](https://github.com/mancunianetz/APNGb) ![Freeware][Freeware Icon]
 * [Droply](https://convergencelab.gumroad.com/l/droply) - 离线批量图片去背景工具。
 * [AppIconBuilder(图标构建)](https://apps.apple.com/cn/app/shotbuilder/id1294179975?platform=mac) - App图标多平台一键导出。[![App Store][app-store Icon]](https://apps.apple.com/cn/app/shotbuilder/id1294179975?platform=mac)

--- a/README.md
+++ b/README.md
@@ -772,6 +772,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 ### Other Tools
 
 * [Amazing AI](https://sindresorhus.com/amazing-ai) - Generate images from text using Stable Diffusion. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id1660147028?platform=mac)
+* [Anthora](https://goodburrow.com/anthora/) - Local photo and video library for browsing, searching, and reviewing duplicates across folders and mounted drives.
 * [APNGb](https://github.com/mancunianetz/APNGb) - PNG image assembler/disassembler app. [![Open-Source Software][OSS Icon]](https://github.com/mancunianetz/APNGb) ![Freeware][Freeware Icon]
 * [Aspect](https://aspect.bildhuus.com) - Photo organization app with peer-to-peer sync. ![Freeware][Freeware Icon]
 * [Lap](https://github.com/julyx10/lap) - Local photo manager for browsing and organizing personal media libraries offline. [![Open-Source Software][OSS Icon]](https://github.com/julyx10/lap) ![Freeware][Freeware Icon]


### PR DESCRIPTION
### Types of Changes

- [x] New addition to list
- [ ] Fixing bug in existing item in list
- [ ] Removing item from list
- [ ] Changing structure (organization) of list

### Proposed Changes

Add Anthora to the existing Other Tools section and its Chinese, Japanese and Korean equivalents. It combines local browsing, search and duplicate review for photos and videos in ordinary folders and mounted drives. The entries use one sentence each, the same product URL, and local alphabetical placement without changing neighboring entries.

Closes #2801.

### PR Checklist

- [x] I have read the CONTRIBUTING guide.
- [x] I have explained why this PR is important.
- [x] I have added necessary documentation (if appropriate).

### Further Comments

Developer submission, prepared with AI assistance using the repository's awesome-mac-maintainer guidance. Anthora is commercial: browsing, search and duplicate analysis are free for up to 500 items; larger libraries and cleanup cost $29 once for two Macs. No freeware or open-source badges are included. The translations describe the app; its interface is currently English.

It requires Apple silicon and macOS 14 or later, works with ordinary folders rather than directly opening Apple Photos libraries, and the direct download is not Apple-notarized. The product page includes installation instructions. These limitations are also documented in #2801.

Validation: four files changed with exactly one addition each; verified one Anthora entry per file, consistent URL and category, and a clean `git diff --check`. No executable code changes.
