### PR TITLE
Add Arazio to Finder Tools

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1548,6 +1548,7 @@ Awesome Mac
 
 ### Finderツール
 
+* [Arazio](https://arazioformac.com) - Finderでファイルをドラッグ中に修飾キーを押し、目的の形式へ離すだけで変換でき、すべてローカルで動作。
 * [Command X](https://sindresorhus.com/command-x) - Finderでファイルの切り取り＆貼り付け。 ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id1666327168?platform=mac)
 * [Default Folder X](https://www.stclairsoft.com/DefaultFolderX/index.html) - あらゆるアプリからファイルやフォルダに素早くアクセス。
 * [AppPorts](https://github.com/wzh4869/AppPorts) - `/Applications` の起動リンクを保ったままアプリを外部ストレージへ移せるツール。 [![Open-Source Software][OSS Icon]](https://github.com/wzh4869/AppPorts) ![Freeware][Freeware Icon]

--- a/README-ko.md
+++ b/README-ko.md
@@ -990,6 +990,7 @@ Awesome Mac
 ### 파일 정리 도구
 
 * [AppPorts](https://github.com/wzh4869/AppPorts) - `/Applications`의 실행 링크를 유지한 채 앱을 외부 저장소로 옮기는 도구. [![Open-Source Software][OSS Icon]](https://github.com/wzh4869/AppPorts) ![Freeware][Freeware Icon]
+* [Arazio](https://arazioformac.com) - Finder에서 파일을 드래그하다 보조 키를 누른 뒤 원하는 형식 쪽으로 놓으면 변환되며, 모든 처리는 기기에서 이루어짐.
 * [Modal File Manager](https://github.com/raguay/ModalFileManager/) - Vim 스타일 단축키를 갖춘 듀얼 패널 파일 관리자. [![Open-Source Software][OSS Icon]](https://GitHub.com/raguay/ModalFileManager) ![Freeware][Freeware Icon]
 * [cmd+x](https://apps.apple.com/app/cmd-x/id6754665762?platform=mac) - Ctrl+Opt+Delete로 활동 모니터를 실행하고 Finder에서 Cmd+X로 파일을 잘라 이동.
 * [Oka Unarchiver](https://okaapps.com/product/1441507725) - RAR와 암호 보호 압축 파일까지 다루는 압축 해제 도구. [![App Store][app-store Icon]](https://apps.apple.com/app/id1441507725?pt=119209922&ct=github)

--- a/README-zh.md
+++ b/README-zh.md
@@ -1483,6 +1483,7 @@ Awesome Mac
 ### Finder
 
 * [AppPorts](https://github.com/wzh4869/AppPorts) - 一键将 `/Applications` 中的应用迁移到外部存储，并在原位置保留可启动入口的链接工具。 [![Open-Source Software][OSS Icon]](https://github.com/wzh4869/AppPorts) ![Freeware][Freeware Icon]
+* [Arazio](https://arazioformac.com) - 在访达中拖拽文件时按住修饰键，朝目标格式松手即可完成转换，全部在本地运行。
 * [Modal File Manager](https://github.com/raguay/ModalFileManager/) - 带 Vim 风格快捷键的双栏文件管理器。 [![Open-Source Software][OSS Icon]](https://GitHub.com/raguay/ModalFileManager) ![Freeware][Freeware Icon]
 * [fman](https://fman.io) - 先进的双窗口文件管理器，拥有很多特性。
 * [ForkLift](http://binarynights.com/forklift/) - 先进的双窗口文件管理器和文件传输客户端。

--- a/README.md
+++ b/README.md
@@ -1549,6 +1549,7 @@ If you have any suggestions, ideas, or discover excellent software, feel free to
 
 ### Finder Tools
 
+* [Arazio](https://arazioformac.com) - Converts files straight from a Finder drag by holding a modifier and releasing toward a format, entirely on-device.
 * [Command X](https://sindresorhus.com/command-x) - Cut and paste files in Finder. ![Freeware][Freeware Icon] [![App Store][app-store Icon]](https://apps.apple.com/app/id1666327168?platform=mac)
 * [Default Folder X](https://www.stclairsoft.com/DefaultFolderX/index.html) - Quick access to your files and folders in every app.
 * [FileMinutes](https://www.fileminutes.com/) - Find files and take actions, all in one.


### PR DESCRIPTION
Adds Arazio to Finder Tools.

**What it is:** a macOS menu-bar utility that converts files from the drag itself — pick a file up in Finder, hold a modifier, and a radial menu appears around the cursor showing only the formats that file can actually become. Release toward one and the converted file lands next to the original. 283 conversions across 43 formats, plus 14 file tools. Everything runs on-device; the conversion engines contain no networking code at all.

**Category:** Finder Tools, since the whole interaction happens inside a Finder drag rather than in an app window. It sits alongside SaneClick and SwiftyMenu, which are also Finder-centric file utilities.

**Guidelines followed:**

- Searched for duplicates — Arazio is not currently listed.
- One suggestion, one pull request.
- Inserted in alphabetical order within each section.
- One sentence per entry, no trailing whitespace.
- No icon: it is paid, closed-source and not on the App Store, matching how Default Folder X, ForkLift and Path Finder are listed.
- Synced across all four READMEs, with the description translated rather than copied.

**A note on the Korean file:** `README-ko.md` has no Finder Tools section, so the entry went into `파일 정리 도구`, which is where that file already keeps Finder extensions such as SaneClick and SwiftyMenu. Happy to move it if you would rather it went elsewhere.

**Disclosure:** I am the developer. Arazio is paid software ($14.99, one-time).
