### PR TITLE
Add Voz to Voice-to-Text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1078,6 +1078,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [VoiceInk](https://tryvoiceink.com/) - Real-time speech-to-text app. [![Open-Source Software][OSS Icon]](https://github.com/Beingpax/VoiceInk) ![Freeware][Freeware Icon]
 * [VoxFlow](https://github.com/xingbofeng/VoxFlow) - Open-source voice input workspace with local and cloud ASR, OCR, history, and coding-agent workflows. [![Open-Source Software][OSS Icon]](https://github.com/xingbofeng/VoxFlow) ![Freeware][Freeware Icon]
 * [Voxt](https://github.com/hehehai/voxt) - Hold-to-talk voice input tool with AI transcription rules per app and URL, and built-in translation. [![Open-Source Software][OSS Icon]](https://github.com/hehehai/voxt) ![Freeware][Freeware Icon]
+* [Voz](https://www.vozwhisper.com/) - Hotkey dictation transcribed on-device by a bundled Whisper model; also records meetings and transcribes local files. [![Open-Source Software][OSS Icon]](https://github.com/quietbin/voz-mac)
 * [Whispering](https://epicenter.md/whispering/) - Multi-provider speech-to-text with AI transformations and keyboard shortcuts. [![Open-Source Software][OSS Icon]](https://github.com/EpicenterHQ/epicenter/tree/main/apps/whispering) ![Freeware][Freeware Icon]
 * [Willow Voice](https://willowvoice.com/) - AI dictation with automatic editing, style-matching, and noise optimization.
 


### PR DESCRIPTION
Adds [Voz](https://www.vozwhisper.com/), a macOS dictation app that transcribes on-device using a bundled whisper.cpp and Whisper base model — no account, no server, works offline.

Source is GPL-3.0 at https://github.com/quietbin/voz-mac and builds into the same app.

Placed alphabetically in Voice-to-Text between Voxt and Whispering, following the existing entry format. Disclosure: I'm the developer.