### PR TITLE
Add Tethersnap to File Sharing

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -923,6 +923,7 @@ Awesome Mac
 * [LocalSend](https://localsend.org/) - AirDropに代わるオープンソースのクロスプラットフォームアプリ。 [![Open-Source Software][OSS Icon]](https://github.com/localsend/localsend) ![Freeware][Freeware Icon]
 * [NearDrop](https://github.com/grishka/NearDrop) - macOS用の非公式Google Nearby Share/Quick Shareアプリ。 [![Open-Source Software][OSS Icon]](https://github.com/localsend/localsend) ![Freeware][Freeware Icon]
 * [Rclone UI](https://rcloneui.com/) - RcloneとS3のためのGUI。 [![App Store][app-store Icon]](https://apps.apple.com/app/rclone-ui/id6756127598?platform=mac) [![Open-Source Software][OSS Icon]](https://github.com/rclone-ui/rclone-ui) ![Freeware][Freeware Icon]
+* [Tethersnap](https://github.com/Luminoid/Tethersnap) - Nintendo Switch 2のスクリーンショットと動画をUSB経由で書き出すオープンソースのアプリとCLI。 [![Open-Source Software][OSS Icon]](https://github.com/Luminoid/Tethersnap) ![Freeware][Freeware Icon]
 * [Transmit](https://panic.com/transmit/) - 非常に柔軟で直感的なFTPクライアント。SFTP、S3、iDisk/WebDAVをサポート。
 
 ## データ復旧ツール

--- a/README-ko.md
+++ b/README-ko.md
@@ -747,6 +747,7 @@ Awesome Mac
 * [LocalSend](https://localsend.org/) - AirDrop의 오픈 소스 크로스 플랫폼 대안. [![Open-Source Software][OSS Icon]](https://github.com/localsend/localsend) ![Freeware][Freeware Icon]
 * [NearDrop](https://github.com/grishka/NearDrop) - macOS용 비공식 Google Quick Share 앱. [![Open-Source Software][OSS Icon]](https://github.com/localsend/localsend) ![Freeware][Freeware Icon]
 * [SwiftMTP](https://github.com/Neighbor-Z/SwiftMTP) - Mac과 Android 기기 사이에서 파일을 탐색하고 전송하는 오픈 소스 MTP 관리 도구입니다. [![Open-Source Software][OSS Icon]](https://github.com/Neighbor-Z/SwiftMTP) ![Freeware][Freeware Icon]
+* [Tethersnap](https://github.com/Luminoid/Tethersnap) - Nintendo Switch 2의 스크린샷과 동영상을 USB로 내보내는 오픈 소스 앱 및 CLI. [![Open-Source Software][OSS Icon]](https://github.com/Luminoid/Tethersnap) ![Freeware][Freeware Icon]
 * [Transmit](https://panic.com/transmit/) - 세계 최고의 Mac용 파일 전송 앱.
 
 ## 데이터 복구 도구

--- a/README-zh.md
+++ b/README-zh.md
@@ -710,6 +710,7 @@ Awesome Mac
 * [LocalSend](https://localsend.org/) - 跨平台的文件传输工具，界面简洁[![Open-Source Software][OSS Icon]](https://github.com/localsend/localsend) ![Freeware][Freeware Icon]
 * [NearDrop](https://github.com/grishka/NearDrop) -适用于 macOS 的非官方 Google Nearby Share/Quick Share 应用。 [![Open-Source Software][OSS Icon]](https://github.com/localsend/localsend) ![Freeware][Freeware Icon]
 * [Rclone UI](https://rcloneui.com/) - Rclone 和 s3 的图形用户界面。 [![App Store][app-store Icon]](https://apps.apple.com/app/rclone-ui/id6756127598?platform=mac) [![Open-Source Software][OSS Icon]](https://github.com/rclone-ui/rclone-ui) ![Freeware][Freeware Icon]
+* [Tethersnap](https://github.com/Luminoid/Tethersnap) - 通过 USB 导出 Nintendo Switch 2 截图与视频的开源应用及命令行工具。 [![Open-Source Software][OSS Icon]](https://github.com/Luminoid/Tethersnap) ![Freeware][Freeware Icon]
 * [Transmit](https://panic.com/transmit/) - 一个 FTP 客户端，支持 FTP + SFTP + S3。
 * [Yummy FTP](http://www.yummysoftware.com) - 专业快速，可靠的 FTP 客户端。
 

--- a/README.md
+++ b/README.md
@@ -921,6 +921,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [LocalSend](https://localsend.org/) - An open-source cross-platform alternative to AirDrop. [![Open-Source Software][OSS Icon]](https://github.com/localsend/localsend) ![Freeware][Freeware Icon]
 * [NearDrop](https://github.com/grishka/NearDrop) - An unofficial Google Nearby Share/Quick Share app for macOS. [![Open-Source Software][OSS Icon]](https://github.com/localsend/localsend) ![Freeware][Freeware Icon]
 * [Rclone UI](https://rcloneui.com/) - The GUI for Rclone & S3. [![App Store][app-store Icon]](https://apps.apple.com/app/rclone-ui/id6756127598?platform=mac) [![Open-Source Software][OSS Icon]](https://github.com/rclone-ui/rclone-ui) ![Freeware][Freeware Icon]
+* [Tethersnap](https://github.com/Luminoid/Tethersnap) - Open-source app and CLI for exporting Nintendo Switch 2 screenshots and videos over USB. [![Open-Source Software][OSS Icon]](https://github.com/Luminoid/Tethersnap) ![Freeware][Freeware Icon]
 * [Transmit](https://panic.com/transmit/) - Highly flexible and intuitive FTP client, supports SFTP, S3 and iDisk/WebDAV.
 
 ## Data Recovery Tools


### PR DESCRIPTION
Adds [Tethersnap](https://github.com/Luminoid/Tethersnap), an open-source Mac app and CLI that export Nintendo Switch 2 screenshots and videos over USB. macOS has no built-in support for the console's transfer mode, so this fills the same gap for Switch owners that LocalSend and NearDrop fill for phones.