### PR TITLE
Add Autorec to Screen Recording

### DIFF
--- a/README.md
+++ b/README.md
@@ -746,6 +746,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 
 ### Screen Recording
 
+* [Autorec](https://autorec.app/) - Detects Zoom, Teams and Google Meet calls and records them locally, with on-device transcription. ![Native App][Native Icon]
 * [BetterCapture](https://jsattler.github.io/BetterCapture/) - Free and open source screen recorder with professional encoding support. [![Open-Source Software][OSS Icon]](https://github.com/jsattler/BetterCapture) ![Freeware][Freeware Icon]
 * [Capty](https://capty.app/) - Screen capture and recording tool with built-in editing and annotations.
 * [Capso](https://github.com/lzhgus/Capso) - Open-source screenshot and screen recording tool with annotations, OCR, and webcam overlays. [![Open-Source Software][OSS Icon]](https://github.com/lzhgus/Capso) ![Freeware][Freeware Icon]


### PR DESCRIPTION
[Autorec](https://autorec.app/) is a native macOS app (also Linux and Windows) that detects Zoom, Microsoft Teams and Google Meet calls, records the meeting window and audio to MP4 locally, and transcribes it on-device with whisper.cpp. No bot joins the call and nothing is uploaded.

Added alphabetically at the top of `### Screen Recording`.