### PR TITLE
Add LightTable to Design Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -672,6 +672,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 * [Inkscape](https://inkscape.org/en/) - Professional vector graphics editor. [![Open-Source Software][OSS Icon]](https://launchpad.net/inkscape)
 * [ItsPaint](https://itspaintmac.com/) - Native paint and screenshot markup: step badges, pixelate redaction, Instant Alpha. No account or telemetry. [![Open-Source Software][OSS Icon]](https://github.com/joshlin2201/itspaint) ![Freeware][Freeware Icon]
 * [Krita](https://krita.org/en/) - Open-source digital painting software for concept artists, digital painters, and illustrators. [![Open-Source Software][OSS Icon]](https://github.com/KDE/krita) ![Freeware][Freeware Icon]
+* [LightTable](https://lighttable.app/) - Digital darkroom and RAW developer with physically modelled film stock simulation. [![Open-Source Software][OSS Icon]](https://github.com/reville/lighttable-digital-darkroom) ![Freeware][Freeware Icon]
 * [macSVG](https://macsvg.org/) - Designing HTML5 SVG art and animation. [![Open-Source Software][OSS Icon]](https://github.com/dsward2/macSVG) ![Freeware][Freeware Icon]
 * [MagicaVoxel](https://ephtracy.github.io/) - Free, lightweight 8-bit voxel editor and interactive path tracing renderer.
 * [MakeHuman](https://www.makehumancommunity.org) - Powerful and free 3D human modeler. ![Freeware][Freeware Icon]


### PR DESCRIPTION
LightTable is a free, open source digital darkroom for macOS. It's a Lightroom alternative in both design and function, with [spektrafilm](https://github.com/andreavolpato/agx-emulsion) built in, so film stock and print emulsions are modelled physically rather than applied as a LUT. Film can be switched off for conventional RAW development.

It has a Rust render core that runs on the GPU. Face grouping and object tagging run locally on the machine, so there's no account and no cloud.

- Site and screenshots: https://lighttable.app
- Source: https://github.com/reville/lighttable-digital-darkroom
- License: GPL-3.0

Placed alphabetically in Design Tools between Krita and macSVG, next to darktable and RawTherapee.