### PR TITLE
Add Vocemo to Voice-to-Text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1075,6 +1075,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Spokenly](https://spokenly.app/) - Voice-to-text with 100+ languages, offline mode, and AI-powered formatting.
 * [Tambourine](https://tambourinevoice.com/) - Open-source, customizable AI voice dictation that works in any app. [![Open-Source Software][OSS Icon]](https://github.com/kstonekuan/tambourine-voice/) ![Freeware][Freeware Icon]
 * [TypeWhisper](https://www.typewhisper.com) - Local Whisper-based speech-to-text with a global hotkey. [![Open-Source Software][OSS Icon]](https://github.com/TypeWhisper/typewhisper-mac) ![Freeware][Freeware Icon]
+* [Vocemo](https://vocemo.com) - On-device dictation, transcription with speaker labels, read-aloud, translation and document conversion. Every model runs locally, so nothing is uploaded.
 * [VoiceInk](https://tryvoiceink.com/) - Real-time speech-to-text app. [![Open-Source Software][OSS Icon]](https://github.com/Beingpax/VoiceInk) ![Freeware][Freeware Icon]
 * [VoxFlow](https://github.com/xingbofeng/VoxFlow) - Open-source voice input workspace with local and cloud ASR, OCR, history, and coding-agent workflows. [![Open-Source Software][OSS Icon]](https://github.com/xingbofeng/VoxFlow) ![Freeware][Freeware Icon]
 * [Voxt](https://github.com/hehehai/voxt) - Hold-to-talk voice input tool with AI transcription rules per app and URL, and built-in translation. [![Open-Source Software][OSS Icon]](https://github.com/hehehai/voxt) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds Vocemo to the Voice-to-Text section.

**Disclosure:** I work on this app. Submitting it here rather than waiting to be found, and happy for it to be removed if you would rather the list stayed to things people discovered independently.

- **What it is:** dictation into any app, transcription with speaker labels and captions, read-aloud, translation and document conversion, all running on the Mac itself. No account, and nothing is uploaded.
- **Why this section:** dictation and transcription are the primary features, which puts it alongside Aiko, VoiceInk and Willow Voice rather than in Utilities.
- **Placement:** inserted alphabetically, before VoiceInk.
- **Badges:** none. It is a paid subscription and closed source, so neither the Freeware nor the Open-Source marker applies, matching entries such as Ottex, Spokenly and Willow Voice.
- **Platform:** macOS 13+, Apple silicon. The download is signed and notarised.

Only `README.md` is touched; I have left the translated READMEs alone since they look generated, but say the word and I will update them too.