### PR TITLE
Add Macxelio to Proxy and VPN Tools

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1181,6 +1181,7 @@ Awesome Mac
 * [Hiddify](https://github.com/hiddify/hiddify-app) - 複数のプロキシプロトコルとサブスクリプションを扱えるマルチプラットフォームクライアント。 [![Open-Source Software][OSS Icon]](https://github.com/hiddify/hiddify-app) ![Freeware][Freeware Icon]
 * [Jumper VPN](https://jumpervpn.com/) - Macおよびその他のプラットフォーム用のVPNクライアント。セキュアで高速なVPNプロキシ。
 * [Lantern](https://getlantern.org) - オープンなインターネットへの高速で信頼性の高いセキュアなアクセスを提供する無料アプリケーション。 [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/getlantern/lantern)
+* [Macxelio](https://github.com/dalirnet/macxelio) - Xray-core搭載のネイティブメニューバープロキシクライアント。ルールベースのルーティング、カスタムDNS、共有リンクのインポートに対応。 [![Open-Source Software][OSS Icon]](https://github.com/dalirnet/macxelio) ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [Mullvad VPN](https://mullvad.net) - 匿名アカウントと強いプライバシー保護を重視したVPNサービス。 [![Open-Source Software][OSS Icon]](https://github.com/mullvad/mullvadvpn-app)
 * [Outline](https://getoutline.org/) - VPNサーバーの作成を簡単にし、誰でも自由でオープンなインターネットにアクセスできるようにする。 [![Open-Source Software][OSS Icon]](https://github.com/Jigsaw-Code) ![Freeware][Freeware Icon]
 * [RerouteMe](https://nadenco.gumroad.com/l/rerouteme) - 簡単ワンクリックのmacOSプロキシ設定アプリ。 ![Freeware][Freeware Icon]

--- a/README-ko.md
+++ b/README-ko.md
@@ -900,6 +900,7 @@ Awesome Mac
 * [Cloudflare WARP](https://1.1.1.1/) - Cloudflare를 통해 트래픽을 라우팅하는 보안 네트워크 서비스. ![Freeware][Freeware Icon]
 * [DashVPN](https://getdashvpn.com/) - 스마트 라우팅을 지원하는 프록시 클라이언트로 VLESS, Shadowsocks, HTTPS 구독을 지원합니다. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/us/app/dash-vpn-for-outline-vless/id6758860923?platform=mac)
 * [Hiddify](https://github.com/hiddify/hiddify-app) - 여러 프록시 프로토콜과 구독을 관리할 수 있는 멀티플랫폼 클라이언트. [![Open-Source Software][OSS Icon]](https://github.com/hiddify/hiddify-app) ![Freeware][Freeware Icon]
+* [Macxelio](https://github.com/dalirnet/macxelio) - Xray-core 기반 네이티브 메뉴 막대 프록시 클라이언트로 규칙 기반 라우팅, 사용자 지정 DNS, 공유 링크 가져오기를 지원합니다. [![Open-Source Software][OSS Icon]](https://github.com/dalirnet/macxelio) ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [Mullvad VPN](https://mullvad.net) - 익명 계정과 강한 개인정보 보호를 앞세운 VPN 서비스. [![Open-Source Software][OSS Icon]](https://github.com/mullvad/mullvadvpn-app)
 * [TrustTunnel](https://trusttunnel.org/) - 현대적인 오픈 소스 VPN 프로토콜로, 원래 AdGuard VPN에서 개발되었습니다. [![Open-Source Software][OSS Icon]](https://github.com/TrustTunnel/TrustTunnel) ![Freeware][Freeware Icon]
 * [Tunnelbear](https://www.tunnelbear.com) - 안전한 브라우징과 위치 전환을 위한 간단한 VPN 서비스. ![Freeware][Freeware Icon]

--- a/README-zh.md
+++ b/README-zh.md
@@ -1130,6 +1130,7 @@ Awesome Mac
 * [Hiddify](https://github.com/hiddify/hiddify-app) - 支持多种代理协议与订阅的跨平台代理客户端。 [![Open-Source Software][OSS Icon]](https://github.com/hiddify/hiddify-app) ![Freeware][Freeware Icon]
 * [Mullvad VPN](https://mullvad.net) - 注重隐私、支持匿名账号的 VPN 服务。 [![Open-Source Software][OSS Icon]](https://github.com/mullvad/mullvadvpn-app)
 * [Lantern](https://getlantern.org) - 科学上网。[![Open-Source Software][OSS Icon]](https://github.com/getlantern/lantern)![Freeware][Freeware Icon]
+* [Macxelio](https://github.com/dalirnet/macxelio) - 基于 Xray-core 的原生菜单栏代理客户端，支持规则路由、自定义 DNS 和分享链接导入。 [![Open-Source Software][OSS Icon]](https://github.com/dalirnet/macxelio) ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [Mihomo Party](https://github.com/mihomo-party-org/mihomo-party) - 一个以mihomo内核的GUI [![Open-Source Software][OSS Icon]](https://github.com/mihomo-party-org/mihomo-party) ![Freeware][Freeware Icon]
 * [Outline](https://getoutline.org/) - 借助 Outline，创建 VPN 服务器变得轻而易举，从而让任何人都能访问自由、开放的互联网。[![Open-Source Software][OSS Icon]](https://github.com/Jigsaw-Code)![Freeware][Freeware Icon]
 * [ShadowsocksX](http://shadowsocks.org/) - 一个快速的隧道代理，可以帮助你绕过防火墙。[![Open-Source Software][OSS Icon]](https://github.com/shadowsocks)![Freeware][Freeware Icon]

--- a/README.md
+++ b/README.md
@@ -1181,6 +1181,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Hiddify](https://github.com/hiddify/hiddify-app) - Multi-platform proxy client for managing subscriptions and multiple proxy protocols. [![Open-Source Software][OSS Icon]](https://github.com/hiddify/hiddify-app) ![Freeware][Freeware Icon]
 * [Jumper VPN](https://jumpervpn.com/) - VPN Client for Mac and other platforms, secure, fast VPN proxy.
 * [Lantern](https://getlantern.org) - Free application that delivers fast, reliable and secure access to the open internet. [![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]](https://github.com/getlantern/lantern)
+* [Macxelio](https://github.com/dalirnet/macxelio) - Native menu bar proxy client powered by Xray-core, with rule-based routing, custom DNS, and share-link import. [![Open-Source Software][OSS Icon]](https://github.com/dalirnet/macxelio) ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [Mullvad VPN](https://mullvad.net) - Privacy-focused VPN service with anonymous accounts and flat-rate access. [![Open-Source Software][OSS Icon]](https://github.com/mullvad/mullvadvpn-app)
 * [Outline](https://getoutline.org/) - Outline makes it easy to create a VPN server, giving anyone access to the free and open internet. [![Open-Source Software][OSS Icon]](https://github.com/Jigsaw-Code) ![Freeware][Freeware Icon]
 * [RerouteMe](https://nadenco.gumroad.com/l/rerouteme) - An easy one-click macOS Proxy Configuration app. ![Freeware][Freeware Icon]


### PR DESCRIPTION
### Types of Changes

- [x] New addition to list
- [ ] Fixing bug in existing item in list
- [ ] Removing item from list
- [ ] Changing structure (organization) of list

### Proposed Changes

Adds [Macxelio](https://github.com/dalirnet/macxelio) to `Proxy and VPN Tools` in `README.md`, `README-zh.md` (科学上网), `README-ja.md` and `README-ko.md`.

Macxelio is a native (SwiftUI, macOS 13+) open-source menu bar proxy client powered by Xray-core. The section's existing entries are either VPN services, Clash/mihomo-based clients, or cross-platform Electron/Flutter builds — this adds a genuinely native Mac client for the Xray side.

What makes it worth adding:

- **Menu bar only** — switch proxy, change mode, and toggle the system proxy or DNS without opening a window. No Dock icon, no accounts, no telemetry.
- Protocols: Shadowsocks, VLESS, VMess, Trojan, SOCKS and HTTP, with TLS and REALITY transport security.
- Rule-based routing by Domain, IP, GeoIP or GeoSite, plus custom hosts and DNS servers including DoH, applied system-wide.
- Paste a `vless://`, `vmess://`, `trojan://`, `ss://`, `socks://` or `http://` share link and the proxy form fills itself.
- Configures your dev tools too — shell, git, docker, VS Code, Zed, npm, pip, go.
- MIT licensed, free, universal binary available in [Releases](https://github.com/dalirnet/macxelio/releases/latest).

### PR Checklist

- [x] I have read the CONTRIBUTING guide
- [x] I have explained why this PR is important
- [x] I have added necessary documentation (if appropriate)
