### PR TITLE
Add Constly to Markdown Tools

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -231,6 +231,7 @@ Awesome Mac
 ### Markdownツール [![Awesome List][awesome-list Icon]](https://github.com/BubuAnabelas/awesome-markdown#tools)
 
 * [Archimedes](https://furnacecreek.org/archimedes/) - インラインLaTeXをサポートした数学的記述向けのネイティブmacOS Markdownエディタ。
+* [Constly](https://constly.com) - 入力しながらレンダリングするWYSIWYG Markdownエディタ。編集していない箇所は書き換えない。
 * [Edmund](https://github.com/I7T5/Edmund) - ライブプレビュー付きのミニマルなMarkdownエディタ。既存ファイルをそのまま編集でき、保管庫不要。 [![Open-Source Software][OSS Icon]](https://github.com/I7T5/Edmund) ![Freeware][Freeware Icon]
 * [EME](https://github.com/egoist/eme) - Chromeのようなインターフェースを持つオープンソースMarkdownエディタ。 ![Open-Source Software][OSS Icon]
 * [iA Writer](https://ia.net/writer/) - シンプルさとデザインを重視したライティングアプリ。

--- a/README-ko.md
+++ b/README-ko.md
@@ -205,6 +205,7 @@ Awesome Mac
 ### 마크다운 도구 [![Awesome List][awesome-list Icon]](https://github.com/BubuAnabelas/awesome-markdown#tools)
 
 * [Archimedes](https://furnacecreek.org/archimedes/) - 인라인 LaTeX를 지원하는 수학 쓰기에 최적화된 마크다운 편집기.
+* [Constly](https://constly.com) - 입력하는 대로 렌더링하는 WYSIWYG 마크다운 편집기. 직접 수정하지 않은 마크다운은 다시 쓰지 않음.
 * [Edmund](https://github.com/I7T5/Edmund) - 실시간 미리보기를 지원하는 미니멀 마크다운 편집기. 기존 파일을 바로 편집하며 별도 보관함 불필요. [![Open-Source Software][OSS Icon]](https://github.com/I7T5/Edmund) ![Freeware][Freeware Icon]
 * [EME](https://github.com/egoist/eme) - Chrome과 같은 인터페이스를 가진 오픈 소스 마크다운 편집기. ![Open-Source Software][OSS Icon]
 * [iA Writer](https://ia.net/writer/) - 단순함과 디자인에 강조를 둔 쓰기 앱.

--- a/README-zh.md
+++ b/README-zh.md
@@ -858,6 +858,7 @@ Awesome Mac
 > A curated list of delightful Markdown stuff. [![Awesome List][awesome-list Icon]](https://github.com/BubuAnabelas/awesome-markdown#tools)
 
 * [Cmd Markdown](https://www.zybuluo.com/) - Cmd Markdown 编辑阅读器，支持实时同步预览，区分写作和阅读模式，支持在线存储，分享文稿网址。 ![Freeware][Freeware Icon]
+* [Constly](https://constly.com) - 所见即所得的 Markdown 编辑器，输入时即时渲染，不会改写你未曾编辑的内容。
 * [Effie](https://www.effie.co/) - 轻量级 Markdown 写作软件，支持大纲笔记和思维导图。![Freeware][Freeware Icon]
 * [Edmund](https://github.com/I7T5/Edmund) - 极简 Markdown 编辑器，支持实时预览，直接编辑现有文件，无需建立资料库。 [![Open-Source Software][OSS Icon]](https://github.com/I7T5/Edmund) ![Freeware][Freeware Icon]
 * [EME](https://github.com/egoist/eme) - 一款 Markdown 编辑器，界面很像 Chrome 浏览器的界面，很简约。

--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 ### Markdown Tools [![Awesome List][awesome-list Icon]](https://github.com/BubuAnabelas/awesome-markdown#tools)
 
 * [Archimedes](https://furnacecreek.org/archimedes/) - Native macOS Markdown editor geared toward mathematical writing with inline LaTeX support.
+* [Constly](https://constly.com) - WYSIWYG Markdown editor that renders as you type and never rewrites Markdown you did not touch.
 * [Edmund](https://github.com/I7T5/Edmund) - Minimal, native macOS Markdown editor with live preview; works with your existing files, no vault. [![Open-Source Software][OSS Icon]](https://github.com/I7T5/Edmund) ![Freeware][Freeware Icon] ![Native App][Native Icon]
 * [EME](https://github.com/egoist/eme) - Open-source Markdown editor with an interface like Chrome. ![Open-Source Software][OSS Icon]
 * [iA Writer](https://ia.net/writer/) - Writing app with an emphasis on simplicity and design.


### PR DESCRIPTION
Adds Constly to **Markdown Tools**, synced across all four READMEs as the contributing guidelines ask.

**Constly** — https://constly.com — a WYSIWYG Markdown editor for macOS, Windows and Linux. Markdown renders in place as you type, and the raw marks show only on the line the cursor is on. Plain text stays the document: saving touches only the bytes you changed, so line endings, BOM and trailing spaces survive and untouched Markdown is never re-wrapped or reordered.

Placed alphabetically between Archimedes and Edmund in `README.md`, `README-ja.md` and `README-ko.md`. In `README-zh.md` that section starts at Cmd Markdown rather than Archimedes, so it sits between Cmd Markdown and Effie.

No icons, matching the other closed-source entries in the section (Typora, iA Writer, Ulysses, Marked 2, Obsidian).

The zh/ja/ko descriptions are my own translations of the English one-liner, written to match the length and register of the neighbouring entries. Happy to take a correction on any of the three.
